### PR TITLE
Fix indexing timeout

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  review_details: false
+  auto_review:
+    enabled: true
+    drafts: false
+chat:
+  auto_reply: true

--- a/crates/lsp/server/src/engine_client.rs
+++ b/crates/lsp/server/src/engine_client.rs
@@ -1,8 +1,14 @@
-use std::{fmt, future::Future};
+use std::{
+    fmt,
+    future::Future,
+    time::{Duration, Instant},
+};
 
 use anyhow::Context as _;
 use rg_lsp_proto::{EngineResult, EngineServiceClient};
 use tarpc::client::RpcError as TarpcRpcError;
+
+const INDEXING_RPC_DEADLINE: Duration = Duration::from_secs(30 * 60);
 
 /// RPC client for one engine, without any knowledge of how that engine is hosted.
 ///
@@ -29,12 +35,9 @@ impl EngineClient {
         F: FnOnce(EngineServiceClient, tarpc::context::Context) -> Fut,
         Fut: Future<Output = Result<EngineResult<T>, TarpcRpcError>>,
     {
-        let result = request(
-            self.engine_service_client.clone(),
-            tarpc::context::current(),
-        )
-        .await
-        .with_context(|| format!("while attempting to call engine RPC `{operation}`"))?;
+        let result = request(self.engine_service_client.clone(), Self::context(operation))
+            .await
+            .with_context(|| format!("while attempting to call engine RPC `{operation}`"))?;
         result.map_err(anyhow::Error::from)
     }
 
@@ -47,10 +50,51 @@ impl EngineClient {
             tracing::debug!(operation, error = %error, "engine notification failed");
         }
     }
+
+    fn context(operation: &'static str) -> tarpc::context::Context {
+        let mut context = tarpc::context::current();
+        if Self::operation_may_rebuild_analysis(operation) {
+            context.deadline = Instant::now() + INDEXING_RPC_DEADLINE;
+        }
+        context
+    }
+
+    fn operation_may_rebuild_analysis(operation: &'static str) -> bool {
+        matches!(operation, "initialize" | "reindex_workspace" | "did_save")
+    }
 }
 
 impl fmt::Debug for EngineClient {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("EngineClient").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use super::EngineClient;
+
+    #[test]
+    fn indexing_operations_get_long_rpc_deadline() {
+        for operation in ["initialize", "reindex_workspace", "did_save"] {
+            let context = EngineClient::context(operation);
+
+            assert!(
+                context.deadline > Instant::now() + Duration::from_secs(20 * 60),
+                "{operation} should allow slow analysis rebuilds",
+            );
+        }
+    }
+
+    #[test]
+    fn interactive_operations_keep_tarpc_default_deadline() {
+        let context = EngineClient::context("hover");
+
+        assert!(
+            context.deadline < Instant::now() + Duration::from_secs(20),
+            "interactive engine calls should keep the default short tarpc deadline",
+        );
     }
 }


### PR DESCRIPTION
10 seconds is not really enough for indexing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved language server reliability by optimizing RPC timeout handling. Long-running indexing, workspace analysis, and reindexing operations now use extended deadlines to complete reliably without timeout failures, while interactive operations maintain responsive timeout behavior for immediate user feedback.

* **Chores**
  * Configured code review tool automation and integration settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/popzxc/rust-glancer/pull/8)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->