### PR TITLE
feat: Support "goto implementations"

### DIFF
--- a/crates/engine/analysis/src/api/mod.rs
+++ b/crates/engine/analysis/src/api/mod.rs
@@ -83,6 +83,17 @@ impl<'a> Analysis<'a> {
             .goto_type_definition(target, file_id, offset)
     }
 
+    /// Returns best-effort implementations for the symbol under a source offset.
+    pub fn goto_implementation(
+        &self,
+        target: TargetRef,
+        file_id: FileId,
+        offset: u32,
+    ) -> anyhow::Result<Vec<NavigationTarget>> {
+        query::navigation::ImplementationResolver::new(self)
+            .goto_implementation(target, file_id, offset)
+    }
+
     /// Returns the best-effort Body IR type under a source offset.
     pub fn type_at(
         &self,

--- a/crates/engine/analysis/src/api/query/navigation/implementation.rs
+++ b/crates/engine/analysis/src/api/query/navigation/implementation.rs
@@ -1,0 +1,338 @@
+//! Goto-implementation query flow.
+
+use rg_body_ir::{BodyImplId, BodyResolution, BodyTy, ExprKind, ResolvedFunctionRef};
+use rg_def_map::TargetRef;
+use rg_parse::FileId;
+use rg_semantic_ir::{AssocItemId, FunctionRef, ImplRef, ItemOwner, TraitRef, TypeDefRef};
+
+use super::target::NavigationTargetResolver;
+use crate::{
+    api::{
+        Analysis,
+        query::type_at::TypeResolver,
+        resolve::entity::{EntityResolver, ResolvedEntity},
+    },
+    model::{NavigationTarget, SymbolAt},
+};
+
+/// Implements goto-implementation with the facts rust-glancer already collects.
+///
+/// The query deliberately returns concrete source declarations only: impl blocks for types/traits
+/// and concrete methods for trait-method declarations or calls. It avoids inventing targets for
+/// default trait items because those are declarations, not user-written implementations.
+pub(crate) struct ImplementationResolver<'a, 'db>(&'a Analysis<'db>);
+
+impl<'a, 'db> ImplementationResolver<'a, 'db> {
+    pub(crate) fn new(analysis: &'a Analysis<'db>) -> Self {
+        Self(analysis)
+    }
+
+    pub(crate) fn goto_implementation(
+        &self,
+        target: TargetRef,
+        file_id: FileId,
+        offset: u32,
+    ) -> anyhow::Result<Vec<NavigationTarget>> {
+        let Some(symbol) = self.0.symbol_at_for_query(target, file_id, offset)? else {
+            return Ok(Vec::new());
+        };
+
+        let mut targets = Vec::new();
+        if self.push_method_call_targets(&symbol, &mut targets)? {
+            return Ok(targets);
+        }
+
+        for entity in EntityResolver::new(self.0).entities_for_symbol(symbol)? {
+            self.push_entity_targets(entity, &mut targets)?;
+        }
+
+        if targets.is_empty()
+            && let Some(ty) = TypeResolver::new(self.0).type_at(target, file_id, offset)?
+        {
+            self.push_ty_targets(&ty, &mut targets)?;
+        }
+
+        Ok(targets)
+    }
+
+    fn push_method_call_targets(
+        &self,
+        symbol: &SymbolAt,
+        targets: &mut Vec<NavigationTarget>,
+    ) -> anyhow::Result<bool> {
+        let SymbolAt::Expr { body, expr } = *symbol else {
+            return Ok(false);
+        };
+        let Some(body_data) = self.0.body_ir.body_data(body)? else {
+            return Ok(false);
+        };
+        let Some(expr_data) = body_data.expr(expr) else {
+            return Ok(false);
+        };
+        let ExprKind::MethodCall {
+            receiver: Some(receiver),
+            ..
+        } = &expr_data.kind
+        else {
+            return Ok(false);
+        };
+        let BodyResolution::Method(functions) = &expr_data.resolution else {
+            return Ok(false);
+        };
+        let receiver_ty = body_data.expr(*receiver).map(|data| &data.ty);
+
+        for function in functions {
+            self.push_resolved_function_targets(*function, receiver_ty, targets)?;
+        }
+
+        Ok(true)
+    }
+
+    fn push_entity_targets(
+        &self,
+        entity: ResolvedEntity,
+        targets: &mut Vec<NavigationTarget>,
+    ) -> anyhow::Result<()> {
+        match entity {
+            ResolvedEntity::TypeDef(ty) => self.push_type_def_targets(ty, targets),
+            ResolvedEntity::Trait(trait_ref) => self.push_trait_impl_targets(trait_ref, targets),
+            ResolvedEntity::Function(function) => {
+                self.push_resolved_function_targets(function, None, targets)
+            }
+            ResolvedEntity::LocalBinding { body, binding } => {
+                let Some(body_data) = self.0.body_ir.body_data(body)? else {
+                    return Ok(());
+                };
+                let Some(binding_data) = body_data.binding(binding) else {
+                    return Ok(());
+                };
+                self.push_ty_targets(&binding_data.ty, targets)
+            }
+            ResolvedEntity::LocalItem(item) => self.push_local_type_targets(item, targets),
+            ResolvedEntity::Module { .. }
+            | ResolvedEntity::Field(_)
+            | ResolvedEntity::EnumVariant(_)
+            | ResolvedEntity::TypeAlias(_)
+            | ResolvedEntity::Const(_)
+            | ResolvedEntity::Static(_)
+            | ResolvedEntity::LocalDef(_) => Ok(()),
+        }
+    }
+
+    fn push_ty_targets(
+        &self,
+        ty: &BodyTy,
+        targets: &mut Vec<NavigationTarget>,
+    ) -> anyhow::Result<()> {
+        for local_ty in ty.local_nominals() {
+            self.push_local_type_targets(local_ty.item, targets)?;
+        }
+        for ty in ty.nominal_tys() {
+            self.push_type_def_targets(ty.def, targets)?;
+        }
+        Ok(())
+    }
+
+    fn push_type_def_targets(
+        &self,
+        ty: TypeDefRef,
+        targets: &mut Vec<NavigationTarget>,
+    ) -> anyhow::Result<()> {
+        for impl_ref in self.0.semantic_ir.impls_for_type(ty)? {
+            self.push_impl_target(impl_ref, targets)?;
+        }
+        Ok(())
+    }
+
+    fn push_local_type_targets(
+        &self,
+        item: rg_body_ir::BodyItemRef,
+        targets: &mut Vec<NavigationTarget>,
+    ) -> anyhow::Result<()> {
+        let Some(body) = self.0.body_ir.body_data(item.body)? else {
+            return Ok(());
+        };
+
+        for (impl_idx, data) in body.local_impls().iter().enumerate() {
+            if data.self_item != Some(item) {
+                continue;
+            }
+            let Some(target) = NavigationTargetResolver::new(self.0)
+                .navigation_target_for_body_impl(item.body, BodyImplId(impl_idx))?
+            else {
+                continue;
+            };
+            Self::push_unique_target(targets, target);
+        }
+        Ok(())
+    }
+
+    fn push_trait_impl_targets(
+        &self,
+        trait_ref: TraitRef,
+        targets: &mut Vec<NavigationTarget>,
+    ) -> anyhow::Result<()> {
+        for impl_ref in self.0.semantic_ir.impls_for_trait(trait_ref)? {
+            self.push_impl_target(impl_ref, targets)?;
+        }
+        Ok(())
+    }
+
+    fn push_resolved_function_targets(
+        &self,
+        function: ResolvedFunctionRef,
+        receiver_ty: Option<&BodyTy>,
+        targets: &mut Vec<NavigationTarget>,
+    ) -> anyhow::Result<()> {
+        match function {
+            ResolvedFunctionRef::Semantic(function) => {
+                self.push_semantic_function_targets(function, receiver_ty, targets)
+            }
+            ResolvedFunctionRef::BodyLocal(function) => {
+                let Some(target) = NavigationTargetResolver::new(self.0)
+                    .navigation_target_for_resolved_function(ResolvedFunctionRef::BodyLocal(
+                        function,
+                    ))?
+                else {
+                    return Ok(());
+                };
+                Self::push_unique_target(targets, target);
+                Ok(())
+            }
+        }
+    }
+
+    fn push_semantic_function_targets(
+        &self,
+        function: FunctionRef,
+        receiver_ty: Option<&BodyTy>,
+        targets: &mut Vec<NavigationTarget>,
+    ) -> anyhow::Result<()> {
+        let Some(data) = self.0.semantic_ir.function_data(function)? else {
+            return Ok(());
+        };
+
+        match data.owner {
+            ItemOwner::Trait(trait_id) => {
+                let trait_ref = TraitRef {
+                    target: function.target,
+                    id: trait_id,
+                };
+                match receiver_ty {
+                    Some(receiver_ty) => self.push_trait_method_targets_for_receiver(
+                        trait_ref,
+                        data.name.as_str(),
+                        receiver_ty,
+                        targets,
+                    ),
+                    None => self.push_trait_method_targets(trait_ref, data.name.as_str(), targets),
+                }
+            }
+            ItemOwner::Impl(_) => {
+                let Some(target) = NavigationTargetResolver::new(self.0)
+                    .navigation_target_for_function(function)?
+                else {
+                    return Ok(());
+                };
+                Self::push_unique_target(targets, target);
+                Ok(())
+            }
+            ItemOwner::Module(_) => Ok(()),
+        }
+    }
+
+    fn push_trait_method_targets_for_receiver(
+        &self,
+        trait_ref: TraitRef,
+        method_name: &str,
+        receiver_ty: &BodyTy,
+        targets: &mut Vec<NavigationTarget>,
+    ) -> anyhow::Result<()> {
+        for ty in receiver_ty.nominal_tys() {
+            for trait_impl in self.0.semantic_ir.trait_impls_for_type(ty.def)? {
+                if trait_impl.trait_ref != trait_ref {
+                    continue;
+                }
+                // The nominal type match can still include generic impls for other concrete args.
+                // Reuse method lookup's applicability check so `Wrapper<Account>` does not jump to
+                // implementations that only apply to `Wrapper<User>`.
+                if !self.0.body_ir.semantic_trait_impl_applies_to_receiver(
+                    &self.0.def_map,
+                    &self.0.semantic_ir,
+                    trait_impl,
+                    ty,
+                )? {
+                    continue;
+                }
+                self.push_matching_impl_methods(trait_impl.impl_ref, method_name, targets)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn push_trait_method_targets(
+        &self,
+        trait_ref: TraitRef,
+        method_name: &str,
+        targets: &mut Vec<NavigationTarget>,
+    ) -> anyhow::Result<()> {
+        for impl_ref in self.0.semantic_ir.impls_for_trait(trait_ref)? {
+            self.push_matching_impl_methods(impl_ref, method_name, targets)?;
+        }
+        Ok(())
+    }
+
+    fn push_matching_impl_methods(
+        &self,
+        impl_ref: ImplRef,
+        method_name: &str,
+        targets: &mut Vec<NavigationTarget>,
+    ) -> anyhow::Result<()> {
+        let Some(data) = self.0.semantic_ir.impl_data(impl_ref)? else {
+            return Ok(());
+        };
+
+        for item in &data.items {
+            let AssocItemId::Function(id) = item else {
+                continue;
+            };
+            let function = FunctionRef {
+                target: impl_ref.target,
+                id: *id,
+            };
+            let Some(function_data) = self.0.semantic_ir.function_data(function)? else {
+                continue;
+            };
+            if function_data.name.as_str() != method_name {
+                continue;
+            }
+            let Some(target) =
+                NavigationTargetResolver::new(self.0).navigation_target_for_function(function)?
+            else {
+                continue;
+            };
+            Self::push_unique_target(targets, target);
+        }
+        Ok(())
+    }
+
+    fn push_impl_target(
+        &self,
+        impl_ref: ImplRef,
+        targets: &mut Vec<NavigationTarget>,
+    ) -> anyhow::Result<()> {
+        let Some(target) =
+            NavigationTargetResolver::new(self.0).navigation_target_for_impl(impl_ref)?
+        else {
+            return Ok(());
+        };
+        Self::push_unique_target(targets, target);
+        Ok(())
+    }
+
+    fn push_unique_target(targets: &mut Vec<NavigationTarget>, target: NavigationTarget) {
+        if !targets.contains(&target) {
+            targets.push(target);
+        }
+    }
+}

--- a/crates/engine/analysis/src/api/query/navigation/implementation.rs
+++ b/crates/engine/analysis/src/api/query/navigation/implementation.rs
@@ -38,14 +38,17 @@ impl<'a, 'db> ImplementationResolver<'a, 'db> {
         };
 
         let mut targets = Vec::new();
+        // 1) Method-call sites: prefer concrete callable implementations.
         if self.push_method_call_targets(&symbol, &mut targets)? {
             return Ok(targets);
         }
 
+        // 2) Symbol/entity expansion: trait/type/function/local bindings.
         for entity in EntityResolver::new(self.0).entities_for_symbol(symbol)? {
             self.push_entity_targets(entity, &mut targets)?;
         }
 
+        // 3) If symbol expansion found nothing, fall back to inferred type.
         if targets.is_empty()
             && let Some(ty) = TypeResolver::new(self.0).type_at(target, file_id, offset)?
         {

--- a/crates/engine/analysis/src/api/query/navigation/mod.rs
+++ b/crates/engine/analysis/src/api/query/navigation/mod.rs
@@ -5,10 +5,12 @@
 //! and the public goto query flows compose symbol/type lookup with target projection.
 
 mod goto;
+mod implementation;
 mod symbol;
 mod target;
 mod type_definition;
 
 pub(crate) use self::{
-    goto::GotoResolver, symbol::SymbolResolver, type_definition::TypeDefinitionResolver,
+    goto::GotoResolver, implementation::ImplementationResolver, symbol::SymbolResolver,
+    type_definition::TypeDefinitionResolver,
 };

--- a/crates/engine/analysis/src/api/query/navigation/target.rs
+++ b/crates/engine/analysis/src/api/query/navigation/target.rs
@@ -1,11 +1,13 @@
 //! Concrete navigation target projection.
 
-use rg_body_ir::{BodyFieldRef, BodyItemRef, BodyTy, ResolvedFieldRef, ResolvedFunctionRef};
+use rg_body_ir::{
+    BodyFieldRef, BodyImplId, BodyItemRef, BodyRef, BodyTy, ResolvedFieldRef, ResolvedFunctionRef,
+};
 use rg_def_map::{DefId, LocalDefRef, ModuleOrigin, ModuleRef};
-use rg_semantic_ir::{EnumVariantRef, FieldRef, FunctionRef, TraitRef, TypeDefRef};
+use rg_semantic_ir::{EnumVariantRef, FieldRef, FunctionRef, ImplRef, TraitRef, TypeDefRef};
 
 use crate::{
-    api::Analysis,
+    api::{Analysis, query::symbols::shared},
     model::{NavigationTarget, NavigationTargetKind},
 };
 
@@ -168,6 +170,47 @@ impl<'a, 'db> NavigationTargetResolver<'a, 'db> {
             name: function_data.name.to_string(),
             file_id: function_data.source.file_id,
             span: Some(function_data.name_span.unwrap_or(function_data.span)),
+        }))
+    }
+
+    pub(crate) fn navigation_target_for_impl(
+        &self,
+        impl_ref: ImplRef,
+    ) -> anyhow::Result<Option<NavigationTarget>> {
+        let Some(data) = self.0.semantic_ir.impl_data(impl_ref)? else {
+            return Ok(None);
+        };
+        let Some(local_impl) = self.0.def_map.local_impl(data.local_impl)? else {
+            return Ok(None);
+        };
+
+        Ok(Some(NavigationTarget {
+            target: impl_ref.target,
+            kind: NavigationTargetKind::Impl,
+            name: shared::impl_label(data),
+            file_id: local_impl.file_id,
+            span: Some(local_impl.span),
+        }))
+    }
+
+    pub(crate) fn navigation_target_for_body_impl(
+        &self,
+        body_ref: BodyRef,
+        impl_id: BodyImplId,
+    ) -> anyhow::Result<Option<NavigationTarget>> {
+        let Some(body) = self.0.body_ir.body_data(body_ref)? else {
+            return Ok(None);
+        };
+        let Some(data) = body.local_impl(impl_id) else {
+            return Ok(None);
+        };
+
+        Ok(Some(NavigationTarget {
+            target: body_ref.target,
+            kind: NavigationTargetKind::Impl,
+            name: shared::body_impl_label(data),
+            file_id: data.source.file_id,
+            span: Some(data.source.span),
         }))
     }
 

--- a/crates/engine/analysis/src/api/query/symbols/mod.rs
+++ b/crates/engine/analysis/src/api/query/symbols/mod.rs
@@ -1,5 +1,5 @@
 mod document;
-mod shared;
+pub(crate) mod shared;
 mod workspace;
 
 use anyhow::Result;

--- a/crates/engine/analysis/src/model.rs
+++ b/crates/engine/analysis/src/model.rs
@@ -220,6 +220,8 @@ pub enum NavigationTargetKind {
     Field,
     #[display("fn")]
     Function,
+    #[display("impl")]
+    Impl,
     #[display("macro")]
     Macro,
     #[display("static")]

--- a/crates/engine/analysis/src/tests/goto_implementation.rs
+++ b/crates/engine/analysis/src/tests/goto_implementation.rs
@@ -1,0 +1,161 @@
+use expect_test::expect;
+
+use super::utils::{AnalysisQuery, check_analysis_queries};
+
+#[test]
+fn resolves_type_trait_and_trait_method_implementations() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_goto_implementation"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct User;
+pub struct Account;
+pub struct UserName;
+
+pub trait Na$impl_trait$med {
+    fn na$impl_trait_method$me(&self) -> UserName;
+}
+
+impl Us$impl_type$er {
+    pub fn n$impl_inherent$ew() -> Self {
+        User
+    }
+}
+
+impl Named for User {
+    fn name(&self) -> UserName {
+        missing()
+    }
+}
+
+impl Named for Account {
+    fn name(&self) -> UserName {
+        missing()
+    }
+}
+
+pub fn use_it(user: User) {
+    let _again: User = User::n$impl_inherent_use$ew();
+    let _name = user.na$impl_trait_call$me();
+}
+"#,
+        &[
+            AnalysisQuery::goto_impl("goto implementations of type", "impl_type"),
+            AnalysisQuery::goto_impl("goto implementations of trait", "impl_trait"),
+            AnalysisQuery::goto_impl("goto implementations of trait method", "impl_trait_method"),
+            AnalysisQuery::goto_impl("goto inherent implementation", "impl_inherent"),
+            AnalysisQuery::goto_impl("goto inherent implementation use", "impl_inherent_use"),
+            AnalysisQuery::goto_impl("goto trait implementation from call", "impl_trait_call"),
+        ],
+        expect![[r#"
+            goto implementations of type
+            - impl Named for User @ 15:1-19:2
+            - impl User @ 9:1-13:2
+
+            goto implementations of trait
+            - impl Named for Account @ 21:1-25:2
+            - impl Named for User @ 15:1-19:2
+
+            goto implementations of trait method
+            - fn name @ 16:8-16:12
+            - fn name @ 22:8-22:12
+
+            goto inherent implementation
+            - fn new @ 10:12-10:15
+
+            goto inherent implementation use
+            - fn new @ 10:12-10:15
+
+            goto trait implementation from call
+            - fn name @ 16:8-16:12
+        "#]],
+    );
+}
+
+#[test]
+fn resolves_body_local_type_implementations() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_body_local_goto_implementation"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub fn use_it() {
+    struct Us$impl_local_type$er;
+
+    impl User {
+        fn id(&self) {}
+    }
+
+    let us$impl_local_binding$er: User;
+}
+"#,
+        &[
+            AnalysisQuery::goto_impl(
+                "goto body-local implementations from type",
+                "impl_local_type",
+            ),
+            AnalysisQuery::goto_impl(
+                "goto body-local implementations from binding",
+                "impl_local_binding",
+            ),
+        ],
+        expect![[r#"
+            goto body-local implementations from type
+            - impl User @ 4:5-6:6
+
+            goto body-local implementations from binding
+            - impl User @ 4:5-6:6
+        "#]],
+    );
+}
+
+#[test]
+fn filters_trait_method_call_implementations_by_receiver_generic_args() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_goto_implementation_trait_impl_generics"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct User;
+pub struct Account;
+pub struct Wrapper<T>(T);
+
+pub trait Named {
+    fn name(&self);
+}
+
+impl Named for Wrapper<User> {
+    fn name(&self) {}
+}
+
+impl Named for Wrapper<Account> {
+    fn name(&self) {}
+}
+
+pub fn use_it(account: Wrapper<Account>) {
+    account.na$impl_account_call$me();
+}
+"#,
+        &[AnalysisQuery::goto_impl(
+            "goto trait implementation from generic receiver call",
+            "impl_account_call",
+        )],
+        expect![[r#"
+            goto trait implementation from generic receiver call
+            - fn name @ 14:8-14:12
+        "#]],
+    );
+}

--- a/crates/engine/analysis/src/tests/mod.rs
+++ b/crates/engine/analysis/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod utils;
 mod completions_at_dot;
 mod document_symbols;
 mod goto_definition;
+mod goto_implementation;
 mod goto_type_definition;
 mod hover;
 mod resolve_symbol;

--- a/crates/engine/analysis/src/tests/utils.rs
+++ b/crates/engine/analysis/src/tests/utils.rs
@@ -105,6 +105,10 @@ impl AnalysisQuery {
         Self::new(title, marker, AnalysisQueryKind::GotoTypeDefinition)
     }
 
+    pub(super) fn goto_impl(title: &'static str, marker: &'static str) -> Self {
+        Self::new(title, marker, AnalysisQueryKind::GotoImplementation)
+    }
+
     pub(super) fn ty(title: &'static str, marker: &'static str) -> Self {
         Self::new(title, marker, AnalysisQueryKind::TypeAt)
     }
@@ -219,6 +223,7 @@ enum AnalysisQueryKind {
     ResolveSymbol,
     GotoDefinition,
     GotoTypeDefinition,
+    GotoImplementation,
     TypeAt,
     CompletionsAtDot,
     Hover,
@@ -427,6 +432,15 @@ impl<'a> AnalysisQuerySnapshot<'a> {
                         .analysis()
                         .goto_type_definition(target, file_id, offset)
                         .expect("fixture goto type query should resolve"),
+                    &mut dump,
+                );
+            }
+            AnalysisQueryKind::GotoImplementation => {
+                self.render_targets(
+                    self.db
+                        .analysis()
+                        .goto_implementation(target, file_id, offset)
+                        .expect("fixture goto implementation query should resolve"),
                     &mut dump,
                 );
             }
@@ -715,11 +729,14 @@ impl<'a> AnalysisQuerySnapshot<'a> {
 
         writeln!(dump).expect("string writes should not fail");
         for target in targets {
+            let label = if target.kind == crate::NavigationTargetKind::Impl {
+                target.name
+            } else {
+                format!("{} {}", target.kind, target.name)
+            };
             writeln!(
                 dump,
-                "- {} {} @ {}",
-                target.kind,
-                target.name,
+                "- {label} @ {}",
                 self.render_optional_span(target.target.package, target.file_id, target.span)
             )
             .expect("string writes should not fail");

--- a/crates/engine/body-ir/src/resolution/method.rs
+++ b/crates/engine/body-ir/src/resolution/method.rs
@@ -316,7 +316,7 @@ fn impl_self_args_match_receiver(
     Ok(true)
 }
 
-fn semantic_trait_impl_applicability(
+pub(super) fn semantic_trait_impl_applicability(
     def_map: &DefMapReadTxn<'_>,
     semantic_ir: &SemanticIrReadTxn<'_>,
     trait_impl: TraitImplRef,

--- a/crates/engine/body-ir/src/resolution/mod.rs
+++ b/crates/engine/body-ir/src/resolution/mod.rs
@@ -14,7 +14,7 @@ mod type_path;
 use rg_def_map::{DefMapReadTxn, Path};
 use rg_package_store::PackageStoreError;
 use rg_semantic_ir::{
-    FieldRef, FunctionRef, SemanticIrReadTxn, TraitApplicability, TypePathContext,
+    FieldRef, FunctionRef, SemanticIrReadTxn, TraitApplicability, TraitImplRef, TypePathContext,
 };
 
 use crate::{
@@ -30,6 +30,7 @@ use self::{
         local_function_applies_to_receiver as local_function_applies_to_receiver_impl,
         semantic_function_applies_to_receiver as semantic_function_applies_to_receiver_impl,
         semantic_trait_function_candidates_for_receiver as semantic_trait_function_candidates_for_receiver_impl,
+        semantic_trait_impl_applicability,
     },
     ty::{TypeSubst, ty_from_type_ref_in_context},
     type_path::BodyTypePathResolver,
@@ -109,6 +110,18 @@ pub(super) fn semantic_trait_function_candidates_for_receiver(
         semantic_ir,
         receiver_ty,
         None,
+    )
+}
+
+pub(super) fn semantic_trait_impl_applies_to_receiver(
+    def_map: &DefMapReadTxn<'_>,
+    semantic_ir: &SemanticIrReadTxn<'_>,
+    trait_impl: TraitImplRef,
+    receiver_ty: &BodyNominalTy,
+) -> Result<bool, PackageStoreError> {
+    Ok(
+        semantic_trait_impl_applicability(def_map, semantic_ir, trait_impl, receiver_ty)?
+            .is_applicable(),
     )
 }
 

--- a/crates/engine/body-ir/src/store/txn.rs
+++ b/crates/engine/body-ir/src/store/txn.rs
@@ -2,7 +2,7 @@
 
 use rg_def_map::{DefMapReadTxn, PackageSlot, Path, TargetRef};
 use rg_package_store::{PackageRead, PackageStoreError, PackageStoreReadTxn};
-use rg_semantic_ir::{FieldRef, FunctionRef, SemanticIrReadTxn, TraitApplicability};
+use rg_semantic_ir::{FieldRef, FunctionRef, SemanticIrReadTxn, TraitApplicability, TraitImplRef};
 
 use crate::{
     BodyData, BodyFieldData, BodyFieldRef, BodyFunctionData, BodyFunctionRef, BodyItemRef,
@@ -129,6 +129,22 @@ impl<'db> BodyIrReadTxn<'db> {
         resolution::semantic_trait_function_candidates_for_receiver(
             def_map,
             semantic_ir,
+            receiver_ty,
+        )
+    }
+
+    /// Checks whether a semantic trait impl is a plausible candidate for a receiver type.
+    pub fn semantic_trait_impl_applies_to_receiver(
+        &self,
+        def_map: &DefMapReadTxn<'db>,
+        semantic_ir: &SemanticIrReadTxn<'db>,
+        trait_impl: TraitImplRef,
+        receiver_ty: &BodyNominalTy,
+    ) -> Result<bool, PackageStoreError> {
+        resolution::semantic_trait_impl_applies_to_receiver(
+            def_map,
+            semantic_ir,
+            trait_impl,
             receiver_ty,
         )
     }

--- a/crates/engine/semantic-ir/src/store/txn.rs
+++ b/crates/engine/semantic-ir/src/store/txn.rs
@@ -698,6 +698,21 @@ impl<'db> SemanticIrReadTxn<'db> {
         Ok(impls)
     }
 
+    pub fn impls_for_trait(&self, trait_ref: TraitRef) -> Result<Vec<ImplRef>, PackageStoreError> {
+        let mut impls = Vec::new();
+
+        for impl_ref in self.impl_refs()? {
+            let Some(data) = self.impl_data(impl_ref)? else {
+                continue;
+            };
+            if data.resolved_trait_refs.contains(&trait_ref) {
+                push_unique(&mut impls, impl_ref);
+            }
+        }
+
+        Ok(impls)
+    }
+
     pub fn inherent_impls_for_type(
         &self,
         ty: TypeDefRef,

--- a/crates/lsp/engine/src/engine/command.rs
+++ b/crates/lsp/engine/src/engine/command.rs
@@ -27,6 +27,11 @@ pub(crate) enum EngineCommand {
         position: ls_types::Position,
         respond_to: EngineResponse<Vec<ls_types::Location>>,
     },
+    GotoImplementation {
+        path: PathBuf,
+        position: ls_types::Position,
+        respond_to: EngineResponse<Vec<ls_types::Location>>,
+    },
     Hover {
         path: PathBuf,
         position: ls_types::Position,

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -89,6 +89,21 @@ impl EngineWorker {
                         worker.goto_type_definition(path, position)
                     });
                 }
+                EngineCommand::GotoImplementation {
+                    path,
+                    position,
+                    respond_to,
+                } => {
+                    tracing::trace!(
+                        path = %path.display(),
+                        line = position.line,
+                        character = position.character,
+                        "engine command started: goto_implementation"
+                    );
+                    self.respond_to_query("goto_implementation", respond_to, |worker| {
+                        worker.goto_implementation(path, position)
+                    });
+                }
                 EngineCommand::Hover {
                     path,
                     position,
@@ -313,6 +328,14 @@ impl EngineWorker {
         self.navigation_query(path, position, NavigationQuery::TypeDefinition)
     }
 
+    fn goto_implementation(
+        &self,
+        path: PathBuf,
+        position: ls_types::Position,
+    ) -> anyhow::Result<Vec<ls_types::Location>> {
+        self.navigation_query(path, position, NavigationQuery::Implementation)
+    }
+
     fn completion(
         &self,
         path: PathBuf,
@@ -526,6 +549,9 @@ impl EngineWorker {
                 }
                 NavigationQuery::TypeDefinition => {
                     analysis.goto_type_definition(target, context.file, offset)?
+                }
+                NavigationQuery::Implementation => {
+                    analysis.goto_implementation(target, context.file, offset)?
                 }
             };
 
@@ -776,6 +802,7 @@ impl EngineWorker {
 enum NavigationQuery {
     Definition,
     TypeDefinition,
+    Implementation,
 }
 
 impl NavigationQuery {
@@ -783,6 +810,7 @@ impl NavigationQuery {
         match self {
             Self::Definition => "definition",
             Self::TypeDefinition => "type_definition",
+            Self::Implementation => "implementation",
         }
     }
 }

--- a/crates/lsp/engine/src/service/service_impl.rs
+++ b/crates/lsp/engine/src/service/service_impl.rs
@@ -215,6 +215,26 @@ impl EngineService for Service {
             .map_err(EngineError::from)
     }
 
+    async fn goto_implementation(
+        self,
+        _: context::Context,
+        path: PathBuf,
+        position: ls_types::Position,
+    ) -> EngineResult<Vec<ls_types::Location>> {
+        if self.engine.is_dirty(&path).await {
+            return Ok(Vec::new());
+        }
+
+        self.engine
+            .request(|respond_to| EngineCommand::GotoImplementation {
+                path,
+                position,
+                respond_to,
+            })
+            .await
+            .map_err(EngineError::from)
+    }
+
     async fn hover(
         self,
         _: context::Context,

--- a/crates/lsp/proto/src/service.rs
+++ b/crates/lsp/proto/src/service.rs
@@ -38,6 +38,11 @@ pub trait EngineService {
         position: ls_types::Position,
     ) -> EngineResult<Vec<ls_types::Location>>;
 
+    async fn goto_implementation(
+        path: PathBuf,
+        position: ls_types::Position,
+    ) -> EngineResult<Vec<ls_types::Location>>;
+
     async fn hover(
         path: PathBuf,
         position: ls_types::Position,

--- a/crates/lsp/server/src/backend.rs
+++ b/crates/lsp/server/src/backend.rs
@@ -237,6 +237,26 @@ impl LanguageServer for Backend {
     #[tracing::instrument(
         skip_all,
         fields(
+            method = "gotoImplementation",
+            uri = ?params.text_document_position_params.text_document.uri
+        )
+    )]
+    async fn goto_implementation(
+        &self,
+        params: GotoImplementationParams,
+    ) -> Result<Option<GotoImplementationResponse>> {
+        let Some(context) = self
+            .method_context_for(&params.text_document_position_params.text_document.uri)
+            .await?
+        else {
+            return Ok(None);
+        };
+        methods::text_document::implementation::implementation(context, params).await
+    }
+
+    #[tracing::instrument(
+        skip_all,
+        fields(
             method = "hover",
             uri = ?params.text_document_position_params.text_document.uri
         )

--- a/crates/lsp/server/src/capabilities.rs
+++ b/crates/lsp/server/src/capabilities.rs
@@ -15,6 +15,7 @@ pub(crate) fn server_capabilities() -> ServerCapabilities {
         )),
         definition_provider: Some(OneOf::Left(true)),
         type_definition_provider: Some(TypeDefinitionProviderCapability::Simple(true)),
+        implementation_provider: Some(ImplementationProviderCapability::Simple(true)),
         hover_provider: Some(HoverProviderCapability::Simple(true)),
         completion_provider: Some(CompletionOptions {
             resolve_provider: Some(false),
@@ -71,6 +72,12 @@ mod tests {
     fn advertises_hover_support() {
         let capabilities = server_capabilities();
         assert!(capabilities.hover_provider.is_some());
+    }
+
+    #[test]
+    fn advertises_implementation_support() {
+        let capabilities = server_capabilities();
+        assert!(capabilities.implementation_provider.is_some());
     }
 
     #[test]

--- a/crates/lsp/server/src/methods/text_document/implementation.rs
+++ b/crates/lsp/server/src/methods/text_document/implementation.rs
@@ -1,0 +1,41 @@
+use tower_lsp_server::{
+    jsonrpc::Result,
+    ls_types::{request::*, *},
+};
+
+use crate::methods::{MethodContext, internal_error, uri_to_path};
+
+#[tracing::instrument(
+    level = "trace", skip_all,
+    fields(
+        position = ?params.text_document_position_params.position
+    )
+)]
+pub(crate) async fn implementation(
+    ctx: MethodContext,
+    params: GotoImplementationParams,
+) -> Result<Option<GotoImplementationResponse>> {
+    let Some(path) = uri_to_path(&params.text_document_position_params.text_document.uri) else {
+        return Ok(None);
+    };
+    let position = params.text_document_position_params.position;
+    tracing::trace!("implementation request received");
+    let locations = ctx
+        .engine_client
+        .call(
+            "goto_implementation",
+            move |engine_client, request_context| async move {
+                engine_client
+                    .goto_implementation(request_context, path, position)
+                    .await
+            },
+        )
+        .await
+        .map_err(internal_error)?;
+    tracing::trace!(
+        result_count = locations.len(),
+        "implementation request answered"
+    );
+
+    Ok(Some(GotoDefinitionResponse::Array(locations)))
+}

--- a/crates/lsp/server/src/methods/text_document/mod.rs
+++ b/crates/lsp/server/src/methods/text_document/mod.rs
@@ -6,5 +6,6 @@ pub(crate) mod did_open;
 pub(crate) mod did_save;
 pub(crate) mod document_symbol;
 pub(crate) mod hover;
+pub(crate) mod implementation;
 pub(crate) mod inlay_hint;
 pub(crate) mod type_definition;

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -9,6 +9,7 @@ export const EXTENSION_COMMANDS = {
   stopServer: "rust-glancer.stopServer",
   reindexWorkspace: "rust-glancer.reindexWorkspace",
   goToTypeFromHover: "rust-glancer.gotoTypeFromHover",
+  goToImplementationFromHover: "rust-glancer.gotoImplementationFromHover",
   testGetState: "rust-glancer.test.getState",
   testGetOutput: "rust-glancer.test.getOutput",
 } as const;

--- a/editors/code/src/features/hover-actions.ts
+++ b/editors/code/src/features/hover-actions.ts
@@ -127,28 +127,25 @@ function registerGoToLocationsCommand(
   logLabel: string,
   notFoundMessage: string,
 ): vscode.Disposable {
-  return vscode.commands.registerCommand(
-    command,
-    async (serializedLocations: unknown) => {
-      const locations = deserializeLocations(serializedLocations);
-      if (locations.length === 0) {
-        output.warn(`${logLabel} command ignored empty or malformed locations`);
-        return;
-      }
+  return vscode.commands.registerCommand(command, async (serializedLocations: unknown) => {
+    const locations = deserializeLocations(serializedLocations);
+    if (locations.length === 0) {
+      output.warn(`${logLabel} command ignored empty or malformed locations`);
+      return;
+    }
 
-      const activeEditor = vscode.window.activeTextEditor;
-      const originUri = activeEditor?.document.uri ?? locations[0].uri;
-      const originPosition = activeEditor?.selection.active ?? locations[0].range.start;
-      await vscode.commands.executeCommand(
-        "editor.action.goToLocations",
-        originUri,
-        originPosition,
-        locations,
-        "peek",
-        notFoundMessage,
-      );
-    },
-  );
+    const activeEditor = vscode.window.activeTextEditor;
+    const originUri = activeEditor?.document.uri ?? locations[0].uri;
+    const originPosition = activeEditor?.selection.active ?? locations[0].range.start;
+    await vscode.commands.executeCommand(
+      "editor.action.goToLocations",
+      originUri,
+      originPosition,
+      locations,
+      "peek",
+      notFoundMessage,
+    );
+  });
 }
 
 async function typeDefinitionLocations(
@@ -192,10 +189,7 @@ async function navigationLocationsOrEmpty(
   }
 }
 
-function appendHoverActions(
-  hover: vscode.Hover,
-  actions: readonly HoverAction[],
-): vscode.Hover {
+function appendHoverActions(hover: vscode.Hover, actions: readonly HoverAction[]): vscode.Hover {
   if (actions.length === 0) {
     return hover;
   }

--- a/editors/code/src/features/hover-actions.ts
+++ b/editors/code/src/features/hover-actions.ts
@@ -1,13 +1,15 @@
 /**
  * Adds rust-glancer-specific actions to VS Code hover results.
  *
- * The language server provides type-definition data through standard LSP requests; this feature
- * turns that data into safe command links so users can jump from hover text to the underlying type.
+ * The language server provides navigation data through standard LSP requests; this feature turns
+ * that data into safe command links so users can jump from hover text to related declarations.
  */
 import * as vscode from "vscode";
 import {
+  ImplementationRequest,
   TypeDefinitionRequest,
   type Definition,
+  type ImplementationParams,
   type LanguageClient,
   type LanguageClientOptions,
   type Location as ProtocolLocation,
@@ -32,6 +34,12 @@ interface SerializedPosition {
   readonly character: number;
 }
 
+interface HoverAction {
+  readonly command: string;
+  readonly label: string;
+  readonly locations: readonly SerializedLocation[];
+}
+
 export function hoverMiddleware(
   clientProvider: () => LanguageClient | undefined,
   output: vscode.LogOutputChannel,
@@ -49,18 +57,47 @@ export function hoverMiddleware(
       }
 
       try {
-        const locations = typeDefinitionLocationsExcludingCurrentHover(
-          await typeDefinitionLocations(client, document, position),
+        const [rawTypeLocations, rawImplementationLocations] = await Promise.all([
+          navigationLocationsOrEmpty(output, "hover go-to-type", () =>
+            typeDefinitionLocations(client, document, position),
+          ),
+          navigationLocationsOrEmpty(output, "hover go-to-implementation", () =>
+            implementationLocations(client, document, position),
+          ),
+        ]);
+        const typeLocations = locationsExcludingCurrentHover(
+          rawTypeLocations,
           document.uri,
           hover.range,
         );
-        if (token.isCancellationRequested || locations.length === 0) {
+        const implementationTargets = locationsExcludingCurrentHover(
+          rawImplementationLocations,
+          document.uri,
+          hover.range,
+        );
+        if (token.isCancellationRequested) {
           return hover;
         }
 
-        return appendGoToTypeAction(hover, locations);
+        return appendHoverActions(
+          hover,
+          [
+            hoverAction(
+              EXTENSION_COMMANDS.goToTypeFromHover,
+              typeLocations,
+              "type",
+              "type definitions",
+            ),
+            hoverAction(
+              EXTENSION_COMMANDS.goToImplementationFromHover,
+              implementationTargets,
+              "implementation",
+              "implementations",
+            ),
+          ].filter((action) => action.locations.length > 0),
+        );
       } catch (error) {
-        output.warn(`hover go-to-type action failed: ${String(error)}`);
+        output.warn(`hover navigation action failed: ${String(error)}`);
         return hover;
       }
     },
@@ -68,20 +105,34 @@ export function hoverMiddleware(
 }
 
 export function registerHoverActionCommands(output: vscode.LogOutputChannel): vscode.Disposable {
+  return vscode.Disposable.from(
+    registerGoToLocationsCommand(
+      EXTENSION_COMMANDS.goToTypeFromHover,
+      output,
+      "hover go-to-type",
+      "No type definition found",
+    ),
+    registerGoToLocationsCommand(
+      EXTENSION_COMMANDS.goToImplementationFromHover,
+      output,
+      "hover go-to-implementation",
+      "No implementation found",
+    ),
+  );
+}
+
+function registerGoToLocationsCommand(
+  command: string,
+  output: vscode.LogOutputChannel,
+  logLabel: string,
+  notFoundMessage: string,
+): vscode.Disposable {
   return vscode.commands.registerCommand(
-    EXTENSION_COMMANDS.goToTypeFromHover,
+    command,
     async (serializedLocations: unknown) => {
       const locations = deserializeLocations(serializedLocations);
       if (locations.length === 0) {
-        output.warn("hover go-to-type command ignored empty or malformed locations");
-        return;
-      }
-
-      if (locations.length === 1) {
-        await vscode.window.showTextDocument(locations[0].uri, {
-          preview: true,
-          selection: locations[0].range,
-        });
+        output.warn(`${logLabel} command ignored empty or malformed locations`);
         return;
       }
 
@@ -93,8 +144,8 @@ export function registerHoverActionCommands(output: vscode.LogOutputChannel): vs
         originUri,
         originPosition,
         locations,
-        "goto",
-        "No type definition found",
+        "peek",
+        notFoundMessage,
       );
     },
   );
@@ -114,24 +165,69 @@ async function typeDefinitionLocations(
   return uniqueLocations(protocolDefinitionLocations(definition));
 }
 
-function appendGoToTypeAction(
-  hover: vscode.Hover,
-  locations: readonly SerializedLocation[],
-): vscode.Hover {
-  const label =
-    locations.length === 1 ? "Go to type" : `Go to ${locations.length} type definitions`;
-  const args = encodeURIComponent(JSON.stringify([locations]));
-  const action = new vscode.MarkdownString(
-    `[${label}](command:${EXTENSION_COMMANDS.goToTypeFromHover}?${args})`,
-  );
+async function implementationLocations(
+  client: LanguageClient,
+  document: vscode.TextDocument,
+  position: vscode.Position,
+): Promise<SerializedLocation[]> {
+  const params: ImplementationParams = {
+    textDocument: { uri: document.uri.toString() },
+    position: { line: position.line, character: position.character },
+  };
 
-  // Only this locally generated command link is trusted. The server-rendered docs and signatures
-  // keep VS Code's default untrusted Markdown behavior.
-  action.isTrusted = { enabledCommands: [EXTENSION_COMMANDS.goToTypeFromHover] };
+  const implementation = await client.sendRequest(ImplementationRequest.type, params);
+  return uniqueLocations(protocolDefinitionLocations(implementation));
+}
+
+async function navigationLocationsOrEmpty(
+  output: vscode.LogOutputChannel,
+  label: string,
+  load: () => Promise<SerializedLocation[]>,
+): Promise<SerializedLocation[]> {
+  try {
+    return await load();
+  } catch (error) {
+    output.warn(`${label} action failed: ${String(error)}`);
+    return [];
+  }
+}
+
+function appendHoverActions(
+  hover: vscode.Hover,
+  actions: readonly HoverAction[],
+): vscode.Hover {
+  if (actions.length === 0) {
+    return hover;
+  }
 
   const contents = Array.isArray(hover.contents) ? [...hover.contents] : [hover.contents];
-  contents.push(action);
+  contents.push(commandLinkLine(actions));
   return new vscode.Hover(contents, hover.range);
+}
+
+function hoverAction(
+  command: string,
+  locations: readonly SerializedLocation[],
+  singularLabel: string,
+  pluralNoun: string,
+): HoverAction {
+  const label = locations.length === 1 ? singularLabel : `${locations.length} ${pluralNoun}`;
+  return { command, label, locations };
+}
+
+function commandLinkLine(actions: readonly HoverAction[]): vscode.MarkdownString {
+  const links = actions.map(commandLink).join(" | ");
+  const line = new vscode.MarkdownString(`Go to ${links}`);
+
+  // Only these locally generated command links are trusted. The server-rendered docs and signatures
+  // keep VS Code's default untrusted Markdown behavior.
+  line.isTrusted = { enabledCommands: actions.map((action) => action.command) };
+  return line;
+}
+
+function commandLink(action: HoverAction): string {
+  const args = encodeURIComponent(JSON.stringify([action.locations]));
+  return `[${action.label}](command:${action.command}?${args})`;
 }
 
 function protocolDefinitionLocations(
@@ -174,7 +270,7 @@ function uniqueLocations(locations: SerializedLocation[]): SerializedLocation[] 
   return unique;
 }
 
-function typeDefinitionLocationsExcludingCurrentHover(
+function locationsExcludingCurrentHover(
   locations: SerializedLocation[],
   documentUri: vscode.Uri,
   hoverRange: vscode.Range | undefined,


### PR DESCRIPTION
Implements support for finding implementations for symbol.
Slightly improves representation in links on hover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Go to Implementation" navigation added across LSP, engine, and editor hover — jump to implementation sites (inherent, trait, method)
  * Editor hover now offers both go-to-type and go-to-implementation actions and registers commands for invoke/peek

* **Behavior**
  * Implementation results are filtered by receiver/type to show only applicable impls

* **Tests**
  * New tests and snapshots cover goto-implementation scenarios and formatting

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/popzxc/rust-glancer/pull/12)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->