### PR TITLE
Improve logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,6 +1344,7 @@ dependencies = [
  "rg_memsize",
  "rg_project",
  "rg_workspace",
+ "serde_json",
  "tikv-jemalloc-sys",
  "tikv-jemallocator",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ ls_types = { package = "ls-types", version = "0.0.6" }
 wincode = { version = "0.4.9", features = ["derive"] }
 rayon = "1.12.0"
 serde = "1.0"
+serde_json = "1.0"
 tarpc = "0.37"
 tempfile = "3.27.0"
 thiserror = "2.0.17"

--- a/crates/lsp/server/src/engine_process.rs
+++ b/crates/lsp/server/src/engine_process.rs
@@ -15,6 +15,7 @@ use tower_lsp_server::Client as LspClient;
 use crate::{engine_client::EngineClient, notifications::NotificationsPublisher};
 
 const ENGINE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
+const ENGINE_ID_ENV: &str = "RUST_GLANCER_ENGINE_ID";
 
 /// Process-backed handle to one engine owned by the LSP server.
 ///
@@ -28,7 +29,7 @@ pub(crate) struct EngineProcess {
 }
 
 impl EngineProcess {
-    pub(crate) async fn spawn(lsp_client: LspClient) -> anyhow::Result<Self> {
+    pub(crate) async fn spawn(lsp_client: LspClient, engine_id: String) -> anyhow::Result<Self> {
         // Initialize transport for engine service.
         let (mut engine_listener, engine_addr) = {
             // Both JSON and TCP are chosen for convenience of debugging, not that we need too much speed.
@@ -56,7 +57,7 @@ impl EngineProcess {
         };
 
         // Spawn the engine subprocess.
-        let child = Self::spawn_worker(engine_addr, notifications_addr)?;
+        let child = Self::spawn_worker(engine_addr, notifications_addr, &engine_id)?;
 
         // Spawn the notifications publisher.
         {
@@ -126,6 +127,7 @@ impl EngineProcess {
     fn spawn_worker(
         engine_addr: SocketAddr,
         notifications_addr: SocketAddr,
+        engine_id: &str,
     ) -> anyhow::Result<Child> {
         let executable = std::env::current_exe()
             .context("while attempting to locate rust-glancer executable")?;
@@ -139,6 +141,7 @@ impl EngineProcess {
 
         tokio::process::Command::new(executable)
             .args(args)
+            .env(ENGINE_ID_ENV, engine_id)
             // The parent LSP server owns stdout for JSON-RPC. The engine may log to stderr, but it
             // must never inherit stdout and accidentally corrupt the LSP stream.
             .stdin(Stdio::null())

--- a/crates/lsp/server/src/engine_registry/mod.rs
+++ b/crates/lsp/server/src/engine_registry/mod.rs
@@ -276,7 +276,7 @@ impl EngineRegistry {
         root: PathBuf,
         config: EngineConfig,
     ) -> anyhow::Result<EngineProcess> {
-        let engine = EngineProcess::spawn(self.lsp_client.clone()).await?;
+        let engine = EngineProcess::spawn(self.lsp_client.clone(), Self::engine_id(&root)).await?;
         let engine_client = engine.engine_client().clone();
         let initialize_root = root.clone();
         engine_client
@@ -292,6 +292,14 @@ impl EngineRegistry {
 
         tracing::info!(root = %root.display(), "started rust-glancer engine");
         Ok(engine)
+    }
+
+    fn engine_id(root: &Path) -> String {
+        root.file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .unwrap_or("unknown")
+            .to_string()
     }
 }
 

--- a/crates/rust-glancer/Cargo.toml
+++ b/crates/rust-glancer/Cargo.toml
@@ -27,6 +27,7 @@ rg_project.workspace = true
 rg_workspace.workspace = true
 rg_lsp_engine.workspace = true
 rg_lsp_server.workspace = true
+serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }

--- a/crates/rust-glancer/src/analyze/mod.rs
+++ b/crates/rust-glancer/src/analyze/mod.rs
@@ -68,7 +68,7 @@ pub(super) fn analyze(
     let sysroot = SysrootSources::discover(workspace.workspace_root());
     let sysroot_elapsed = sysroot_started.elapsed();
     let workspace = workspace.with_sysroot_sources(sysroot);
-    let memory_control = crate::runtime::memory_control();
+    let memory_control = crate::memory::memory_control();
 
     let builder = Project::builder(workspace)
         .cargo_metadata_config(cargo_metadata_config)

--- a/crates/rust-glancer/src/logging.rs
+++ b/crates/rust-glancer/src/logging.rs
@@ -1,0 +1,162 @@
+//! Process logging setup for the CLI and editor-facing modes.
+//!
+//! The standalone `analyze` command uses normal human-readable tracing output on stderr so it stays
+//! useful from a terminal. The LSP server and its engine subprocesses instead emit newline-delimited
+//! JSON records on stderr. The VS Code extension reads those records from the language client output
+//! stream, verifies the schema, and maps the event level/message/fields into its
+//! `Rust Glancer Language Server` log channel.
+
+use std::{fmt, io::Write as _};
+
+use serde_json::{Map, Value, json};
+use tracing::{
+    Event, Subscriber,
+    field::{Field, Visit},
+};
+use tracing_subscriber::{EnvFilter, Layer, layer::Context, prelude::*, registry::LookupSpan};
+
+const ENGINE_ID_ENV: &str = "RUST_GLANCER_ENGINE_ID";
+const LOG_SCHEMA: &str = "rust-glancer-log/v1";
+
+/// Identifies which process emitted an LSP-mode log line.
+///
+/// The VS Code extension uses this compact label to split server and per-engine logs without
+/// teaching the Rust side about editor output channels.
+#[derive(Debug, Clone)]
+pub(crate) enum LogComponent {
+    Server,
+    Engine { id: String },
+}
+
+impl LogComponent {
+    pub(crate) fn engine_from_env() -> Self {
+        let id = std::env::var(ENGINE_ID_ENV)
+            .ok()
+            .filter(|id| !id.is_empty())
+            .unwrap_or_else(|| "unknown".to_string());
+
+        Self::Engine { id }
+    }
+}
+
+/// Initializes the logger in a human-readable form.
+pub(crate) fn init_plain_tracing() {
+    let filter = EnvFilter::try_from_env("RUST_GLANCER_LOG")
+        .unwrap_or_else(|_| EnvFilter::new("info,tarpc=warn"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .try_init()
+        .ok();
+}
+
+/// Initializes the structured JSON logger consumed by the editor extension.
+pub(crate) fn init_lsp_tracing(component: LogComponent) {
+    let filter = EnvFilter::try_from_env("RUST_GLANCER_LOG")
+        .unwrap_or_else(|_| EnvFilter::new("info,tarpc=warn"));
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(JsonLogLayer { component })
+        .try_init()
+        .ok();
+}
+
+#[derive(Debug, Clone)]
+struct JsonLogLayer {
+    component: LogComponent,
+}
+
+impl<S> Layer<S> for JsonLogLayer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let metadata = event.metadata();
+        let mut fields = JsonFields::default();
+        event.record(&mut fields);
+
+        let mut log = Map::new();
+        log.insert("schema".to_string(), Value::String(LOG_SCHEMA.to_string()));
+        log.insert(
+            "level".to_string(),
+            Value::String(metadata.level().to_string()),
+        );
+        log.insert(
+            "target".to_string(),
+            Value::String(metadata.target().to_string()),
+        );
+        match &self.component {
+            LogComponent::Server => {
+                log.insert("component".to_string(), Value::String("server".to_string()));
+            }
+            LogComponent::Engine { id } => {
+                log.insert("component".to_string(), Value::String("engine".to_string()));
+                log.insert("engine".to_string(), Value::String(id.clone()));
+            }
+        }
+        log.insert(
+            "message".to_string(),
+            Value::String(
+                fields
+                    .message
+                    .unwrap_or_else(|| metadata.name().to_string()),
+            ),
+        );
+        log.insert("fields".to_string(), Value::Object(fields.values));
+
+        let mut stderr = std::io::stderr().lock();
+        if serde_json::to_writer(&mut stderr, &Value::Object(log)).is_ok() {
+            let _ = writeln!(stderr);
+        }
+    }
+}
+
+#[derive(Default)]
+struct JsonFields {
+    message: Option<String>,
+    values: Map<String, Value>,
+}
+
+impl JsonFields {
+    fn record_value(&mut self, field: &Field, value: Value) {
+        if field.name() == "message" {
+            self.message = Some(Self::message_value(value));
+        } else {
+            self.values.insert(field.name().to_string(), value);
+        }
+    }
+
+    fn message_value(value: Value) -> String {
+        match value {
+            Value::String(value) => value,
+            value => value.to_string(),
+        }
+    }
+}
+
+impl Visit for JsonFields {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.record_value(field, Value::String(format!("{value:?}")));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.record_value(field, Value::String(value.to_string()));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.record_value(field, Value::Bool(value));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.record_value(field, json!(value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.record_value(field, json!(value));
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.record_value(field, json!(value));
+    }
+}

--- a/crates/rust-glancer/src/main.rs
+++ b/crates/rust-glancer/src/main.rs
@@ -4,7 +4,8 @@ use clap::{Parser, Subcommand};
 use rg_project::StartupCacheLoad;
 
 mod analyze;
-mod runtime;
+mod logging;
+mod memory;
 mod start_engine;
 mod start_server;
 
@@ -62,18 +63,21 @@ fn main() -> anyhow::Result<()> {
             load,
             package_residency,
             target,
-        } => analyze::analyze(
-            path,
-            profile,
-            memory,
-            if load {
-                StartupCacheLoad::Enabled
-            } else {
-                StartupCacheLoad::Disabled
-            },
-            package_residency.into(),
-            target,
-        ),
+        } => {
+            logging::init_plain_tracing();
+            analyze::analyze(
+                path,
+                profile,
+                memory,
+                if load {
+                    StartupCacheLoad::Enabled
+                } else {
+                    StartupCacheLoad::Disabled
+                },
+                package_residency.into(),
+                target,
+            )
+        }
         Command::Lsp => start_server::start_server(),
         Command::LspEngine {
             engine_addr,

--- a/crates/rust-glancer/src/memory.rs
+++ b/crates/rust-glancer/src/memory.rs
@@ -1,4 +1,4 @@
-//! Process runtime selection and memory controls for the CLI/LSP binary.
+//! Process memory controls for the CLI/LSP binary.
 //!
 //! Allocator choice is intentionally kept at the executable boundary. The analysis engine remains
 //! allocator-agnostic, while release builds can still compare jemalloc and the platform allocator
@@ -7,17 +7,6 @@
 use rg_lsp_engine::{AllocatorPurgeResult, AllocatorStats, MemoryControl};
 
 const JEMALLOC_PURGE_AFTER_BUILD_ENV: &str = "RUST_GLANCER_PURGE_MEMORY_AFTER_BUILD";
-
-pub(crate) fn init_tracing() {
-    let filter = tracing_subscriber::EnvFilter::try_from_env("RUST_GLANCER_LOG")
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,tarpc=warn"));
-    tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_writer(std::io::stderr)
-        .with_ansi(false)
-        .try_init()
-        .ok();
-}
 
 #[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
 #[global_allocator]

--- a/crates/rust-glancer/src/start_engine.rs
+++ b/crates/rust-glancer/src/start_engine.rs
@@ -10,10 +10,10 @@ pub(crate) fn start_engine(
     engine_addr: SocketAddr,
     notifications_addr: SocketAddr,
 ) -> anyhow::Result<()> {
-    crate::runtime::init_tracing();
+    crate::logging::init_lsp_tracing(crate::logging::LogComponent::engine_from_env());
 
     let memory_control: Arc<dyn rg_lsp_engine::MemoryControl> =
-        Arc::new(crate::runtime::memory_control());
+        Arc::new(crate::memory::memory_control());
     tracing::info!(
         allocator = memory_control.allocator_name(),
         allocator_purge_enabled = memory_control.allocator_purge_enabled(),

--- a/crates/rust-glancer/src/start_server.rs
+++ b/crates/rust-glancer/src/start_server.rs
@@ -5,7 +5,7 @@ use anyhow::Context as _;
 /// The binary owns process-wide setup: logging, runtime construction, and selecting the transport
 /// mode. The server crate owns the LSP backend and engine orchestration once the runtime exists.
 pub(crate) fn start_server() -> anyhow::Result<()> {
-    crate::runtime::init_tracing();
+    crate::logging::init_lsp_tracing(crate::logging::LogComponent::Server);
     tracing::info!("starting rust-glancer LSP server over stdio");
 
     let runtime = tokio::runtime::Builder::new_multi_thread()

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -100,17 +100,6 @@
           "default": "workspace-and-path-deps",
           "description": "Controls which package analysis artifacts remain resident after indexing. Restart the rust-glancer server after changing this setting."
         },
-        "rust-glancer.trace.server": {
-          "scope": "window",
-          "type": "string",
-          "enum": [
-            "off",
-            "messages",
-            "verbose"
-          ],
-          "default": "off",
-          "description": "Controls LSP protocol tracing for the rust-glancer client."
-        },
         "rust-glancer.diagnosticsOnStartup": {
           "scope": "window",
           "type": "boolean",

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -7,7 +7,6 @@
  */
 import * as vscode from "vscode";
 
-export type TraceSetting = "off" | "messages" | "verbose";
 export type PackageResidencySetting =
   | "all-resident"
   | "workspace"
@@ -21,7 +20,6 @@ export interface ExtensionConfig {
   readonly purgeMemoryAfterBuild: boolean;
   readonly cargo: CargoConfig;
   readonly cache: CacheConfig;
-  readonly traceServer: TraceSetting;
   readonly diagnostics: DiagnosticsConfig;
 }
 
@@ -51,7 +49,6 @@ export namespace ExtensionConfig {
       "cache.packageResidency",
       "workspace-and-path-deps",
     );
-    const traceServer = config.get<TraceSetting>("trace.server", "off");
     const diagnosticsOnStartup = config.get<boolean>("diagnosticsOnStartup", false);
     const diagnosticsOnSave = config.get<boolean>("diagnosticsOnSave", false);
     const diagnosticsCommand = config.get<string>("diagnostics.command", "check");
@@ -70,7 +67,6 @@ export namespace ExtensionConfig {
       cache: {
         packageResidency,
       },
-      traceServer,
       diagnostics: {
         onStartup: diagnosticsOnStartup,
         onSave: diagnosticsOnSave,

--- a/editors/code/src/extension-controller.ts
+++ b/editors/code/src/extension-controller.ts
@@ -23,10 +23,11 @@ export class ExtensionController implements vscode.Disposable {
   /** Wires VS Code workspace/editor events to the window-level LSP client lifecycle. */
   public constructor(
     extensionPath: string,
-    private readonly output: vscode.OutputChannel,
+    private readonly extensionLog: vscode.LogOutputChannel,
+    serverOutput: vscode.OutputChannel,
     private readonly status: StatusView,
   ) {
-    this.clientSlot = new LanguageClientSlot(extensionPath, output, status);
+    this.clientSlot = new LanguageClientSlot(extensionPath, extensionLog, serverOutput, status);
     this.workspaceListeners = vscode.Disposable.from(
       vscode.window.onDidChangeActiveTextEditor((editor) => {
         void this.activateForEditor(editor);
@@ -53,7 +54,7 @@ export class ExtensionController implements vscode.Disposable {
   public async start(): Promise<void> {
     const workspaceFolder = this.selectedWorkspaceFolder();
     if (workspaceFolder === undefined) {
-      this.output.appendLine("no workspace folder found; rust-glancer server was not started");
+      this.extensionLog.info("no workspace folder found; rust-glancer server was not started");
       this.status.stopped("no workspace folder");
       return;
     }

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -9,20 +9,33 @@ import * as vscode from "vscode";
 import { EXTENSION_COMMANDS } from "./commands";
 import { ExtensionController } from "./extension-controller";
 import { registerHoverActionCommands } from "./features/hover-actions";
+import { ServerOutputChannel } from "./logging/server-output-channel";
 import { StatusView } from "./status/status-view";
-import { RecordingOutputChannel } from "./test-support/recording-output-channel";
+import { RecordingLogOutputChannel } from "./test-support/recording-output-channel";
 
 let controller: ExtensionController | undefined;
 
 const EXTENSION_TEST_ENV = "RUST_GLANCER_EXTENSION_TEST";
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  const rawOutput = vscode.window.createOutputChannel("Rust Glancer");
-  const recordingOutput =
-    process.env[EXTENSION_TEST_ENV] === "1" ? new RecordingOutputChannel(rawOutput) : undefined;
-  const output = recordingOutput ?? rawOutput;
+  const rawExtensionLog = vscode.window.createOutputChannel("Rust Glancer Extension", {
+    log: true,
+  });
+  const rawServerLog = vscode.window.createOutputChannel("Rust Glancer Language Server", {
+    log: true,
+  });
+  const recordingExtensionLog =
+    process.env[EXTENSION_TEST_ENV] === "1"
+      ? new RecordingLogOutputChannel(rawExtensionLog)
+      : undefined;
+  const recordingServerLog =
+    process.env[EXTENSION_TEST_ENV] === "1"
+      ? new RecordingLogOutputChannel(rawServerLog)
+      : undefined;
+  const extensionLog = recordingExtensionLog ?? rawExtensionLog;
+  const serverOutput = new ServerOutputChannel(recordingServerLog ?? rawServerLog);
   const status = new StatusView();
-  controller = new ExtensionController(context.extensionPath, output, status);
+  controller = new ExtensionController(context.extensionPath, extensionLog, serverOutput, status);
 
   // Extension-host tests need a stable synchronization point. Keep this command out of the
   // package manifest so it is available only when the test runner opts in through the environment.
@@ -31,18 +44,20 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       vscode.commands.registerCommand(EXTENSION_COMMANDS.testGetState, () =>
         controller?.snapshot(),
       ),
-      vscode.commands.registerCommand(
-        EXTENSION_COMMANDS.testGetOutput,
-        () => recordingOutput?.snapshot() ?? "",
+      vscode.commands.registerCommand(EXTENSION_COMMANDS.testGetOutput, () =>
+        [recordingExtensionLog?.snapshot(), recordingServerLog?.snapshot()]
+          .filter((output): output is string => output !== undefined)
+          .join(""),
       ),
     );
   }
 
   context.subscriptions.push(
-    output,
+    extensionLog,
+    serverOutput,
     status,
     controller,
-    registerHoverActionCommands(output),
+    registerHoverActionCommands(extensionLog),
     vscode.commands.registerCommand(EXTENSION_COMMANDS.restartServer, async () => {
       await controller?.restart();
     }),

--- a/editors/code/src/features/hover-actions.ts
+++ b/editors/code/src/features/hover-actions.ts
@@ -34,7 +34,7 @@ interface SerializedPosition {
 
 export function hoverMiddleware(
   clientProvider: () => LanguageClient | undefined,
-  output: vscode.OutputChannel,
+  output: vscode.LogOutputChannel,
 ): LanguageClientOptions["middleware"] {
   return {
     async provideHover(document, position, token, next) {
@@ -60,20 +60,20 @@ export function hoverMiddleware(
 
         return appendGoToTypeAction(hover, locations);
       } catch (error) {
-        output.appendLine(`hover go-to-type action failed: ${String(error)}`);
+        output.warn(`hover go-to-type action failed: ${String(error)}`);
         return hover;
       }
     },
   };
 }
 
-export function registerHoverActionCommands(output: vscode.OutputChannel): vscode.Disposable {
+export function registerHoverActionCommands(output: vscode.LogOutputChannel): vscode.Disposable {
   return vscode.commands.registerCommand(
     EXTENSION_COMMANDS.goToTypeFromHover,
     async (serializedLocations: unknown) => {
       const locations = deserializeLocations(serializedLocations);
       if (locations.length === 0) {
-        output.appendLine("hover go-to-type command ignored empty or malformed locations");
+        output.warn("hover go-to-type command ignored empty or malformed locations");
         return;
       }
 

--- a/editors/code/src/language-client/language-client-session.ts
+++ b/editors/code/src/language-client/language-client-session.ts
@@ -10,11 +10,10 @@ import {
   LanguageClient,
   State,
   type LanguageClientOptions,
-  Trace,
 } from "vscode-languageclient/node";
 
 import { SERVER_COMMANDS, SERVER_NOTIFICATIONS } from "../commands";
-import { ExtensionConfig, type TraceSetting } from "../config";
+import { ExtensionConfig } from "../config";
 import { hoverMiddleware } from "../features/hover-actions";
 import {
   ClientStatus,
@@ -38,7 +37,8 @@ export class LanguageClientSession implements vscode.Disposable {
 
   public constructor(
     private readonly extensionPath: string,
-    private readonly output: vscode.OutputChannel,
+    private readonly extensionLog: vscode.LogOutputChannel,
+    private readonly serverOutput: vscode.OutputChannel,
     status: StatusView,
     private readonly workspaceFolder: vscode.WorkspaceFolder,
   ) {
@@ -70,16 +70,15 @@ export class LanguageClientSession implements vscode.Disposable {
       serverSource: server.source,
     };
 
-    this.output.appendLine(`workspace root: ${this.workspaceFolder.uri.fsPath}`);
-    this.output.appendLine(`server command: ${statusDetails.serverCommand}`);
-    this.output.appendLine(`server source: ${statusDetails.serverSource}`);
+    this.extensionLog.info(`workspace root: ${this.workspaceFolder.uri.fsPath}`);
+    this.extensionLog.info(`server command: ${statusDetails.serverCommand}`);
+    this.extensionLog.info(`server source: ${statusDetails.serverSource}`);
     this.clientStatus.starting(statusDetails);
 
     const clientOptions: LanguageClientOptions = {
       documentSelector: [{ scheme: "file", language: "rust" }],
       diagnosticCollectionName: "rust-glancer",
-      outputChannel: this.output,
-      traceOutputChannel: this.output,
+      outputChannel: this.serverOutput,
       initializationOptions: {
         diagnostics: config.diagnostics,
         cargo: config.cargo,
@@ -91,7 +90,7 @@ export class LanguageClientSession implements vscode.Disposable {
     const client = new LanguageClient(
       "rust-glancer",
       "Rust Glancer",
-      ResolvedServer.options(server, this.output),
+      ResolvedServer.options(server, this.extensionLog),
       clientOptions,
     );
 
@@ -126,16 +125,15 @@ export class LanguageClientSession implements vscode.Disposable {
 
     try {
       await client.start();
-      await client.setTrace(trace(config.traceServer));
       this.clientStatus.ready(statusDetails);
       this.refreshStatus();
-      this.output.appendLine("rust-glancer client started");
+      this.extensionLog.info("rust-glancer client started");
     } catch (error) {
       this.client = undefined;
       this.clientState?.dispose();
       this.clientState = undefined;
       this.clientStatus.failed(String(error), statusDetails);
-      this.output.appendLine(`rust-glancer client failed to start: ${String(error)}`);
+      this.extensionLog.error(`rust-glancer client failed to start: ${String(error)}`);
       void vscode.window.showErrorMessage(
         "Rust Glancer failed to start. Check the Rust Glancer output for details.",
       );
@@ -152,7 +150,7 @@ export class LanguageClientSession implements vscode.Disposable {
       return;
     }
 
-    this.output.appendLine("reindexing rust-glancer active workspace");
+    this.extensionLog.info("reindexing rust-glancer active workspace");
     this.clientStatus.indexing();
 
     try {
@@ -160,10 +158,10 @@ export class LanguageClientSession implements vscode.Disposable {
         command: SERVER_COMMANDS.reindexWorkspace,
         arguments: [],
       });
-      this.output.appendLine("rust-glancer active workspace reindex finished");
+      this.extensionLog.info("rust-glancer active workspace reindex finished");
       this.refreshStatus();
     } catch (error) {
-      this.output.appendLine(`rust-glancer active workspace reindex failed: ${String(error)}`);
+      this.extensionLog.error(`rust-glancer active workspace reindex failed: ${String(error)}`);
       this.clientStatus.operationFailed(`reindex failed: ${String(error)}`);
       void vscode.window.showErrorMessage(
         "Rust Glancer failed to reindex the workspace. Check the Rust Glancer output for details.",
@@ -179,7 +177,7 @@ export class LanguageClientSession implements vscode.Disposable {
 
     if (client !== undefined) {
       await client.stop();
-      this.output.appendLine("rust-glancer client stopped");
+      this.extensionLog.info("rust-glancer client stopped");
     }
 
     this.clientStatus.stopped("not running");
@@ -205,7 +203,7 @@ export class LanguageClientSession implements vscode.Disposable {
 
   private middleware(): LanguageClientOptions["middleware"] {
     return {
-      ...hoverMiddleware(() => this.client, this.output),
+      ...hoverMiddleware(() => this.client, this.extensionLog),
       handleWorkDoneProgress: (token, params, next) => {
         this.clientStatus.handleWorkDoneProgress(token, params, this.isActiveRustDocumentDirty());
         next(token, params);
@@ -223,15 +221,4 @@ interface ActiveWorkspaceChangedParams {
   readonly root: string;
   readonly state: ActiveWorkspaceState;
   readonly message?: string;
-}
-
-function trace(setting: TraceSetting): Trace {
-  switch (setting) {
-    case "off":
-      return Trace.Off;
-    case "messages":
-      return Trace.Messages;
-    case "verbose":
-      return Trace.Verbose;
-  }
 }

--- a/editors/code/src/language-client/language-client-slot.ts
+++ b/editors/code/src/language-client/language-client-slot.ts
@@ -17,7 +17,8 @@ export class LanguageClientSlot implements vscode.Disposable {
 
   public constructor(
     private readonly extensionPath: string,
-    private readonly output: vscode.OutputChannel,
+    private readonly extensionLog: vscode.LogOutputChannel,
+    private readonly serverOutput: vscode.OutputChannel,
     private readonly status: StatusView,
   ) {}
 
@@ -77,7 +78,8 @@ export class LanguageClientSlot implements vscode.Disposable {
   ): Promise<LanguageClientSession | undefined> {
     const session = new LanguageClientSession(
       this.extensionPath,
-      this.output,
+      this.extensionLog,
+      this.serverOutput,
       this.status,
       workspaceFolder,
     );

--- a/editors/code/src/language-client/server.ts
+++ b/editors/code/src/language-client/server.ts
@@ -57,11 +57,11 @@ export namespace ResolvedServer {
     return executableServer("rust-glancer", "PATH", config, workspaceFolder);
   }
 
-  export function options(server: ResolvedServer, output: vscode.OutputChannel): ServerOptions {
+  export function options(server: ResolvedServer, output: vscode.LogOutputChannel): ServerOptions {
     return (): Promise<ChildProcess> => {
-      output.appendLine(`starting server: ${server.command} ${server.args.join(" ")}`);
-      output.appendLine(`server cwd: ${server.cwd}`);
-      output.appendLine(`server source: ${server.source}`);
+      output.info(`starting server: ${server.command} ${server.args.join(" ")}`);
+      output.info(`server cwd: ${server.cwd}`);
+      output.info(`server source: ${server.source}`);
 
       const child = spawn(server.command, [...server.args], {
         cwd: server.cwd,
@@ -70,20 +70,18 @@ export namespace ResolvedServer {
       });
 
       child.on("spawn", () => {
-        output.appendLine(`server process started with pid ${child.pid ?? "unknown"}`);
+        output.info(`server process started with pid ${child.pid ?? "unknown"}`);
       });
 
       child.on("error", (error) => {
-        output.appendLine(`server failed to start: ${error.message}`);
+        output.error(`server failed to start: ${error.message}`);
         void vscode.window.showErrorMessage(
           `Failed to start rust-glancer language server: ${error.message}`,
         );
       });
 
       child.on("exit", (code, signal) => {
-        output.appendLine(
-          `server exited with code ${code ?? "null"} and signal ${signal ?? "null"}`,
-        );
+        output.info(`server exited with code ${code ?? "null"} and signal ${signal ?? "null"}`);
       });
 
       return Promise.resolve(child);

--- a/editors/code/src/logging/server-log.ts
+++ b/editors/code/src/logging/server-log.ts
@@ -1,0 +1,139 @@
+/**
+ * Parses structured logs emitted by the Rust LSP server and engine subprocesses.
+ *
+ * In LSP mode, Rust writes one JSON object per stderr line. Each event carries a schema marker,
+ * severity level, human message, component/engine identity, and a small bag of structured fields.
+ * The extension keeps this parser narrow so unknown or non-JSON stderr remains visible as raw log
+ * output instead of disappearing.
+ */
+const SERVER_LOG_SCHEMA = "rust-glancer-log/v1";
+
+export type ServerLogLevel = "trace" | "debug" | "info" | "warn" | "error";
+
+export interface ServerLogRecord {
+  readonly level: ServerLogLevel;
+  readonly component: string;
+  readonly engine?: string;
+  readonly message: string;
+  readonly target?: string;
+  readonly fields: Record<string, unknown>;
+}
+
+export type ParsedServerLogLine =
+  | {
+      readonly kind: "structured";
+      readonly record: ServerLogRecord;
+    }
+  | {
+      readonly kind: "raw";
+      readonly level: ServerLogLevel;
+      readonly message: string;
+    };
+
+export function parseServerLogLine(line: string): ParsedServerLogLine {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) {
+    return { kind: "raw", level: "info", message: "" };
+  }
+
+  const parsed = parseJsonObject(trimmed);
+  if (parsed === undefined || parsed.schema !== SERVER_LOG_SCHEMA) {
+    return { kind: "raw", level: rawLineLevel(trimmed), message: trimmed };
+  }
+
+  const level = logLevel(parsed.level);
+  const message = stringValue(parsed.message) ?? "";
+  const component = stringValue(parsed.component) ?? "server";
+  const engine = stringValue(parsed.engine);
+  const target = stringValue(parsed.target);
+  const fields = recordValue(parsed.fields) ?? {};
+
+  return {
+    kind: "structured",
+    record: {
+      level,
+      component,
+      engine,
+      message,
+      target,
+      fields,
+    },
+  };
+}
+
+export function formatServerLogRecord(record: ServerLogRecord): string {
+  const source =
+    record.component === "engine" && record.engine !== undefined
+      ? `${record.component}:${record.engine}`
+      : record.component;
+  const fields = formatFields(record.fields);
+
+  return fields.length === 0
+    ? `[${source}] ${record.message}`
+    : `[${source}] ${record.message} ${fields}`;
+}
+
+function parseJsonObject(line: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    return recordValue(parsed);
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+function logLevel(value: unknown): ServerLogLevel {
+  switch (stringValue(value)?.toLowerCase()) {
+    case "trace":
+      return "trace";
+    case "debug":
+      return "debug";
+    case "warn":
+    case "warning":
+      return "warn";
+    case "error":
+      return "error";
+    default:
+      return "info";
+  }
+}
+
+function rawLineLevel(line: string): ServerLogLevel {
+  return /(^|\b)(error|panic|fatal)(\b|:)/i.test(line) ? "error" : "info";
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function formatFields(fields: Record<string, unknown>): string {
+  return Object.entries(fields)
+    .map(([key, value]) => `${key}=${formatFieldValue(value)}`)
+    .join(" ");
+}
+
+function formatFieldValue(value: unknown): string {
+  if (typeof value === "string") {
+    return quoteIfNeeded(value);
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (value === null) {
+    return "null";
+  }
+
+  return JSON.stringify(value);
+}
+
+function quoteIfNeeded(value: string): string {
+  return /^[A-Za-z0-9_./:-]+$/.test(value) ? value : JSON.stringify(value);
+}

--- a/editors/code/src/logging/server-output-channel.ts
+++ b/editors/code/src/logging/server-output-channel.ts
@@ -1,0 +1,98 @@
+import * as vscode from "vscode";
+
+import {
+  type ParsedServerLogLine,
+  type ServerLogLevel,
+  formatServerLogRecord,
+  parseServerLogLine,
+} from "./server-log";
+
+/// Adapts stderr text from `vscode-languageclient` into VS Code's log-channel API.
+///
+/// The Rust side emits one structured JSON log event per line. Cargo startup output, panics, and
+/// other non-JSON stderr still remain visible through the raw-line fallback.
+export class ServerOutputChannel implements vscode.OutputChannel {
+  private bufferedText = "";
+
+  public constructor(private readonly inner: vscode.LogOutputChannel) {}
+
+  public get name(): string {
+    return this.inner.name;
+  }
+
+  public append(value: string): void {
+    this.bufferedText += value;
+
+    for (;;) {
+      const newline = this.bufferedText.indexOf("\n");
+      if (newline === -1) {
+        return;
+      }
+
+      const line = this.bufferedText.slice(0, newline).replace(/\r$/, "");
+      this.bufferedText = this.bufferedText.slice(newline + 1);
+      this.publishLine(parseServerLogLine(line));
+    }
+  }
+
+  public appendLine(value: string): void {
+    this.append(`${value}\n`);
+  }
+
+  public replace(value: string): void {
+    this.bufferedText = "";
+    this.inner.clear();
+    this.append(value);
+  }
+
+  public clear(): void {
+    this.bufferedText = "";
+    this.inner.clear();
+  }
+
+  public show(preserveFocus?: boolean): void;
+  public show(column?: vscode.ViewColumn, preserveFocus?: boolean): void;
+  public show(columnOrPreserveFocus?: vscode.ViewColumn | boolean, preserveFocus?: boolean): void {
+    if (typeof columnOrPreserveFocus === "number") {
+      this.inner.show(columnOrPreserveFocus, preserveFocus);
+    } else {
+      this.inner.show(columnOrPreserveFocus);
+    }
+  }
+
+  public hide(): void {
+    this.inner.hide();
+  }
+
+  public dispose(): void {
+    this.inner.dispose();
+  }
+
+  private publishLine(line: ParsedServerLogLine): void {
+    if (line.kind === "structured") {
+      this.publish(line.record.level, formatServerLogRecord(line.record));
+    } else if (line.message.length > 0) {
+      this.publish(line.level, line.message);
+    }
+  }
+
+  private publish(level: ServerLogLevel, message: string): void {
+    switch (level) {
+      case "trace":
+        this.inner.trace(message);
+        break;
+      case "debug":
+        this.inner.debug(message);
+        break;
+      case "warn":
+        this.inner.warn(message);
+        break;
+      case "error":
+        this.inner.error(message);
+        break;
+      case "info":
+        this.inner.info(message);
+        break;
+    }
+  }
+}

--- a/editors/code/src/test-support/recording-output-channel.ts
+++ b/editors/code/src/test-support/recording-output-channel.ts
@@ -6,13 +6,21 @@
  */
 import * as vscode from "vscode";
 
-export class RecordingOutputChannel implements vscode.OutputChannel {
+export class RecordingLogOutputChannel implements vscode.LogOutputChannel {
   private readonly lines: string[] = [];
 
-  public constructor(private readonly inner: vscode.OutputChannel) {}
+  public constructor(private readonly inner: vscode.LogOutputChannel) {}
 
   public get name(): string {
     return this.inner.name;
+  }
+
+  public get logLevel(): vscode.LogLevel {
+    return this.inner.logLevel;
+  }
+
+  public get onDidChangeLogLevel(): vscode.Event<vscode.LogLevel> {
+    return this.inner.onDidChangeLogLevel;
   }
 
   public append(value: string): void {
@@ -54,8 +62,37 @@ export class RecordingOutputChannel implements vscode.OutputChannel {
     this.inner.dispose();
   }
 
+  public trace(message: string, ...args: any[]): void {
+    this.recordLine(message);
+    this.inner.trace(message, ...args);
+  }
+
+  public debug(message: string, ...args: any[]): void {
+    this.recordLine(message);
+    this.inner.debug(message, ...args);
+  }
+
+  public info(message: string, ...args: any[]): void {
+    this.recordLine(message);
+    this.inner.info(message, ...args);
+  }
+
+  public warn(message: string, ...args: any[]): void {
+    this.recordLine(message);
+    this.inner.warn(message, ...args);
+  }
+
+  public error(error: string | Error, ...args: any[]): void {
+    this.recordLine(error instanceof Error ? (error.stack ?? error.message) : error);
+    this.inner.error(error, ...args);
+  }
+
   public snapshot(): string {
     return this.lines.join("");
+  }
+
+  private recordLine(value: string): void {
+    this.record(`${value}\n`);
   }
 
   private record(value: string): void {

--- a/editors/code/unit/server-log.test.ts
+++ b/editors/code/unit/server-log.test.ts
@@ -1,0 +1,44 @@
+import * as assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { formatServerLogRecord, parseServerLogLine } from "../src/logging/server-log";
+
+describe("server log parsing", () => {
+  it("parses structured rust-glancer log lines", () => {
+    const parsed = parseServerLogLine(
+      JSON.stringify({
+        schema: "rust-glancer-log/v1",
+        level: "INFO",
+        component: "engine",
+        engine: "simple_crate",
+        target: "rg_lsp_engine::engine::worker",
+        message: "workspace indexing finished",
+        fields: {
+          elapsed_ms: 7630,
+          workspace_root: "/workspace/simple_crate",
+        },
+      }),
+    );
+
+    assert.equal(parsed.kind, "structured");
+    if (parsed.kind === "structured") {
+      assert.equal(parsed.record.level, "info");
+      assert.equal(parsed.record.component, "engine");
+      assert.equal(parsed.record.engine, "simple_crate");
+      assert.equal(
+        formatServerLogRecord(parsed.record),
+        "[engine:simple_crate] workspace indexing finished elapsed_ms=7630 workspace_root=/workspace/simple_crate",
+      );
+    }
+  });
+
+  it("keeps non-json stderr visible", () => {
+    const parsed = parseServerLogLine("error: failed to compile");
+
+    assert.deepEqual(parsed, {
+      kind: "raw",
+      level: "error",
+      message: "error: failed to compile",
+    });
+  });
+});


### PR DESCRIPTION
Introduces two different windows to represent extension and server logs separately.
Adds colored output.
Passes logs from server to extension as structured JSON payload which is adapted to the expected vscode format. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured JSON logging for the language server and engine with improved formatting.
  * Separated extension and server output channels in VS Code for better log organization.

* **Configuration Changes**
  * Removed the `rust-glancer.trace.server` setting; server tracing is now handled via structured logging.

* **Tests**
  * Added unit tests for structured server log parsing and formatting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/popzxc/rust-glancer/pull/9)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->