### PR TITLE
feat: Dirty buffers via reindexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +1867,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/crates/engine/body-ir/src/build/lower.rs
+++ b/crates/engine/body-ir/src/build/lower.rs
@@ -19,7 +19,7 @@ use rg_semantic_ir::{FunctionRef, ImplRef, ItemOwner, SemanticIrReadTxn, TraitRe
 use rg_text::{Name, NameInterner, PackageNameInterners};
 
 use crate::{
-    BodyIrBuildPolicy,
+    BodyIrBuildPolicy, BodyIrFile,
     ir::{
         BindingData, BindingId, BindingKind, BodyBuilder, BodyData, BodyFunctionData,
         BodyFunctionId, BodyFunctionOwner, BodyImplData, BodyImplId, BodyItemData, BodyItemId,
@@ -46,7 +46,7 @@ pub(super) fn build_packages(
     build_package_outputs(
         parse,
         semantic_ir,
-        policy,
+        BodyIrLoweringScope::PackagePolicy(policy),
         interners,
         &selected,
         &mut packages,
@@ -61,12 +61,13 @@ pub(super) fn build_packages(
 pub(super) fn build_selected_packages(
     parse: &ParseDb,
     semantic_ir: &SemanticIrReadTxn<'_>,
-    policy: BodyIrBuildPolicy,
+    scope: BodyIrLoweringScope<'_>,
     package_slots: &[PackageSlot],
     interners: &mut PackageNameInterners,
 ) -> anyhow::Result<Vec<(PackageSlot, PackageBodies)>> {
     validate_package_inputs(parse, parse.package_count(), interners)?;
     validate_selected_packages(parse.package_count(), package_slots)?;
+    validate_selected_files(parse.package_count(), &scope)?;
 
     let mut selected = vec![false; parse.package_count()];
     for package_slot in package_slots {
@@ -78,7 +79,7 @@ pub(super) fn build_selected_packages(
     build_package_outputs(
         parse,
         semantic_ir,
-        policy,
+        scope,
         interners,
         &selected,
         &mut packages,
@@ -94,7 +95,7 @@ pub(super) fn build_selected_packages(
 fn build_package_outputs(
     parse: &ParseDb,
     semantic_ir: &SemanticIrReadTxn<'_>,
-    policy: BodyIrBuildPolicy,
+    scope: BodyIrLoweringScope<'_>,
     interners: &mut PackageNameInterners,
     selected: &[bool],
     packages: &mut [Option<PackageBodies>],
@@ -108,16 +109,16 @@ fn build_package_outputs(
 
     let selected_count = selected.iter().filter(|selected| **selected).count();
     if selected_count <= 1 {
-        build_package_outputs_serial(parse, semantic_ir, policy, interners, selected, packages)
+        build_package_outputs_serial(parse, semantic_ir, scope, interners, selected, packages)
     } else {
-        build_package_outputs_parallel(parse, semantic_ir, policy, interners, selected, packages)
+        build_package_outputs_parallel(parse, semantic_ir, scope, interners, selected, packages)
     }
 }
 
 fn build_package_outputs_serial(
     parse: &ParseDb,
     semantic_ir: &SemanticIrReadTxn<'_>,
-    policy: BodyIrBuildPolicy,
+    scope: BodyIrLoweringScope<'_>,
     interners: &mut PackageNameInterners,
     selected: &[bool],
     packages: &mut [Option<PackageBodies>],
@@ -138,7 +139,7 @@ fn build_package_outputs_serial(
         *output = Some(build_package_with_interner(
             parse_package,
             semantic_ir,
-            policy,
+            scope,
             package,
             interner,
         )?);
@@ -150,7 +151,7 @@ fn build_package_outputs_serial(
 fn build_package_outputs_parallel(
     parse: &ParseDb,
     semantic_ir: &SemanticIrReadTxn<'_>,
-    policy: BodyIrBuildPolicy,
+    scope: BodyIrLoweringScope<'_>,
     interners: &mut PackageNameInterners,
     selected: &[bool],
     packages: &mut [Option<PackageBodies>],
@@ -177,7 +178,7 @@ fn build_package_outputs_parallel(
                     *output = Some(build_package_with_interner(
                         parse_package,
                         semantic_ir,
-                        policy,
+                        scope,
                         package,
                         interner,
                     )?);
@@ -190,7 +191,7 @@ fn build_package_outputs_parallel(
 fn build_package_with_interner(
     parse_package: &rg_parse::Package,
     semantic_ir: &SemanticIrReadTxn<'_>,
-    policy: BodyIrBuildPolicy,
+    scope: BodyIrLoweringScope<'_>,
     package: PackageSlot,
     interner: &mut NameInterner,
 ) -> anyhow::Result<PackageBodies> {
@@ -217,7 +218,9 @@ fn build_package_with_interner(
             .map(|(function_ref, function)| (function_ref, function.source.file_id, function.span))
             .collect::<Vec<_>>();
         let function_count = functions.len();
-        if !policy.should_lower_package(parse_package) {
+        if !scope.should_lower_package(package, parse_package)
+            || !scope.should_lower_target(package, &functions)
+        {
             targets.push(TargetBodies::skipped(function_count));
             continue;
         }
@@ -226,6 +229,8 @@ fn build_package_with_interner(
             TargetLowering {
                 parse_package,
                 semantic_ir,
+                scope,
+                package,
                 functions,
                 target_bodies: TargetBodies::new(function_count),
                 interner,
@@ -238,6 +243,45 @@ fn build_package_with_interner(
     }
 
     Ok(PackageBodies::new(targets))
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum BodyIrLoweringScope<'a> {
+    PackagePolicy(BodyIrBuildPolicy),
+    SelectedFiles(&'a [BodyIrFile]),
+}
+
+impl BodyIrLoweringScope<'_> {
+    fn should_lower_package(self, package: PackageSlot, parse_package: &rg_parse::Package) -> bool {
+        match self {
+            Self::PackagePolicy(policy) => policy.should_lower_package(parse_package),
+            Self::SelectedFiles(files) => files.iter().any(|file| file.package == package),
+        }
+    }
+
+    fn should_lower_target(
+        self,
+        package: PackageSlot,
+        functions: &[(FunctionRef, FileId, Span)],
+    ) -> bool {
+        match self {
+            Self::PackagePolicy(_) => true,
+            Self::SelectedFiles(files) => functions.iter().any(|(_, file_id, _)| {
+                files
+                    .iter()
+                    .any(|file| file.package == package && file.file == *file_id)
+            }),
+        }
+    }
+
+    fn should_lower_function(self, package: PackageSlot, file_id: FileId) -> bool {
+        match self {
+            Self::PackagePolicy(_) => true,
+            Self::SelectedFiles(files) => files
+                .iter()
+                .any(|file| file.package == package && file.file == file_id),
+        }
+    }
 }
 
 fn validate_package_inputs(
@@ -279,9 +323,33 @@ fn validate_selected_packages(
     Ok(())
 }
 
+fn validate_selected_files(
+    package_count: usize,
+    scope: &BodyIrLoweringScope<'_>,
+) -> anyhow::Result<()> {
+    let BodyIrLoweringScope::SelectedFiles(files) = scope else {
+        return Ok(());
+    };
+
+    if let Some(file) = files
+        .iter()
+        .copied()
+        .find(|file| file.package.0 >= package_count)
+    {
+        anyhow::bail!(
+            "body IR file package slot {} is out of bounds for {package_count} parsed packages",
+            file.package.0,
+        );
+    }
+
+    Ok(())
+}
+
 struct TargetLowering<'a> {
     parse_package: &'a rg_parse::Package,
     semantic_ir: &'a SemanticIrReadTxn<'a>,
+    scope: BodyIrLoweringScope<'a>,
+    package: PackageSlot,
     functions: Vec<(FunctionRef, FileId, Span)>,
     target_bodies: TargetBodies,
     interner: &'a mut NameInterner,
@@ -290,6 +358,10 @@ struct TargetLowering<'a> {
 impl<'a> TargetLowering<'a> {
     fn lower(mut self) -> anyhow::Result<TargetBodies> {
         for &(function_ref, file_id, span) in &self.functions {
+            if !self.scope.should_lower_function(self.package, file_id) {
+                continue;
+            }
+
             let Some(owner_module) = self.owner_module(function_ref)? else {
                 continue;
             };

--- a/crates/engine/body-ir/src/build/mod.rs
+++ b/crates/engine/body-ir/src/build/mod.rs
@@ -12,7 +12,7 @@ use rg_package_store::{LoadPackage, PackageLoader, PackageStoreError, PackageSub
 use rg_semantic_ir::PackageIr;
 use rg_text::PackageNameInterners;
 
-use crate::{BodyIrBuildPolicy, BodyIrDb};
+use crate::{BodyIrBuildPolicy, BodyIrDb, BodyIrFile};
 
 /// Builder for a fresh Body IR snapshot.
 pub struct BodyIrDbBuilder<'db, 'names> {
@@ -100,6 +100,7 @@ pub struct BodyIrDbPackageRebuilder<'db, 'names> {
     def_map: &'db rg_def_map::DefMapDb,
     semantic_ir: &'db rg_semantic_ir::SemanticIrDb,
     policy: BodyIrBuildPolicy,
+    selected_files: Option<Vec<BodyIrFile>>,
     packages: &'db [PackageSlot],
     interners: &'names mut PackageNameInterners,
     def_map_loader: PackageLoader<'db, DefMapPackage>,
@@ -126,6 +127,7 @@ impl<'db, 'names> BodyIrDbPackageRebuilder<'db, 'names> {
             def_map,
             semantic_ir,
             policy: BodyIrBuildPolicy::default(),
+            selected_files: None,
             packages,
             interners,
             def_map_loader,
@@ -139,9 +141,18 @@ impl<'db, 'names> BodyIrDbPackageRebuilder<'db, 'names> {
         self
     }
 
+    pub fn selected_files(mut self, files: Vec<BodyIrFile>) -> Self {
+        self.selected_files = Some(files);
+        self
+    }
+
     pub fn build(self) -> anyhow::Result<BodyIrDb> {
         let mut next = self.old.clone();
         let packages = normalized_package_slots(self.packages);
+        let lowering_scope = match &self.selected_files {
+            Some(files) => lower::BodyIrLoweringScope::SelectedFiles(files),
+            None => lower::BodyIrLoweringScope::PackagePolicy(self.policy),
+        };
         let semantic_ir_txn = self
             .semantic_ir
             .read_txn_for_subset(self.semantic_ir_loader, self.subset);
@@ -151,7 +162,7 @@ impl<'db, 'names> BodyIrDbPackageRebuilder<'db, 'names> {
         let mut rebuilt_packages = lower::build_selected_packages(
             self.parse,
             &semantic_ir_txn,
-            self.policy,
+            lowering_scope,
             &packages,
             self.interners,
         )

--- a/crates/engine/body-ir/src/lib.rs
+++ b/crates/engine/body-ir/src/lib.rs
@@ -4,6 +4,9 @@ mod ir;
 mod resolution;
 mod store;
 
+use rg_def_map::PackageSlot;
+use rg_parse::FileId;
+
 #[cfg(test)]
 mod tests;
 
@@ -21,6 +24,19 @@ pub use self::{
     },
     store::{BodyIrDb, BodyIrPackageBundle, BodyIrReadTxn},
 };
+
+/// One package-local source file whose function bodies should be lowered during a partial rebuild.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BodyIrFile {
+    pub package: PackageSlot,
+    pub file: FileId,
+}
+
+impl BodyIrFile {
+    pub fn new(package: PackageSlot, file: FileId) -> Self {
+        Self { package, file }
+    }
+}
 
 /// Package-set selector for eager body lowering.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/crates/engine/parse/src/db.rs
+++ b/crates/engine/parse/src/db.rs
@@ -171,6 +171,36 @@ impl ParseDb {
 
         Ok(changed_files)
     }
+
+    /// Reparses a known source file from an in-memory buffer for every package that owns it.
+    ///
+    /// Dirty-buffer analysis uses this to build an ephemeral project snapshot without changing the
+    /// saved filesystem-backed project. Unknown files are intentionally ignored: discovering new
+    /// module files still goes through ordinary root traversal and filesystem module rules.
+    pub fn reparse_file_from_source(
+        &mut self,
+        file_path: &Path,
+        source: &str,
+    ) -> anyhow::Result<Vec<PackageFileRef>> {
+        let canonical_file_path = file_path
+            .canonicalize()
+            .with_context(|| format!("while attempting to canonicalize {}", file_path.display()))?;
+        let mut changed_files = Vec::new();
+
+        for (package_slot, package) in self.packages.iter_mut().enumerate() {
+            let Some(file_id) = package.reparse_file_from_source(&canonical_file_path, source)
+            else {
+                continue;
+            };
+
+            changed_files.push(PackageFileRef {
+                package: package_slot,
+                file: file_id,
+            });
+        }
+
+        Ok(changed_files)
+    }
 }
 
 /// Renders a project-level report of parsed packages and diagnostics.

--- a/crates/engine/parse/src/file.rs
+++ b/crates/engine/parse/src/file.rs
@@ -178,6 +178,17 @@ impl FileDb {
         Ok(Some(file_id))
     }
 
+    /// Reparses an already known file from caller-provided source text.
+    pub(super) fn reparse_file_from_source(
+        &mut self,
+        file_path: &Path,
+        source: &str,
+    ) -> Option<FileId> {
+        let file_id = self.file_ids_by_path.get(file_path).copied()?;
+        self.parsed_files[file_id] = Self::parse_source(file_path.to_path_buf(), source);
+        Some(file_id)
+    }
+
     /// Ensures that syntax for an already known file is available for AST-consuming lowering.
     pub(super) fn ensure_file_syntax(&mut self, file_id: FileId) -> anyhow::Result<()> {
         let Some(parsed_file) = self.parsed_files.get(file_id) else {

--- a/crates/engine/parse/src/package.rs
+++ b/crates/engine/parse/src/package.rs
@@ -55,6 +55,15 @@ impl Package {
         self.files.reparse_file_from_disk(file_path)
     }
 
+    /// Reparses a package file from caller-provided text when it is already known to this package.
+    pub(crate) fn reparse_file_from_source(
+        &mut self,
+        file_path: &Path,
+        source: &str,
+    ) -> Option<FileId> {
+        self.files.reparse_file_from_source(file_path, source)
+    }
+
     /// Rehydrates syntax for a known file before an AST-consuming lowering pass.
     pub fn ensure_file_syntax(&mut self, file_id: FileId) -> anyhow::Result<()> {
         self.files.ensure_file_syntax(file_id)

--- a/crates/engine/project/src/lib.rs
+++ b/crates/engine/project/src/lib.rs
@@ -8,8 +8,8 @@ pub use self::{
         BuildCheckpoint, BuildProcessMemory, BuildProfile, CacheProbeProfile, ProcessMemorySampler,
     },
     project::{
-        AnalysisChangeSummary, ChangedFile, FileContext, Project, ProjectBuild, ProjectBuilder,
-        ProjectSnapshot, ProjectStats, SavedFileChange, StartupCacheLoad,
+        AnalysisChangeSummary, ChangedFile, DirtyFileChange, FileContext, Project, ProjectBuild,
+        ProjectBuilder, ProjectSnapshot, ProjectStats, SavedFileChange, StartupCacheLoad,
     },
     residency::{PackageResidency, PackageResidencyPlan, PackageResidencyPolicy},
 };

--- a/crates/engine/project/src/project/dirty.rs
+++ b/crates/engine/project/src/project/dirty.rs
@@ -1,0 +1,108 @@
+//! Builds temporary project snapshots for unsaved editor buffers.
+//!
+//! Dirty overlays are deliberately separate from saved-source updates. They reuse the same package
+//! rebuild machinery, but never update fingerprints, write package artifacts, or restore
+//! offloadable residency after the rebuild; callers query the overlay and then drop it.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context as _;
+use rg_def_map::PackageSlot;
+
+use super::{ChangedFile, Project, update};
+
+/// One in-memory source file used to build a temporary dirty analysis overlay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirtyFileChange {
+    pub path: PathBuf,
+    pub text: String,
+}
+
+impl DirtyFileChange {
+    pub fn new(path: impl AsRef<Path>, text: impl Into<String>) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+            text: text.into(),
+        }
+    }
+}
+
+pub(super) fn build_overlay(
+    project: &Project,
+    changes: impl IntoIterator<Item = DirtyFileChange>,
+) -> anyhow::Result<Option<Project>> {
+    let changes = canonicalize_changes(changes)?;
+    let mut overlay = project.clone();
+    let mut changed_files = Vec::new();
+    let mut fallback_package_roots = Vec::new();
+
+    for change in changes {
+        let changed = overlay
+            .state
+            .parse_db_mut()
+            .reparse_file_from_source(&change.path, &change.text)
+            .with_context(|| {
+                format!(
+                    "while attempting to apply dirty file change for {}",
+                    change.path.display()
+                )
+            })?;
+
+        if changed.is_empty() {
+            // Dirty overlays intentionally avoid virtual module files for now. Rebuilding the
+            // containing package can still make an existing on-disk file visible if a dirty root
+            // reaches it through ordinary module discovery.
+            for package_slot in overlay
+                .state
+                .workspace()
+                .package_slots_containing_path(&change.path)
+            {
+                let package_slot = PackageSlot(package_slot);
+                if !fallback_package_roots.contains(&package_slot) {
+                    fallback_package_roots.push(package_slot);
+                }
+            }
+        }
+
+        for changed_file in changed {
+            let changed_file = ChangedFile {
+                package: PackageSlot(changed_file.package),
+                file: changed_file.file,
+            };
+            if !changed_files.contains(&changed_file) {
+                changed_files.push(changed_file);
+            }
+        }
+    }
+
+    let affected_packages =
+        update::affected_packages(&overlay, &changed_files, &fallback_package_roots);
+    if affected_packages.is_empty() {
+        return Ok(None);
+    }
+
+    update::rebuild_dirty_overlay_packages(&mut overlay.state, &affected_packages)
+        .context("while attempting to rebuild dirty analysis overlay packages")?;
+
+    Ok(Some(overlay))
+}
+
+fn canonicalize_changes(
+    changes: impl IntoIterator<Item = DirtyFileChange>,
+) -> anyhow::Result<Vec<DirtyFileChange>> {
+    changes
+        .into_iter()
+        .map(|change| {
+            let path = change.path.canonicalize().with_context(|| {
+                format!(
+                    "while attempting to canonicalize dirty file {}",
+                    change.path.display()
+                )
+            })?;
+            Ok(DirtyFileChange {
+                path,
+                text: change.text,
+            })
+        })
+        .collect()
+}

--- a/crates/engine/project/src/project/dirty.rs
+++ b/crates/engine/project/src/project/dirty.rs
@@ -7,6 +7,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
+use rg_body_ir::BodyIrFile;
 use rg_def_map::PackageSlot;
 
 use super::{ChangedFile, Project, update};
@@ -81,7 +82,11 @@ pub(super) fn build_overlay(
         return Ok(None);
     }
 
-    update::rebuild_dirty_overlay_packages(&mut overlay.state, &affected_packages)
+    let body_files = changed_files
+        .iter()
+        .map(|file| BodyIrFile::new(file.package, file.file))
+        .collect::<Vec<_>>();
+    update::rebuild_dirty_overlay_packages(&mut overlay.state, &affected_packages, &body_files)
         .context("while attempting to rebuild dirty analysis overlay packages")?;
 
     Ok(Some(overlay))

--- a/crates/engine/project/src/project/mod.rs
+++ b/crates/engine/project/src/project/mod.rs
@@ -1,4 +1,5 @@
 mod build;
+mod dirty;
 pub(crate) mod loading;
 mod memsize;
 pub(crate) mod offloading;
@@ -21,6 +22,7 @@ use crate::residency::PackageResidencyPlan;
 
 pub use self::{
     build::{ProjectBuild, ProjectBuilder, StartupCacheLoad},
+    dirty::DirtyFileChange,
     snapshot::ProjectSnapshot,
     stats::ProjectStats,
 };
@@ -30,9 +32,9 @@ pub use self::{
 /// `Project` is the LSP-facing state container: it accepts saved file changes, refreshes the
 /// derived phase databases, and hands out immutable snapshots for queries.
 ///
-/// The project intentionally follows a rebuild-on-save model. It does not track arbitrary unsaved
-/// editor buffers; callers should provide text only for committed save events, or read the saved
-/// file from disk and pass that content through the same API.
+/// The main project intentionally follows a rebuild-on-save model. Dirty editor buffers are handled
+/// as temporary overlays so saved-state fingerprints, package cache artifacts, and residency
+/// decisions remain tied to committed source files.
 #[derive(Debug, Clone)]
 pub struct Project {
     pub(crate) state: ProjectState,
@@ -95,6 +97,18 @@ impl Project {
     ) -> anyhow::Result<AnalysisChangeSummary> {
         let changes = canonicalize_changes(changes)?;
         update::apply_changes(self, changes)
+    }
+
+    /// Builds an ephemeral analysis project from dirty editor buffers.
+    ///
+    /// The returned project is intentionally detached from saved-state cache lifecycle: dirty
+    /// rebuilds keep rebuilt package payloads resident and never refresh source fingerprints or
+    /// package artifacts. Callers can query the returned snapshot and then drop it.
+    pub fn dirty_overlay(
+        &self,
+        changes: impl IntoIterator<Item = DirtyFileChange>,
+    ) -> anyhow::Result<Option<Project>> {
+        dirty::build_overlay(self, changes)
     }
 }
 

--- a/crates/engine/project/src/project/update/mod.rs
+++ b/crates/engine/project/src/project/update/mod.rs
@@ -6,8 +6,9 @@ mod workspace;
 mod workspace_graph;
 
 use anyhow::Context as _;
+use rg_def_map::PackageSlot;
 
-use super::{AnalysisChangeSummary, Project, SavedFileChange};
+use super::{AnalysisChangeSummary, ChangedFile, Project, SavedFileChange, state::ProjectState};
 use workspace_graph::WorkspaceGraphChanges;
 
 pub(crate) use package::rebuild_resident_from_source;
@@ -33,4 +34,46 @@ pub(super) fn apply_changes(
             .context("while attempting to rebuild analysis project after workspace change"),
         WorkspaceGraphChanges::Unchanged => source::apply_source_changes(project, changes),
     }
+}
+
+pub(super) fn rebuild_dirty_overlay_packages(
+    state: &mut ProjectState,
+    packages: &[PackageSlot],
+) -> anyhow::Result<()> {
+    package::rebuild_dirty_overlay_packages(state, packages)
+}
+
+pub(super) fn affected_packages(
+    project: &Project,
+    changed_files: &[ChangedFile],
+    fallback_package_roots: &[PackageSlot],
+) -> Vec<PackageSlot> {
+    let mut changed_package_ids = changed_files
+        .iter()
+        .filter_map(|changed_file| {
+            project
+                .state
+                .workspace()
+                .packages()
+                .get(changed_file.package.0)
+                .map(|package| package.id.clone())
+        })
+        .collect::<Vec<_>>();
+
+    for package_slot in fallback_package_roots {
+        let Some(package) = project.state.workspace().packages().get(package_slot.0) else {
+            continue;
+        };
+        if !changed_package_ids.contains(&package.id) {
+            changed_package_ids.push(package.id.clone());
+        }
+    }
+
+    project
+        .state
+        .workspace()
+        .reverse_dependency_closure(&changed_package_ids)
+        .into_iter()
+        .map(PackageSlot)
+        .collect()
 }

--- a/crates/engine/project/src/project/update/mod.rs
+++ b/crates/engine/project/src/project/update/mod.rs
@@ -6,6 +6,7 @@ mod workspace;
 mod workspace_graph;
 
 use anyhow::Context as _;
+use rg_body_ir::BodyIrFile;
 use rg_def_map::PackageSlot;
 
 use super::{AnalysisChangeSummary, ChangedFile, Project, SavedFileChange, state::ProjectState};
@@ -39,8 +40,9 @@ pub(super) fn apply_changes(
 pub(super) fn rebuild_dirty_overlay_packages(
     state: &mut ProjectState,
     packages: &[PackageSlot],
+    body_files: &[BodyIrFile],
 ) -> anyhow::Result<()> {
-    package::rebuild_dirty_overlay_packages(state, packages)
+    package::rebuild_dirty_overlay_packages(state, packages, body_files)
 }
 
 pub(super) fn affected_packages(

--- a/crates/engine/project/src/project/update/package.rs
+++ b/crates/engine/project/src/project/update/package.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Context as _;
 
+use rg_body_ir::BodyIrFile;
 use rg_def_map::PackageSlot;
 use rg_item_tree::ItemTreeDb;
 
@@ -21,7 +22,8 @@ pub(super) fn rebuild_packages(
         return Ok(());
     }
 
-    match try_rebuild_packages(state, packages, RebuildResidency::RestoreSavedState) {
+    let plan = PackageRebuildPlan::saved(packages);
+    match try_rebuild_packages(state, plan) {
         Ok(()) => Ok(()),
         Err(error) if ProjectState::is_recoverable_cache_load_failure(&error) => {
             ResidencyApplication::failure_recovery(state).with_context(|| {
@@ -37,29 +39,38 @@ pub(super) fn rebuild_packages(
 pub(super) fn rebuild_dirty_overlay_packages(
     state: &mut ProjectState,
     packages: &[PackageSlot],
+    body_files: &[BodyIrFile],
 ) -> anyhow::Result<()> {
     if packages.is_empty() {
         return Ok(());
     }
 
-    try_rebuild_packages(state, packages, RebuildResidency::KeepResident)
+    try_rebuild_packages(
+        state,
+        PackageRebuildPlan::dirty_overlay(packages, body_files),
+    )
 }
 
 fn try_rebuild_packages(
     state: &mut ProjectState,
-    packages: &[PackageSlot],
-    residency: RebuildResidency,
+    plan: PackageRebuildPlan<'_>,
 ) -> anyhow::Result<()> {
     // Rebuilding one package can resolve names through its dependencies, but unrelated packages
     // should stay offloaded so save handling does not recreate full-project spikes.
-    let rebuild_subset =
-        subset::rebuild_packages_with_visible_dependencies(&state.workspace, packages);
+    let rebuild_subset = subset::rebuild_packages_with_visible_dependencies(
+        &state.workspace,
+        plan.semantic_packages,
+    );
     let loaders = PackageReadLoaders::new(state);
     let old_def_map_txn = state
         .def_map
         .read_txn_for_subset(loaders.def_map.clone(), &rebuild_subset);
 
-    let package_indices = packages.iter().map(|package| package.0).collect::<Vec<_>>();
+    let package_indices = plan
+        .semantic_packages
+        .iter()
+        .map(|package| package.0)
+        .collect::<Vec<_>>();
     let item_tree = ItemTreeDb::build_packages_with_interners(
         &mut state.parse,
         &package_indices,
@@ -73,7 +84,7 @@ fn try_rebuild_packages(
             &state.workspace,
             &state.parse,
             &item_tree,
-            packages,
+            plan.semantic_packages,
             &mut state.names,
         )
         .build()
@@ -84,26 +95,29 @@ fn try_rebuild_packages(
         .package_rebuilder(
             &item_tree,
             &def_map,
-            packages,
+            plan.semantic_packages,
             loaders.def_map.clone(),
             loaders.semantic_ir.clone(),
             &rebuild_subset,
         )
         .build()
         .context("while attempting to rebuild affected semantic IR packages")?;
-    let body_ir = state
-        .body_ir
-        .package_rebuilder(
-            &state.parse,
-            &def_map,
-            &semantic_ir,
-            packages,
-            &mut state.names,
-            loaders.def_map,
-            loaders.semantic_ir,
-            &rebuild_subset,
-        )
-        .policy(state.body_ir_policy)
+    let body_packages = plan.body_packages();
+    let mut body_rebuilder = state.body_ir.package_rebuilder(
+        &state.parse,
+        &def_map,
+        &semantic_ir,
+        &body_packages,
+        &mut state.names,
+        loaders.def_map,
+        loaders.semantic_ir,
+        &rebuild_subset,
+    );
+    body_rebuilder = match plan.body_scope {
+        BodyRebuildScope::SavedPolicy => body_rebuilder.policy(state.body_ir_policy),
+        BodyRebuildScope::DirtyFiles(files) => body_rebuilder.selected_files(files.to_vec()),
+    };
+    let body_ir = body_rebuilder
         .build()
         .context("while attempting to rebuild affected body IR packages")?;
 
@@ -117,13 +131,55 @@ fn try_rebuild_packages(
     state.semantic_ir = semantic_ir;
     state.body_ir = body_ir;
     state.names.shrink_to_fit();
-    if matches!(residency, RebuildResidency::RestoreSavedState) {
-        ResidencyApplication::restore(state, packages)
+    if matches!(plan.residency, RebuildResidency::RestoreSavedState) {
+        ResidencyApplication::restore(state, plan.semantic_packages)
             .apply()
             .context("while attempting to apply package cache residency after package rebuild")?;
     }
 
     Ok(())
+}
+
+struct PackageRebuildPlan<'a> {
+    semantic_packages: &'a [PackageSlot],
+    body_scope: BodyRebuildScope<'a>,
+    residency: RebuildResidency,
+}
+
+impl<'a> PackageRebuildPlan<'a> {
+    fn saved(packages: &'a [PackageSlot]) -> Self {
+        Self {
+            semantic_packages: packages,
+            body_scope: BodyRebuildScope::SavedPolicy,
+            residency: RebuildResidency::RestoreSavedState,
+        }
+    }
+
+    fn dirty_overlay(semantic_packages: &'a [PackageSlot], body_files: &'a [BodyIrFile]) -> Self {
+        Self {
+            semantic_packages,
+            body_scope: BodyRebuildScope::DirtyFiles(body_files),
+            residency: RebuildResidency::KeepResident,
+        }
+    }
+
+    fn body_packages(&self) -> Vec<PackageSlot> {
+        match self.body_scope {
+            BodyRebuildScope::SavedPolicy => self.semantic_packages.to_vec(),
+            BodyRebuildScope::DirtyFiles(files) => {
+                let mut packages = files.iter().map(|file| file.package).collect::<Vec<_>>();
+                packages.sort_by_key(|package| package.0);
+                packages.dedup();
+                packages
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BodyRebuildScope<'a> {
+    SavedPolicy,
+    DirtyFiles(&'a [BodyIrFile]),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/engine/project/src/project/update/package.rs
+++ b/crates/engine/project/src/project/update/package.rs
@@ -21,7 +21,7 @@ pub(super) fn rebuild_packages(
         return Ok(());
     }
 
-    match try_rebuild_packages(state, packages) {
+    match try_rebuild_packages(state, packages, RebuildResidency::RestoreSavedState) {
         Ok(()) => Ok(()),
         Err(error) if ProjectState::is_recoverable_cache_load_failure(&error) => {
             ResidencyApplication::failure_recovery(state).with_context(|| {
@@ -34,7 +34,22 @@ pub(super) fn rebuild_packages(
     }
 }
 
-fn try_rebuild_packages(state: &mut ProjectState, packages: &[PackageSlot]) -> anyhow::Result<()> {
+pub(super) fn rebuild_dirty_overlay_packages(
+    state: &mut ProjectState,
+    packages: &[PackageSlot],
+) -> anyhow::Result<()> {
+    if packages.is_empty() {
+        return Ok(());
+    }
+
+    try_rebuild_packages(state, packages, RebuildResidency::KeepResident)
+}
+
+fn try_rebuild_packages(
+    state: &mut ProjectState,
+    packages: &[PackageSlot],
+    residency: RebuildResidency,
+) -> anyhow::Result<()> {
     // Rebuilding one package can resolve names through its dependencies, but unrelated packages
     // should stay offloaded so save handling does not recreate full-project spikes.
     let rebuild_subset =
@@ -102,11 +117,19 @@ fn try_rebuild_packages(state: &mut ProjectState, packages: &[PackageSlot]) -> a
     state.semantic_ir = semantic_ir;
     state.body_ir = body_ir;
     state.names.shrink_to_fit();
-    ResidencyApplication::restore(state, packages)
-        .apply()
-        .context("while attempting to apply package cache residency after package rebuild")?;
+    if matches!(residency, RebuildResidency::RestoreSavedState) {
+        ResidencyApplication::restore(state, packages)
+            .apply()
+            .context("while attempting to apply package cache residency after package rebuild")?;
+    }
 
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RebuildResidency {
+    RestoreSavedState,
+    KeepResident,
 }
 
 pub(crate) fn rebuild_resident_from_source(state: &mut ProjectState) -> anyhow::Result<()> {

--- a/crates/engine/project/src/project/update/source.rs
+++ b/crates/engine/project/src/project/update/source.rs
@@ -10,7 +10,7 @@ use anyhow::Context as _;
 
 use rg_def_map::{PackageSlot, TargetRef};
 
-use super::package;
+use super::{affected_packages, package};
 use crate::project::{AnalysisChangeSummary, ChangedFile, Project, SavedFileChange};
 
 pub(super) fn apply_source_changes(
@@ -84,41 +84,6 @@ pub(super) fn apply_source_changes(
         affected_packages,
         changed_targets,
     })
-}
-
-fn affected_packages(
-    project: &Project,
-    changed_files: &[ChangedFile],
-    fallback_package_roots: &[PackageSlot],
-) -> Vec<PackageSlot> {
-    let mut changed_package_ids = changed_files
-        .iter()
-        .filter_map(|changed_file| {
-            project
-                .state
-                .workspace()
-                .packages()
-                .get(changed_file.package.0)
-                .map(|package| package.id.clone())
-        })
-        .collect::<Vec<_>>();
-
-    for package_slot in fallback_package_roots {
-        let Some(package) = project.state.workspace().packages().get(package_slot.0) else {
-            continue;
-        };
-        if !changed_package_ids.contains(&package.id) {
-            changed_package_ids.push(package.id.clone());
-        }
-    }
-
-    project
-        .state
-        .workspace()
-        .reverse_dependency_closure(&changed_package_ids)
-        .into_iter()
-        .map(PackageSlot)
-        .collect()
 }
 
 fn promote_discovered_fallback_files(

--- a/crates/engine/project/src/tests/mod.rs
+++ b/crates/engine/project/src/tests/mod.rs
@@ -5,7 +5,7 @@ use rg_workspace::WorkspaceMetadata;
 use test_fixture::fixture_crate;
 
 use self::utils::{HostFixture, HostObservation};
-use crate::{PackageResidencyPolicy, Project};
+use crate::{DirtyFileChange, PackageResidencyPolicy, Project};
 
 #[test]
 fn timing_profile_reports_phase_checkpoints_without_memory_sampling() {
@@ -183,6 +183,93 @@ pub struct Account;
     assert_eq!(
         after_file_id, before_file_id,
         "known file reparses should keep the package-local FileId stable"
+    );
+}
+
+#[test]
+fn dirty_overlay_rebuilds_analysis_without_mutating_saved_project() {
+    let fixture = fixture_crate(
+        r#"
+//- /Cargo.toml
+[package]
+name = "dirty_overlay_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct Saved;
+"#,
+    );
+    let workspace = WorkspaceMetadata::from_cargo(fixture.metadata())
+        .expect("fixture workspace metadata should build");
+    let project = Project::builder(workspace)
+        .package_residency_policy(PackageResidencyPolicy::AllOffloadable)
+        .build()
+        .expect("fixture project should build")
+        .into_project();
+    let saved_stats = project.snapshot().stats();
+    assert_eq!(
+        saved_stats.def_map.target_count, 0,
+        "all-offloadable saved project should start without resident def maps",
+    );
+
+    let overlay = project
+        .dirty_overlay([DirtyFileChange::new(
+            fixture.path("src/lib.rs"),
+            "pub struct Dirty;\n",
+        )])
+        .expect("dirty overlay should build")
+        .expect("known dirty file should produce an overlay");
+    let dirty_stats = overlay.snapshot().stats();
+    assert!(
+        dirty_stats.def_map.target_count > 0,
+        "dirty overlay should keep rebuilt def maps resident",
+    );
+    assert!(
+        dirty_stats.semantic_ir.target_count > 0,
+        "dirty overlay should keep rebuilt semantic IR resident",
+    );
+    assert!(
+        dirty_stats.body_ir.target_count > 0,
+        "dirty overlay should keep rebuilt body IR resident",
+    );
+
+    let saved_analysis = project
+        .snapshot()
+        .full_analysis()
+        .expect("saved analysis should materialize");
+    let dirty_analysis = overlay
+        .snapshot()
+        .full_analysis()
+        .expect("dirty analysis should materialize");
+
+    assert!(
+        dirty_analysis
+            .workspace_symbols("Dirty")
+            .expect("dirty workspace symbol query should run")
+            .iter()
+            .any(|symbol| symbol.name == "Dirty"),
+        "dirty overlay should expose symbols from the live buffer"
+    );
+    assert!(
+        saved_analysis
+            .workspace_symbols("Dirty")
+            .expect("saved workspace symbol query should run")
+            .is_empty(),
+        "dirty overlay must not mutate saved project analysis"
+    );
+    assert!(
+        saved_analysis
+            .workspace_symbols("Saved")
+            .expect("saved workspace symbol query should run")
+            .iter()
+            .any(|symbol| symbol.name == "Saved"),
+        "saved project should retain its original source snapshot"
+    );
+    assert_eq!(
+        project.snapshot().stats().def_map.target_count,
+        0,
+        "dirty overlay must not materialize the saved project under all-offloadable policy",
     );
 }
 

--- a/crates/engine/project/src/tests/mod.rs
+++ b/crates/engine/project/src/tests/mod.rs
@@ -5,7 +5,7 @@ use rg_workspace::WorkspaceMetadata;
 use test_fixture::fixture_crate;
 
 use self::utils::{HostFixture, HostObservation};
-use crate::{DirtyFileChange, PackageResidencyPolicy, Project};
+use crate::{PackageResidencyPolicy, Project};
 
 #[test]
 fn timing_profile_reports_phase_checkpoints_without_memory_sampling() {
@@ -188,7 +188,7 @@ pub struct Account;
 
 #[test]
 fn dirty_overlay_rebuilds_analysis_without_mutating_saved_project() {
-    let fixture = fixture_crate(
+    let fixture = HostFixture::build_with_package_residency_policy(
         r#"
 //- /Cargo.toml
 [package]
@@ -197,80 +197,113 @@ version = "0.1.0"
 edition = "2024"
 
 //- /src/lib.rs
+mod other;
+
 pub struct Saved;
+
+pub fn saved_body(value: Saved) {
+    let _ = value;
+}
+
+//- /src/other.rs
+pub fn untouched_body() {}
 "#,
+        PackageResidencyPolicy::AllOffloadable,
     );
-    let workspace = WorkspaceMetadata::from_cargo(fixture.metadata())
-        .expect("fixture workspace metadata should build");
-    let project = Project::builder(workspace)
-        .package_residency_policy(PackageResidencyPolicy::AllOffloadable)
-        .build()
-        .expect("fixture project should build")
-        .into_project();
-    let saved_stats = project.snapshot().stats();
-    assert_eq!(
-        saved_stats.def_map.target_count, 0,
-        "all-offloadable saved project should start without resident def maps",
-    );
+    let dirty_text = r#"
+mod other;
 
-    let overlay = project
-        .dirty_overlay([DirtyFileChange::new(
-            fixture.path("src/lib.rs"),
-            "pub struct Dirty;\n",
-        )])
-        .expect("dirty overlay should build")
-        .expect("known dirty file should produce an overlay");
-    let dirty_stats = overlay.snapshot().stats();
-    assert!(
-        dirty_stats.def_map.target_count > 0,
-        "dirty overlay should keep rebuilt def maps resident",
-    );
-    assert!(
-        dirty_stats.semantic_ir.target_count > 0,
-        "dirty overlay should keep rebuilt semantic IR resident",
-    );
-    assert!(
-        dirty_stats.body_ir.target_count > 0,
-        "dirty overlay should keep rebuilt body IR resident",
-    );
+pub struct Dirty {
+    pub field: u8,
+}
 
-    let saved_analysis = project
-        .snapshot()
-        .full_analysis()
-        .expect("saved analysis should materialize");
-    let dirty_analysis = overlay
-        .snapshot()
-        .full_analysis()
-        .expect("dirty analysis should materialize");
+pub fn dirty_body(value: Dirty) {
+    value.;
+}
+"#;
+    let completion_offset = dirty_text
+        .find("value.")
+        .map(|offset| offset + "value.".len())
+        .expect("dirty completion fixture should include a dot receiver")
+        .try_into()
+        .expect("dirty completion offset should fit into u32");
 
-    assert!(
-        dirty_analysis
-            .workspace_symbols("Dirty")
-            .expect("dirty workspace symbol query should run")
-            .iter()
-            .any(|symbol| symbol.name == "Dirty"),
-        "dirty overlay should expose symbols from the live buffer"
+    let saved_before = fixture.render(&[
+        HostObservation::resident_stats("saved before dirty overlay"),
+        HostObservation::workspace_symbols("Saved"),
+        HostObservation::workspace_symbols("Dirty"),
+    ]);
+    let overlay = fixture.dirty_overlay("src/lib.rs", dirty_text);
+    let dirty_overlay = fixture.render_project(
+        &overlay,
+        &[
+            HostObservation::resident_stats("dirty overlay"),
+            HostObservation::body_ir_stats("dirty overlay"),
+            HostObservation::workspace_symbols("Dirty"),
+            HostObservation::workspace_symbols("Saved"),
+            HostObservation::completions_at("dirty receiver", "src/lib.rs", completion_offset),
+        ],
     );
-    assert!(
-        saved_analysis
-            .workspace_symbols("Dirty")
-            .expect("saved workspace symbol query should run")
-            .is_empty(),
-        "dirty overlay must not mutate saved project analysis"
+    let saved_after = fixture.render(&[
+        HostObservation::resident_stats("saved after dirty overlay"),
+        HostObservation::workspace_symbols("Saved"),
+        HostObservation::workspace_symbols("Dirty"),
+    ]);
+
+    let actual = format!(
+        "saved project before dirty overlay\n{}\n\ndirty overlay\n{}\n\nsaved project after dirty overlay\n{}\n",
+        saved_before.trim_end(),
+        dirty_overlay.trim_end(),
+        saved_after.trim_end(),
     );
-    assert!(
-        saved_analysis
-            .workspace_symbols("Saved")
-            .expect("saved workspace symbol query should run")
-            .iter()
-            .any(|symbol| symbol.name == "Saved"),
-        "saved project should retain its original source snapshot"
-    );
-    assert_eq!(
-        project.snapshot().stats().def_map.target_count,
-        0,
-        "dirty overlay must not materialize the saved project under all-offloadable policy",
-    );
+    expect![[r#"
+        saved project before dirty overlay
+        resident stats `saved before dirty overlay`
+        - def-map targets 0
+        - semantic targets 0
+        - body targets 0
+
+        workspace symbols `Saved`
+        - fn saved_body @ dirty_overlay_fixture[lib] src/lib.rs
+        - struct Saved @ dirty_overlay_fixture[lib] src/lib.rs
+
+        workspace symbols `Dirty`
+        - <none>
+
+        dirty overlay
+        resident stats `dirty overlay`
+        - def-map targets 1
+        - semantic targets 1
+        - body targets 1
+
+        body ir stats `dirty overlay`
+        - targets 1
+        - bodies 1
+
+        workspace symbols `Dirty`
+        - fn dirty_body @ dirty_overlay_fixture[lib] src/lib.rs
+        - struct Dirty @ dirty_overlay_fixture[lib] src/lib.rs
+
+        workspace symbols `Saved`
+        - <none>
+
+        completions at `dirty receiver`
+        - field field
+
+        saved project after dirty overlay
+        resident stats `saved after dirty overlay`
+        - def-map targets 0
+        - semantic targets 0
+        - body targets 0
+
+        workspace symbols `Saved`
+        - fn saved_body @ dirty_overlay_fixture[lib] src/lib.rs
+        - struct Saved @ dirty_overlay_fixture[lib] src/lib.rs
+
+        workspace symbols `Dirty`
+        - <none>
+    "#]]
+    .assert_eq(&actual);
 }
 
 #[test]

--- a/crates/engine/project/src/tests/utils.rs
+++ b/crates/engine/project/src/tests/utils.rs
@@ -7,14 +7,17 @@ use std::{
 };
 
 use expect_test::Expect;
-use rg_analysis::WorkspaceSymbol;
+use rg_analysis::{CompletionApplicability, CompletionItem, WorkspaceSymbol};
 use rg_def_map::{PackageSlot, TargetRef};
 use rg_package_store::{LoadPackage, PackageLoader, PackageStoreError};
 use rg_parse::{FileId, ParseDb};
 use rg_workspace::WorkspaceMetadata;
 use test_fixture::{CrateFixture, FixtureMarkers, fixture_crate_with_markers};
 
-use crate::{AnalysisChangeSummary, FileContext, PackageResidencyPolicy, Project, SavedFileChange};
+use crate::{
+    AnalysisChangeSummary, DirtyFileChange, FileContext, PackageResidencyPolicy, Project,
+    SavedFileChange,
+};
 
 pub(super) struct HostFixture {
     fixture: CrateFixture,
@@ -135,6 +138,13 @@ impl HostFixture {
         }
     }
 
+    pub(super) fn dirty_overlay(&self, relative_path: &str, text: &str) -> Project {
+        self.host
+            .dirty_overlay([DirtyFileChange::new(self.fixture.path(relative_path), text)])
+            .expect("fixture dirty overlay should build")
+            .expect("fixture dirty overlay should touch a known file")
+    }
+
     fn package_cache_artifact_path(&self, package_name: &str) -> PathBuf {
         let package = package_slot_by_name(self.host.snapshot().parse_db(), package_name);
         let header = self
@@ -150,8 +160,20 @@ impl HostFixture {
     }
 
     pub(super) fn check(&self, observations: &[HostObservation<'_>], expect: Expect) {
-        let actual = self.render_observations(observations);
+        let actual = self.render(observations);
         expect.assert_eq(&format!("{}\n", actual.trim_end()));
+    }
+
+    pub(super) fn render(&self, observations: &[HostObservation<'_>]) -> String {
+        self.render_project(&self.host, observations)
+    }
+
+    pub(super) fn render_project(
+        &self,
+        project: &Project,
+        observations: &[HostObservation<'_>],
+    ) -> String {
+        self.render_observations(project, observations)
     }
 
     pub(super) fn check_save(
@@ -183,7 +205,7 @@ impl HostFixture {
         observations: &[HostObservation<'_>],
     ) -> String {
         let mut dump = self.render_change_summary(summary);
-        let observations = self.render_observations(observations);
+        let observations = self.render_observations(&self.host, observations);
         if !observations.is_empty() {
             writeln!(&mut dump).expect("string writes should not fail");
             dump.push_str(&observations);
@@ -194,22 +216,27 @@ impl HostFixture {
     fn render_change_summary(&self, summary: &AnalysisChangeSummary) -> String {
         let mut dump = String::new();
 
-        self.render_changed_files(&summary.changed_files, &mut dump);
+        self.render_changed_files(&self.host, &summary.changed_files, &mut dump);
         writeln!(&mut dump).expect("string writes should not fail");
-        self.render_affected_packages(&summary.affected_packages, &mut dump);
+        self.render_affected_packages(&self.host, &summary.affected_packages, &mut dump);
         writeln!(&mut dump).expect("string writes should not fail");
-        self.render_changed_targets(&summary.changed_targets, &mut dump);
+        self.render_changed_targets(&self.host, &summary.changed_targets, &mut dump);
 
         dump
     }
 
-    fn render_changed_files(&self, changed_files: &[crate::ChangedFile], dump: &mut String) {
+    fn render_changed_files(
+        &self,
+        project: &Project,
+        changed_files: &[crate::ChangedFile],
+        dump: &mut String,
+    ) {
         writeln!(dump, "changed files").expect("string writes should not fail");
 
         let mut files = changed_files
             .iter()
             .map(|changed_file| {
-                let package = self.package(changed_file.package);
+                let package = self.package(project, changed_file.package);
                 let path = package
                     .file_path(changed_file.file)
                     .expect("changed file should have a parsed path");
@@ -228,12 +255,17 @@ impl HostFixture {
         }
     }
 
-    fn render_affected_packages(&self, packages: &[PackageSlot], dump: &mut String) {
+    fn render_affected_packages(
+        &self,
+        project: &Project,
+        packages: &[PackageSlot],
+        dump: &mut String,
+    ) {
         writeln!(dump, "affected packages").expect("string writes should not fail");
 
         let mut names = packages
             .iter()
-            .map(|slot| self.package(*slot).package_name().to_string())
+            .map(|slot| self.package(project, *slot).package_name().to_string())
             .collect::<Vec<_>>();
         names.sort();
 
@@ -247,12 +279,12 @@ impl HostFixture {
         }
     }
 
-    fn render_changed_targets(&self, targets: &[TargetRef], dump: &mut String) {
+    fn render_changed_targets(&self, project: &Project, targets: &[TargetRef], dump: &mut String) {
         writeln!(dump, "changed targets").expect("string writes should not fail");
 
         let mut labels = targets
             .iter()
-            .map(|target| self.render_target_ref(*target))
+            .map(|target| self.render_target_ref(project, *target))
             .collect::<Vec<_>>();
         labels.sort();
 
@@ -266,7 +298,11 @@ impl HostFixture {
         }
     }
 
-    fn render_observations(&self, observations: &[HostObservation<'_>]) -> String {
+    fn render_observations(
+        &self,
+        project: &Project,
+        observations: &[HostObservation<'_>],
+    ) -> String {
         let mut dump = String::new();
 
         for (idx, observation) in observations.iter().enumerate() {
@@ -275,23 +311,33 @@ impl HostFixture {
             }
             match observation {
                 HostObservation::WorkspaceSymbols { query } => {
-                    self.render_workspace_symbols(query, &mut dump);
+                    self.render_workspace_symbols(project, query, &mut dump);
                 }
                 HostObservation::FileContexts {
                     label,
                     relative_path,
                 } => {
-                    self.render_file_contexts(label, relative_path, &mut dump);
+                    self.render_file_contexts(project, label, relative_path, &mut dump);
                 }
                 HostObservation::TypeNamesAt {
                     label,
                     package,
                     marker,
                 } => {
-                    self.render_type_names_at(label, package, marker, &mut dump);
+                    self.render_type_names_at(project, label, package, marker, &mut dump);
                 }
                 HostObservation::ResidentStats { label } => {
-                    self.render_resident_stats(label, &mut dump);
+                    self.render_resident_stats(project, label, &mut dump);
+                }
+                HostObservation::BodyIrStats { label } => {
+                    self.render_body_ir_stats(project, label, &mut dump);
+                }
+                HostObservation::CompletionsAt {
+                    label,
+                    relative_path,
+                    offset,
+                } => {
+                    self.render_completions_at(project, label, relative_path, *offset, &mut dump);
                 }
             }
         }
@@ -299,18 +345,18 @@ impl HostFixture {
         dump
     }
 
-    fn render_workspace_symbols(&self, query: &str, dump: &mut String) {
+    fn render_workspace_symbols(&self, project: &Project, query: &str, dump: &mut String) {
         writeln!(dump, "workspace symbols `{query}`").expect("string writes should not fail");
 
-        let snapshot = self.host.snapshot();
+        let snapshot = project.snapshot();
         let mut symbols = snapshot
             .full_analysis()
             .expect("fixture analysis should materialize")
             .workspace_symbols(query)
             .expect("fixture workspace symbols should resolve");
         symbols.sort_by(|left, right| {
-            self.workspace_symbol_key(left)
-                .cmp(&self.workspace_symbol_key(right))
+            self.workspace_symbol_key(project, left)
+                .cmp(&self.workspace_symbol_key(project, right))
         });
 
         if symbols.is_empty() {
@@ -319,29 +365,34 @@ impl HostFixture {
         }
 
         for symbol in symbols {
-            let path = self.symbol_path(&symbol);
+            let path = self.symbol_path(project, &symbol);
             writeln!(
                 dump,
                 "- {} {} @ {} {path}",
                 symbol.kind,
                 symbol.name,
-                self.render_target_ref(symbol.target),
+                self.render_target_ref(project, symbol.target),
             )
             .expect("string writes should not fail");
         }
     }
 
-    fn render_file_contexts(&self, label: &str, relative_path: &str, dump: &mut String) {
+    fn render_file_contexts(
+        &self,
+        project: &Project,
+        label: &str,
+        relative_path: &str,
+        dump: &mut String,
+    ) {
         writeln!(dump, "file contexts `{label}`").expect("string writes should not fail");
 
-        let mut contexts = self
-            .host
+        let mut contexts = project
             .snapshot()
             .file_contexts_for_path(self.fixture.path(relative_path))
             .expect("fixture path should resolve to file contexts");
         contexts.sort_by(|left, right| {
-            self.file_context_key(left)
-                .cmp(&self.file_context_key(right))
+            self.file_context_key(project, left)
+                .cmp(&self.file_context_key(project, right))
         });
 
         if contexts.is_empty() {
@@ -350,14 +401,14 @@ impl HostFixture {
         }
 
         for context in contexts {
-            let package = self.package(context.package);
+            let package = self.package(project, context.package);
             let path = package
                 .file_path(context.file)
                 .expect("file context should have a parsed path");
             let mut targets = context
                 .targets
                 .iter()
-                .map(|target| self.render_target_ref(*target))
+                .map(|target| self.render_target_ref(project, *target))
                 .collect::<Vec<_>>();
             targets.sort();
 
@@ -374,6 +425,7 @@ impl HostFixture {
 
     fn render_type_names_at(
         &self,
+        project: &Project,
         label: &str,
         package_name: &str,
         marker: &str,
@@ -383,7 +435,7 @@ impl HostFixture {
 
         let marker = self.markers.position(marker);
         let path = self.fixture.path(&marker.path);
-        let mut names = nominal_type_names_at(&self.host, package_name, &path, marker.offset);
+        let mut names = nominal_type_names_at(project, package_name, &path, marker.offset);
         names.sort();
 
         if names.is_empty() {
@@ -396,8 +448,8 @@ impl HostFixture {
         }
     }
 
-    fn render_resident_stats(&self, label: &str, dump: &mut String) {
-        let stats = self.host.snapshot().stats();
+    fn render_resident_stats(&self, project: &Project, label: &str, dump: &mut String) {
+        let stats = project.snapshot().stats();
 
         writeln!(dump, "resident stats `{label}`").expect("string writes should not fail");
         writeln!(dump, "- def-map targets {}", stats.def_map.target_count)
@@ -412,41 +464,117 @@ impl HostFixture {
             .expect("string writes should not fail");
     }
 
-    fn workspace_symbol_key(&self, symbol: &WorkspaceSymbol) -> (String, String, String, String) {
+    fn render_body_ir_stats(&self, project: &Project, label: &str, dump: &mut String) {
+        let stats = project.snapshot().stats();
+
+        writeln!(dump, "body ir stats `{label}`").expect("string writes should not fail");
+        writeln!(dump, "- targets {}", stats.body_ir.target_count)
+            .expect("string writes should not fail");
+        writeln!(dump, "- bodies {}", stats.body_ir.body_count)
+            .expect("string writes should not fail");
+    }
+
+    fn render_completions_at(
+        &self,
+        project: &Project,
+        label: &str,
+        relative_path: &str,
+        offset: u32,
+        dump: &mut String,
+    ) {
+        writeln!(dump, "completions at `{label}`").expect("string writes should not fail");
+
+        let snapshot = project.snapshot();
+        let contexts = snapshot
+            .file_contexts_for_path(self.fixture.path(relative_path))
+            .expect("fixture path should resolve to file contexts");
+        let targets = contexts
+            .iter()
+            .flat_map(|context| context.targets.iter().copied())
+            .collect::<Vec<_>>();
+        let analysis = snapshot
+            .analysis_for_targets(&targets)
+            .expect("fixture completion analysis should materialize");
+        let mut completions = Vec::new();
+
+        for context in contexts {
+            for target in context.targets {
+                for item in analysis
+                    .completions_at_dot(target, context.file, offset)
+                    .expect("fixture dot completions should resolve")
+                {
+                    if !completions.contains(&item) {
+                        completions.push(item);
+                    }
+                }
+            }
+        }
+
+        completions.sort_by(|left, right| {
+            left.label
+                .cmp(&right.label)
+                .then(left.kind.cmp(&right.kind))
+                .then(left.applicability.cmp(&right.applicability))
+        });
+
+        if completions.is_empty() {
+            writeln!(dump, "- <none>").expect("string writes should not fail");
+            return;
+        }
+
+        for item in completions {
+            writeln!(dump, "- {}", Self::render_completion_item(&item))
+                .expect("string writes should not fail");
+        }
+    }
+
+    fn render_completion_item(item: &CompletionItem) -> String {
+        if matches!(item.applicability, CompletionApplicability::Known) {
+            return format!("{} {}", item.kind, item.label);
+        }
+
+        format!("{} {} ({})", item.kind, item.label, item.applicability)
+    }
+
+    fn workspace_symbol_key(
+        &self,
+        project: &Project,
+        symbol: &WorkspaceSymbol,
+    ) -> (String, String, String, String) {
         (
             symbol.kind.to_string(),
             symbol.name.clone(),
-            self.render_target_ref(symbol.target),
-            self.symbol_path(symbol),
+            self.render_target_ref(project, symbol.target),
+            self.symbol_path(project, symbol),
         )
     }
 
-    fn file_context_key(&self, context: &FileContext) -> (String, String) {
-        let package = self.package(context.package);
+    fn file_context_key(&self, project: &Project, context: &FileContext) -> (String, String) {
+        let package = self.package(project, context.package);
         let path = package
             .file_path(context.file)
             .expect("file context should have a parsed path");
         (package.package_name().to_string(), self.display_path(path))
     }
 
-    fn symbol_path(&self, symbol: &WorkspaceSymbol) -> String {
-        let package = self.package(symbol.target.package);
+    fn symbol_path(&self, project: &Project, symbol: &WorkspaceSymbol) -> String {
+        let package = self.package(project, symbol.target.package);
         let path = package
             .file_path(symbol.file_id)
             .expect("workspace symbol file should be parsed");
         self.display_path(path)
     }
 
-    fn render_target_ref(&self, target_ref: TargetRef) -> String {
-        let package = self.package(target_ref.package);
+    fn render_target_ref(&self, project: &Project, target_ref: TargetRef) -> String {
+        let package = self.package(project, target_ref.package);
         let target = package
             .target(target_ref.target)
             .expect("target should exist while rendering host fixture");
         format!("{}[{}]", package.package_name(), target.kind)
     }
 
-    fn package(&self, package: PackageSlot) -> &rg_parse::Package {
-        self.host
+    fn package<'a>(&self, project: &'a Project, package: PackageSlot) -> &'a rg_parse::Package {
+        project
             .snapshot()
             .parse_db()
             .package(package.0)
@@ -483,6 +611,14 @@ pub(super) enum HostObservation<'a> {
     ResidentStats {
         label: &'a str,
     },
+    BodyIrStats {
+        label: &'a str,
+    },
+    CompletionsAt {
+        label: &'a str,
+        relative_path: &'a str,
+        offset: u32,
+    },
 }
 
 impl<'a> HostObservation<'a> {
@@ -507,6 +643,18 @@ impl<'a> HostObservation<'a> {
 
     pub(super) fn resident_stats(label: &'a str) -> Self {
         Self::ResidentStats { label }
+    }
+
+    pub(super) fn body_ir_stats(label: &'a str) -> Self {
+        Self::BodyIrStats { label }
+    }
+
+    pub(super) fn completions_at(label: &'a str, relative_path: &'a str, offset: u32) -> Self {
+        Self::CompletionsAt {
+            label,
+            relative_path,
+            offset,
+        }
     }
 }
 

--- a/crates/lsp/engine/Cargo.toml
+++ b/crates/lsp/engine/Cargo.toml
@@ -23,5 +23,5 @@ rg_parse.workspace = true
 rg_project.workspace = true
 rg_workspace.workspace = true
 tarpc = { workspace = true, features = ["serde-transport", "serde-transport-json", "tcp", "tokio1"] }
-tokio = { workspace = true, features = ["process", "sync"] }
+tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true

--- a/crates/lsp/engine/src/dirty_state/mod.rs
+++ b/crates/lsp/engine/src/dirty_state/mod.rs
@@ -1,21 +1,34 @@
+//! Dirty buffers are modeled as a narrow layer over the saved project state.
+//!
+//! `DirtyState` is shared with the worker so queued requests can notice when a newer dirty
+//! document identity exists and skip obsolete work. Current dirty requests use `DirtyOverlayCache`
+//! to build a temporary project overlay with the changed file partially reindexed, keeping the
+//! saved project frozen while hover, inlay hints, and similar features read from the buffer text.
+
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     sync::{Arc, Mutex, MutexGuard},
 };
 
-use super::{DirtyDocumentSnapshot, DirtyDocumentSnapshotState, TextFingerprint};
+pub(crate) use self::overlay::DirtyOverlayCache;
+use crate::documents::{DirtyDocumentSnapshot, DirtyDocumentSnapshotState, TextFingerprint};
 
-/// Shared freshness oracle for dirty-buffer analysis requests.
+mod overlay;
+
+#[cfg(test)]
+mod tests;
+
+/// Worker-visible dirty document state for skipping obsolete queued requests.
 ///
-/// The worker queue is FIFO, but document changes arrive outside that queue. This state lets the
-/// worker cheaply reject a queued request that was captured from an older dirty buffer version.
+/// `DocumentStore` owns the live text. This is the small synchronous read model the worker uses
+/// without waiting behind the analysis command queue.
 #[derive(Debug, Clone, Default)]
-pub(crate) struct DirtyAnalysisHandle {
-    state: Arc<Mutex<DirtyAnalysisState>>,
+pub(crate) struct DirtyState {
+    state: Arc<Mutex<DirtyStateInner>>,
 }
 
-impl DirtyAnalysisHandle {
+impl DirtyState {
     pub(crate) fn sync_document(&self, path: &Path, snapshot: &DirtyDocumentSnapshotState) {
         self.state().sync_document(path, snapshot);
     }
@@ -24,19 +37,19 @@ impl DirtyAnalysisHandle {
         self.state().is_current(identity)
     }
 
-    fn state(&self) -> MutexGuard<'_, DirtyAnalysisState> {
+    fn state(&self) -> MutexGuard<'_, DirtyStateInner> {
         self.state
             .lock()
-            .expect("dirty analysis state mutex should not be poisoned")
+            .expect("dirty state mutex should not be poisoned")
     }
 }
 
 #[derive(Debug, Default)]
-struct DirtyAnalysisState {
+struct DirtyStateInner {
     latest_by_path: HashMap<PathBuf, DirtyDocumentIdentity>,
 }
 
-impl DirtyAnalysisState {
+impl DirtyStateInner {
     fn sync_document(&mut self, path: &Path, snapshot: &DirtyDocumentSnapshotState) {
         match snapshot {
             DirtyDocumentSnapshotState::Dirty(snapshot) => {

--- a/crates/lsp/engine/src/dirty_state/overlay.rs
+++ b/crates/lsp/engine/src/dirty_state/overlay.rs
@@ -1,0 +1,100 @@
+use std::{sync::Arc, time::Instant};
+
+use anyhow::Context as _;
+use rg_project::{DirtyFileChange, Project};
+
+use super::DirtyDocumentIdentity;
+use crate::{
+    documents::DirtyDocumentSnapshot,
+    memory::{MemoryControl, MemoryReporter},
+};
+
+/// Caches the most recent single-file dirty overlay built on top of the saved project.
+#[derive(Debug)]
+pub(crate) struct DirtyOverlayCache {
+    memory_control: Arc<dyn MemoryControl>,
+    cached: Option<CachedDirtyOverlay>,
+}
+
+impl DirtyOverlayCache {
+    pub(crate) fn new(memory_control: Arc<dyn MemoryControl>) -> Self {
+        Self {
+            memory_control,
+            cached: None,
+        }
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.cached = None;
+    }
+
+    pub(crate) fn project_for_dirty(
+        &mut self,
+        base: &Project,
+        dirty: &DirtyDocumentSnapshot,
+    ) -> anyhow::Result<&Project> {
+        let identity = DirtyDocumentIdentity::from_snapshot(dirty);
+        let should_rebuild = match &self.cached {
+            Some(cached) => cached.identity != identity,
+            None => true,
+        };
+
+        if should_rebuild {
+            let started = Instant::now();
+            let memory_control = self.memory_control.as_ref();
+            let memory_before =
+                MemoryReporter::log_checkpoint(memory_control, "dirty_overlay", "before_rebuild");
+            let overlay = base
+                .dirty_overlay([DirtyFileChange::new(dirty.path(), dirty.text().to_string())])
+                .with_context(|| {
+                    format!(
+                        "while attempting to build dirty analysis overlay for {}",
+                        dirty.path().display()
+                    )
+                })?;
+            MemoryReporter::log_checkpoint_delta(
+                memory_control,
+                "dirty_overlay",
+                "after_rebuild",
+                memory_before,
+            );
+            // Dirty overlay rebuilds can temporarily materialize much more allocator memory than
+            // the retained overlay needs. Purge at this rebuild boundary without making every
+            // read-only query pay the same cost.
+            MemoryReporter::purge_and_report(memory_control, "after dirty overlay");
+            let changed_known_file = overlay.is_some();
+            let project = overlay.unwrap_or_else(|| base.clone());
+            tracing::debug!(
+                path = %dirty.path().display(),
+                version = ?dirty.version(),
+                text_len = dirty.text().len(),
+                dirty_overlay_cache_hit = false,
+                dirty_overlay_changed_known_file = changed_known_file,
+                dirty_overlay_build_ms = started.elapsed().as_millis(),
+                "dirty analysis overlay rebuilt"
+            );
+            self.cached = Some(CachedDirtyOverlay { identity, project });
+        } else {
+            tracing::debug!(
+                path = %dirty.path().display(),
+                version = ?dirty.version(),
+                text_len = dirty.text().len(),
+                dirty_overlay_cache_hit = true,
+                dirty_overlay_build_ms = 0_u128,
+                "dirty analysis overlay cache hit"
+            );
+        }
+
+        Ok(&self
+            .cached
+            .as_ref()
+            .expect("dirty overlay should be cached after successful build")
+            .project)
+    }
+}
+
+#[derive(Debug)]
+struct CachedDirtyOverlay {
+    identity: DirtyDocumentIdentity,
+    project: Project,
+}

--- a/crates/lsp/engine/src/dirty_state/tests.rs
+++ b/crates/lsp/engine/src/dirty_state/tests.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+use super::{DirtyDocumentIdentity, DirtyState};
+use crate::documents::{DirtyDocumentSnapshotState, DocumentStore};
+
+#[test]
+fn dirty_state_rejects_old_dirty_snapshots() {
+    let path = PathBuf::from("/workspace/src/lib.rs");
+    let mut store = DocumentStore::default();
+    let dirty_state = DirtyState::default();
+
+    store.did_open(path.clone(), Some(1), "fn main() {}\n");
+    dirty_state.sync_document(&path, &store.dirty_snapshot(&path));
+
+    store.did_change(path.clone(), Some(2), Some("fn main() {\n    v2();\n}\n"));
+    let snapshot_v2 = store.dirty_snapshot(&path);
+    dirty_state.sync_document(&path, &snapshot_v2);
+    let DirtyDocumentSnapshotState::Dirty(snapshot_v2) = snapshot_v2 else {
+        panic!("dirty full-sync document should expose version 2 snapshot");
+    };
+    assert!(dirty_state.is_current_identity(&DirtyDocumentIdentity::from_snapshot(&snapshot_v2)));
+
+    store.did_change(path.clone(), Some(3), Some("fn main() {\n    v3();\n}\n"));
+    let snapshot_v3 = store.dirty_snapshot(&path);
+    dirty_state.sync_document(&path, &snapshot_v3);
+    let DirtyDocumentSnapshotState::Dirty(snapshot_v3) = snapshot_v3 else {
+        panic!("dirty full-sync document should expose version 3 snapshot");
+    };
+    assert!(!dirty_state.is_current_identity(&DirtyDocumentIdentity::from_snapshot(&snapshot_v2)));
+    assert!(dirty_state.is_current_identity(&DirtyDocumentIdentity::from_snapshot(&snapshot_v3)));
+
+    store.did_save(path.clone(), Some("fn main() {\n    v3();\n}\n"));
+    dirty_state.sync_document(&path, &store.dirty_snapshot(&path));
+    assert!(!dirty_state.is_current_identity(&DirtyDocumentIdentity::from_snapshot(&snapshot_v3)));
+}

--- a/crates/lsp/engine/src/documents/dirty_analysis.rs
+++ b/crates/lsp/engine/src/documents/dirty_analysis.rs
@@ -1,0 +1,88 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex, MutexGuard},
+};
+
+use super::{DirtyDocumentSnapshot, DirtyDocumentSnapshotState, TextFingerprint};
+
+/// Shared freshness oracle for dirty-buffer analysis requests.
+///
+/// The worker queue is FIFO, but document changes arrive outside that queue. This state lets the
+/// worker cheaply reject a queued request that was captured from an older dirty buffer version.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DirtyAnalysisHandle {
+    state: Arc<Mutex<DirtyAnalysisState>>,
+}
+
+impl DirtyAnalysisHandle {
+    pub(crate) fn sync_document(&self, path: &Path, snapshot: &DirtyDocumentSnapshotState) {
+        self.state().sync_document(path, snapshot);
+    }
+
+    pub(crate) fn is_current_identity(&self, identity: &DirtyDocumentIdentity) -> bool {
+        self.state().is_current(identity)
+    }
+
+    fn state(&self) -> MutexGuard<'_, DirtyAnalysisState> {
+        self.state
+            .lock()
+            .expect("dirty analysis state mutex should not be poisoned")
+    }
+}
+
+#[derive(Debug, Default)]
+struct DirtyAnalysisState {
+    latest_by_path: HashMap<PathBuf, DirtyDocumentIdentity>,
+}
+
+impl DirtyAnalysisState {
+    fn sync_document(&mut self, path: &Path, snapshot: &DirtyDocumentSnapshotState) {
+        match snapshot {
+            DirtyDocumentSnapshotState::Dirty(snapshot) => {
+                self.latest_by_path.insert(
+                    snapshot.path().to_path_buf(),
+                    DirtyDocumentIdentity::from_snapshot(snapshot),
+                );
+            }
+            DirtyDocumentSnapshotState::Clean | DirtyDocumentSnapshotState::DirtyWithoutText => {
+                self.latest_by_path.remove(path);
+            }
+        }
+    }
+
+    fn is_current(&self, identity: &DirtyDocumentIdentity) -> bool {
+        self.latest_by_path
+            .get(identity.path())
+            .is_some_and(|current| current == identity)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DirtyDocumentIdentity {
+    path: PathBuf,
+    version: Option<i32>,
+    fingerprint: TextFingerprint,
+}
+
+impl DirtyDocumentIdentity {
+    pub(crate) fn from_snapshot(snapshot: &DirtyDocumentSnapshot) -> Self {
+        Self {
+            path: snapshot.path().to_path_buf(),
+            version: snapshot.version(),
+            fingerprint: snapshot.fingerprint(),
+        }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) fn version(&self) -> Option<i32> {
+        self.version
+    }
+
+    pub(crate) fn text_len(&self) -> usize {
+        self.fingerprint.len()
+    }
+}

--- a/crates/lsp/engine/src/documents/mod.rs
+++ b/crates/lsp/engine/src/documents/mod.rs
@@ -1,6 +1,5 @@
 //! Tracks LSP document state that sits above the saved analysis project.
 
-mod dirty_analysis;
 mod snapshot;
 
 #[cfg(test)]
@@ -12,7 +11,6 @@ use std::{
     sync::Arc,
 };
 
-pub(crate) use self::dirty_analysis::{DirtyAnalysisHandle, DirtyDocumentIdentity};
 pub(crate) use self::snapshot::{
     DirtyDocumentSnapshot, DirtyDocumentSnapshotState, TextFingerprint,
 };

--- a/crates/lsp/engine/src/documents/mod.rs
+++ b/crates/lsp/engine/src/documents/mod.rs
@@ -1,14 +1,25 @@
+//! Tracks LSP document state that sits above the saved analysis project.
+
+mod snapshot;
+
+#[cfg(test)]
+mod tests;
+
 use std::{
     collections::HashMap,
-    hash::{Hash, Hasher},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
-/// LSP-side document freshness state.
+pub(crate) use self::snapshot::{
+    DirtyDocumentSnapshot, DirtyDocumentSnapshotState, TextFingerprint,
+};
+
+/// LSP-side document freshness and live-buffer state.
 ///
-/// The analysis engine remains save-only. This store only records whether VS Code has told us a
-/// file's live buffer has diverged from the saved snapshot, so position-sensitive requests can
-/// avoid returning stale answers.
+/// The saved project remains the stable baseline, but full-sync change notifications let analysis
+/// requests build a temporary dirty overlay for the queried document. Incremental-only changes
+/// still mark the file dirty without exposing a text snapshot.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct DocumentStore {
     documents: HashMap<PathBuf, DocumentState>,
@@ -23,6 +34,7 @@ impl DocumentStore {
                 version,
                 saved: Some(fingerprint),
                 live: Some(fingerprint),
+                live_text: Some(Arc::from(text)),
                 dirty: false,
             },
         );
@@ -52,9 +64,11 @@ impl DocumentStore {
         if let Some(full_text) = full_text {
             let live = TextFingerprint::new(full_text);
             document.live = Some(live);
+            document.live_text = Some(Arc::from(full_text));
             document.dirty = document.saved != Some(live);
         } else {
             document.live = None;
+            document.live_text = None;
             document.dirty = true;
         }
 
@@ -74,6 +88,7 @@ impl DocumentStore {
             // document back to the saved snapshot.
             if !document.dirty || document.live == Some(saved) || document.live.is_none() {
                 document.live = Some(saved);
+                document.live_text = Some(Arc::from(full_text));
             }
         } else {
             document.saved = document.live;
@@ -103,6 +118,29 @@ impl DocumentStore {
             .map(DocumentFreshness::from_state)
             .unwrap_or_else(DocumentFreshness::untracked)
     }
+
+    pub(crate) fn dirty_snapshot(&self, path: &Path) -> DirtyDocumentSnapshotState {
+        let Some(document) = self.documents.get(path) else {
+            return DirtyDocumentSnapshotState::Clean;
+        };
+        if !document.dirty {
+            return DirtyDocumentSnapshotState::Clean;
+        }
+
+        let Some(fingerprint) = document.live else {
+            return DirtyDocumentSnapshotState::DirtyWithoutText;
+        };
+        let Some(text) = &document.live_text else {
+            return DirtyDocumentSnapshotState::DirtyWithoutText;
+        };
+
+        DirtyDocumentSnapshotState::Dirty(DirtyDocumentSnapshot::new(
+            path.to_path_buf(),
+            document.version,
+            fingerprint,
+            Arc::clone(text),
+        ))
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -110,6 +148,7 @@ struct DocumentState {
     version: Option<i32>,
     saved: Option<TextFingerprint>,
     live: Option<TextFingerprint>,
+    live_text: Option<Arc<str>>,
     dirty: bool,
 }
 
@@ -184,109 +223,5 @@ impl DocumentChange {
             became_dirty: false,
             became_clean: false,
         }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct TextFingerprint {
-    len: usize,
-    hash: u64,
-}
-
-impl TextFingerprint {
-    fn new(text: &str) -> Self {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        text.hash(&mut hasher);
-        Self {
-            len: text.len(),
-            hash: hasher.finish(),
-        }
-    }
-
-    fn len(self) -> usize {
-        self.len
-    }
-
-    fn hash(self) -> u64 {
-        self.hash
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::path::PathBuf;
-
-    use super::DocumentStore;
-
-    #[test]
-    fn tracks_clean_to_dirty_to_clean_document_lifecycle() {
-        let path = PathBuf::from("/workspace/src/lib.rs");
-        let mut store = DocumentStore::default();
-
-        store.did_open(path.clone(), Some(1), "fn main() {}\n");
-        assert!(!store.is_dirty(&path));
-
-        let change = store.did_change(path.clone(), Some(2), Some("fn main() {\n}\n"));
-        assert!(change.became_dirty);
-        assert!(store.is_dirty(&path));
-
-        let change = store.did_change(path.clone(), Some(3), Some("fn main() {\n}\n"));
-        assert!(!change.became_dirty);
-        assert!(store.is_dirty(&path));
-
-        store.did_save(path.clone(), Some("fn main() {\n}\n"));
-        assert!(!store.is_dirty(&path));
-
-        store.mark_dirty_after_failed_save(path.clone());
-        assert!(store.is_dirty(&path));
-
-        store.did_close(&path);
-        assert!(!store.is_dirty(&path));
-    }
-
-    #[test]
-    fn ignores_delayed_change_events_that_match_saved_text() {
-        let path = PathBuf::from("/workspace/src/lib.rs");
-        let mut store = DocumentStore::default();
-
-        store.did_open(path.clone(), Some(1), "fn main() {}\n");
-        store.did_save(path.clone(), Some("fn main() {\n}\n"));
-        assert!(!store.is_dirty(&path));
-
-        let change = store.did_change(path.clone(), Some(2), Some("fn main() {\n}\n"));
-        assert!(!change.became_dirty);
-        assert!(!store.is_dirty(&path));
-    }
-
-    #[test]
-    fn ignores_out_of_order_older_change_versions() {
-        let path = PathBuf::from("/workspace/src/lib.rs");
-        let mut store = DocumentStore::default();
-
-        store.did_open(path.clone(), Some(1), "fn main() {}\n");
-        store.did_change(path.clone(), Some(3), Some("fn main() {\n    work();\n}\n"));
-        store.did_save(path.clone(), Some("fn main() {\n    work();\n}\n"));
-        assert!(!store.is_dirty(&path));
-
-        let change = store.did_change(path.clone(), Some(2), Some("fn main() {\n}\n"));
-        assert!(!change.became_dirty);
-        assert!(!change.became_clean);
-        assert!(!store.is_dirty(&path));
-    }
-
-    #[test]
-    fn save_keeps_document_dirty_when_a_newer_edit_already_landed() {
-        let path = PathBuf::from("/workspace/src/lib.rs");
-        let mut store = DocumentStore::default();
-
-        store.did_open(path.clone(), Some(1), "fn main() {}\n");
-        store.did_change(
-            path.clone(),
-            Some(3),
-            Some("fn main() {\n    unsaved();\n}\n"),
-        );
-
-        store.did_save(path.clone(), Some("fn main() {\n    saved();\n}\n"));
-        assert!(store.is_dirty(&path));
     }
 }

--- a/crates/lsp/engine/src/documents/mod.rs
+++ b/crates/lsp/engine/src/documents/mod.rs
@@ -1,5 +1,6 @@
 //! Tracks LSP document state that sits above the saved analysis project.
 
+mod dirty_analysis;
 mod snapshot;
 
 #[cfg(test)]
@@ -11,6 +12,7 @@ use std::{
     sync::Arc,
 };
 
+pub(crate) use self::dirty_analysis::{DirtyAnalysisHandle, DirtyDocumentIdentity};
 pub(crate) use self::snapshot::{
     DirtyDocumentSnapshot, DirtyDocumentSnapshotState, TextFingerprint,
 };

--- a/crates/lsp/engine/src/documents/snapshot.rs
+++ b/crates/lsp/engine/src/documents/snapshot.rs
@@ -67,7 +67,7 @@ impl TextFingerprint {
         }
     }
 
-    pub(super) fn len(self) -> usize {
+    pub(crate) fn len(self) -> usize {
         self.len
     }
 

--- a/crates/lsp/engine/src/documents/snapshot.rs
+++ b/crates/lsp/engine/src/documents/snapshot.rs
@@ -1,0 +1,77 @@
+use std::{
+    hash::{Hash, Hasher},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DirtyDocumentSnapshotState {
+    Clean,
+    Dirty(DirtyDocumentSnapshot),
+    DirtyWithoutText,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DirtyDocumentSnapshot {
+    path: PathBuf,
+    version: Option<i32>,
+    fingerprint: TextFingerprint,
+    text: Arc<str>,
+}
+
+impl DirtyDocumentSnapshot {
+    pub(super) fn new(
+        path: PathBuf,
+        version: Option<i32>,
+        fingerprint: TextFingerprint,
+        text: Arc<str>,
+    ) -> Self {
+        Self {
+            path,
+            version,
+            fingerprint,
+            text,
+        }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) fn version(&self) -> Option<i32> {
+        self.version
+    }
+
+    pub(crate) fn fingerprint(&self) -> TextFingerprint {
+        self.fingerprint
+    }
+
+    pub(crate) fn text(&self) -> &str {
+        &self.text
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TextFingerprint {
+    len: usize,
+    hash: u64,
+}
+
+impl TextFingerprint {
+    pub(super) fn new(text: &str) -> Self {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        text.hash(&mut hasher);
+        Self {
+            len: text.len(),
+            hash: hasher.finish(),
+        }
+    }
+
+    pub(super) fn len(self) -> usize {
+        self.len
+    }
+
+    pub(super) fn hash(self) -> u64 {
+        self.hash
+    }
+}

--- a/crates/lsp/engine/src/documents/tests.rs
+++ b/crates/lsp/engine/src/documents/tests.rs
@@ -1,8 +1,6 @@
 use std::path::PathBuf;
 
-use super::{
-    DirtyAnalysisHandle, DirtyDocumentIdentity, DirtyDocumentSnapshotState, DocumentStore,
-};
+use super::{DirtyDocumentSnapshotState, DocumentStore};
 
 #[test]
 fn tracks_clean_to_dirty_to_clean_document_lifecycle() {
@@ -91,43 +89,4 @@ fn exposes_dirty_snapshot_when_full_live_text_is_available() {
     assert_eq!(snapshot.path(), path.as_path());
     assert_eq!(snapshot.version(), Some(2));
     assert_eq!(snapshot.text(), "fn main() {\n    live();\n}\n");
-}
-
-#[test]
-fn dirty_analysis_handle_rejects_old_dirty_snapshots() {
-    let path = PathBuf::from("/workspace/src/lib.rs");
-    let mut store = DocumentStore::default();
-    let dirty_analysis = DirtyAnalysisHandle::default();
-
-    store.did_open(path.clone(), Some(1), "fn main() {}\n");
-    dirty_analysis.sync_document(&path, &store.dirty_snapshot(&path));
-
-    store.did_change(path.clone(), Some(2), Some("fn main() {\n    v2();\n}\n"));
-    let snapshot_v2 = store.dirty_snapshot(&path);
-    dirty_analysis.sync_document(&path, &snapshot_v2);
-    let DirtyDocumentSnapshotState::Dirty(snapshot_v2) = snapshot_v2 else {
-        panic!("dirty full-sync document should expose version 2 snapshot");
-    };
-    assert!(
-        dirty_analysis.is_current_identity(&DirtyDocumentIdentity::from_snapshot(&snapshot_v2))
-    );
-
-    store.did_change(path.clone(), Some(3), Some("fn main() {\n    v3();\n}\n"));
-    let snapshot_v3 = store.dirty_snapshot(&path);
-    dirty_analysis.sync_document(&path, &snapshot_v3);
-    let DirtyDocumentSnapshotState::Dirty(snapshot_v3) = snapshot_v3 else {
-        panic!("dirty full-sync document should expose version 3 snapshot");
-    };
-    assert!(
-        !dirty_analysis.is_current_identity(&DirtyDocumentIdentity::from_snapshot(&snapshot_v2))
-    );
-    assert!(
-        dirty_analysis.is_current_identity(&DirtyDocumentIdentity::from_snapshot(&snapshot_v3))
-    );
-
-    store.did_save(path.clone(), Some("fn main() {\n    v3();\n}\n"));
-    dirty_analysis.sync_document(&path, &store.dirty_snapshot(&path));
-    assert!(
-        !dirty_analysis.is_current_identity(&DirtyDocumentIdentity::from_snapshot(&snapshot_v3))
-    );
 }

--- a/crates/lsp/engine/src/documents/tests.rs
+++ b/crates/lsp/engine/src/documents/tests.rs
@@ -1,0 +1,92 @@
+use std::path::PathBuf;
+
+use super::{DirtyDocumentSnapshotState, DocumentStore};
+
+#[test]
+fn tracks_clean_to_dirty_to_clean_document_lifecycle() {
+    let path = PathBuf::from("/workspace/src/lib.rs");
+    let mut store = DocumentStore::default();
+
+    store.did_open(path.clone(), Some(1), "fn main() {}\n");
+    assert!(!store.is_dirty(&path));
+
+    let change = store.did_change(path.clone(), Some(2), Some("fn main() {\n}\n"));
+    assert!(change.became_dirty);
+    assert!(store.is_dirty(&path));
+
+    let change = store.did_change(path.clone(), Some(3), Some("fn main() {\n}\n"));
+    assert!(!change.became_dirty);
+    assert!(store.is_dirty(&path));
+
+    store.did_save(path.clone(), Some("fn main() {\n}\n"));
+    assert!(!store.is_dirty(&path));
+
+    store.mark_dirty_after_failed_save(path.clone());
+    assert!(store.is_dirty(&path));
+
+    store.did_close(&path);
+    assert!(!store.is_dirty(&path));
+}
+
+#[test]
+fn ignores_delayed_change_events_that_match_saved_text() {
+    let path = PathBuf::from("/workspace/src/lib.rs");
+    let mut store = DocumentStore::default();
+
+    store.did_open(path.clone(), Some(1), "fn main() {}\n");
+    store.did_save(path.clone(), Some("fn main() {\n}\n"));
+    assert!(!store.is_dirty(&path));
+
+    let change = store.did_change(path.clone(), Some(2), Some("fn main() {\n}\n"));
+    assert!(!change.became_dirty);
+    assert!(!store.is_dirty(&path));
+}
+
+#[test]
+fn ignores_out_of_order_older_change_versions() {
+    let path = PathBuf::from("/workspace/src/lib.rs");
+    let mut store = DocumentStore::default();
+
+    store.did_open(path.clone(), Some(1), "fn main() {}\n");
+    store.did_change(path.clone(), Some(3), Some("fn main() {\n    work();\n}\n"));
+    store.did_save(path.clone(), Some("fn main() {\n    work();\n}\n"));
+    assert!(!store.is_dirty(&path));
+
+    let change = store.did_change(path.clone(), Some(2), Some("fn main() {\n}\n"));
+    assert!(!change.became_dirty);
+    assert!(!change.became_clean);
+    assert!(!store.is_dirty(&path));
+}
+
+#[test]
+fn save_keeps_document_dirty_when_a_newer_edit_already_landed() {
+    let path = PathBuf::from("/workspace/src/lib.rs");
+    let mut store = DocumentStore::default();
+
+    store.did_open(path.clone(), Some(1), "fn main() {}\n");
+    store.did_change(
+        path.clone(),
+        Some(3),
+        Some("fn main() {\n    unsaved();\n}\n"),
+    );
+
+    store.did_save(path.clone(), Some("fn main() {\n    saved();\n}\n"));
+    assert!(store.is_dirty(&path));
+}
+
+#[test]
+fn exposes_dirty_snapshot_when_full_live_text_is_available() {
+    let path = PathBuf::from("/workspace/src/lib.rs");
+    let mut store = DocumentStore::default();
+
+    store.did_open(path.clone(), Some(1), "fn main() {}\n");
+    store.did_change(path.clone(), Some(2), Some("fn main() {\n    live();\n}\n"));
+
+    let DirtyDocumentSnapshotState::Dirty(snapshot) = store.dirty_snapshot(&path) else {
+        panic!("dirty full-sync document should expose a dirty snapshot");
+    };
+
+    assert_eq!(snapshot.path(), path.as_path());
+    assert_eq!(snapshot.version(), Some(2));
+    assert_eq!(snapshot.text(), "fn main() {\n    live();\n}\n");
+}

--- a/crates/lsp/engine/src/documents/tests.rs
+++ b/crates/lsp/engine/src/documents/tests.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
-use super::{DirtyDocumentSnapshotState, DocumentStore};
+use super::{
+    DirtyAnalysisHandle, DirtyDocumentIdentity, DirtyDocumentSnapshotState, DocumentStore,
+};
 
 #[test]
 fn tracks_clean_to_dirty_to_clean_document_lifecycle() {
@@ -89,4 +91,43 @@ fn exposes_dirty_snapshot_when_full_live_text_is_available() {
     assert_eq!(snapshot.path(), path.as_path());
     assert_eq!(snapshot.version(), Some(2));
     assert_eq!(snapshot.text(), "fn main() {\n    live();\n}\n");
+}
+
+#[test]
+fn dirty_analysis_handle_rejects_old_dirty_snapshots() {
+    let path = PathBuf::from("/workspace/src/lib.rs");
+    let mut store = DocumentStore::default();
+    let dirty_analysis = DirtyAnalysisHandle::default();
+
+    store.did_open(path.clone(), Some(1), "fn main() {}\n");
+    dirty_analysis.sync_document(&path, &store.dirty_snapshot(&path));
+
+    store.did_change(path.clone(), Some(2), Some("fn main() {\n    v2();\n}\n"));
+    let snapshot_v2 = store.dirty_snapshot(&path);
+    dirty_analysis.sync_document(&path, &snapshot_v2);
+    let DirtyDocumentSnapshotState::Dirty(snapshot_v2) = snapshot_v2 else {
+        panic!("dirty full-sync document should expose version 2 snapshot");
+    };
+    assert!(
+        dirty_analysis.is_current_identity(&DirtyDocumentIdentity::from_snapshot(&snapshot_v2))
+    );
+
+    store.did_change(path.clone(), Some(3), Some("fn main() {\n    v3();\n}\n"));
+    let snapshot_v3 = store.dirty_snapshot(&path);
+    dirty_analysis.sync_document(&path, &snapshot_v3);
+    let DirtyDocumentSnapshotState::Dirty(snapshot_v3) = snapshot_v3 else {
+        panic!("dirty full-sync document should expose version 3 snapshot");
+    };
+    assert!(
+        !dirty_analysis.is_current_identity(&DirtyDocumentIdentity::from_snapshot(&snapshot_v2))
+    );
+    assert!(
+        dirty_analysis.is_current_identity(&DirtyDocumentIdentity::from_snapshot(&snapshot_v3))
+    );
+
+    store.did_save(path.clone(), Some("fn main() {\n    v3();\n}\n"));
+    dirty_analysis.sync_document(&path, &store.dirty_snapshot(&path));
+    assert!(
+        !dirty_analysis.is_current_identity(&DirtyDocumentIdentity::from_snapshot(&snapshot_v3))
+    );
 }

--- a/crates/lsp/engine/src/engine/command.rs
+++ b/crates/lsp/engine/src/engine/command.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 use rg_lsp_proto::AnalysisConfig;
 use tokio::sync::oneshot;
 
+use crate::documents::DirtyDocumentSnapshot;
+
 pub(crate) type EngineResponse<T> = oneshot::Sender<anyhow::Result<T>>;
 
 #[derive(Debug)]
@@ -20,46 +22,55 @@ pub(crate) enum EngineCommand {
     GotoDefinition {
         path: PathBuf,
         position: ls_types::Position,
+        dirty: Option<DirtyDocumentSnapshot>,
         respond_to: EngineResponse<Vec<ls_types::Location>>,
     },
     GotoTypeDefinition {
         path: PathBuf,
         position: ls_types::Position,
+        dirty: Option<DirtyDocumentSnapshot>,
         respond_to: EngineResponse<Vec<ls_types::Location>>,
     },
     GotoImplementation {
         path: PathBuf,
         position: ls_types::Position,
+        dirty: Option<DirtyDocumentSnapshot>,
         respond_to: EngineResponse<Vec<ls_types::Location>>,
     },
     References {
         path: PathBuf,
         position: ls_types::Position,
         include_declaration: bool,
+        dirty: Option<DirtyDocumentSnapshot>,
         respond_to: EngineResponse<Vec<ls_types::Location>>,
     },
     DocumentHighlight {
         path: PathBuf,
         position: ls_types::Position,
+        dirty: Option<DirtyDocumentSnapshot>,
         respond_to: EngineResponse<Vec<ls_types::DocumentHighlight>>,
     },
     Hover {
         path: PathBuf,
         position: ls_types::Position,
+        dirty: Option<DirtyDocumentSnapshot>,
         respond_to: EngineResponse<Option<ls_types::Hover>>,
     },
     Completion {
         path: PathBuf,
         position: ls_types::Position,
+        dirty: Option<DirtyDocumentSnapshot>,
         respond_to: EngineResponse<Vec<ls_types::CompletionItem>>,
     },
     DocumentSymbol {
         path: PathBuf,
+        dirty: Option<DirtyDocumentSnapshot>,
         respond_to: EngineResponse<Vec<ls_types::DocumentSymbol>>,
     },
     InlayHint {
         path: PathBuf,
         range: ls_types::Range,
+        dirty: Option<DirtyDocumentSnapshot>,
         respond_to: EngineResponse<Vec<ls_types::InlayHint>>,
     },
     WorkspaceSymbol {

--- a/crates/lsp/engine/src/engine/debounce.rs
+++ b/crates/lsp/engine/src/engine/debounce.rs
@@ -1,10 +1,12 @@
 use std::{
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicU64, Ordering},
     },
     time::Duration,
 };
+
+use tokio::task::JoinHandle;
 
 /// Coalesces repeated triggers so only the latest delayed callback runs.
 ///
@@ -21,24 +23,36 @@ impl Debouncer {
             state: Arc::new(DebounceState {
                 delay,
                 generation: AtomicU64::new(0),
+                pending: Mutex::new(None),
             }),
         }
     }
 
     pub(crate) fn call(&self, callback: impl FnOnce() + Send + 'static) {
+        let mut pending = self.pending();
         let generation = self.next_generation();
         let state = Arc::clone(&self.state);
 
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             tokio::time::sleep(state.delay).await;
             if state.generation.load(Ordering::Relaxed) == generation {
                 callback();
             }
         });
+
+        if let Some(previous) = pending.replace(handle) {
+            previous.abort();
+        }
     }
 
     pub(crate) fn call_now(&self, callback: impl FnOnce()) {
+        let mut pending = self.pending();
         self.next_generation();
+        if let Some(previous) = pending.take() {
+            previous.abort();
+        }
+        drop(pending);
+
         callback();
     }
 
@@ -48,10 +62,18 @@ impl Debouncer {
             .fetch_add(1, Ordering::Relaxed)
             .wrapping_add(1)
     }
+
+    fn pending(&self) -> std::sync::MutexGuard<'_, Option<JoinHandle<()>>> {
+        self.state
+            .pending
+            .lock()
+            .expect("debounce pending-task mutex should not be poisoned")
+    }
 }
 
 #[derive(Debug)]
 struct DebounceState {
     delay: Duration,
     generation: AtomicU64,
+    pending: Mutex<Option<JoinHandle<()>>>,
 }

--- a/crates/lsp/engine/src/engine/debounce.rs
+++ b/crates/lsp/engine/src/engine/debounce.rs
@@ -1,0 +1,57 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+/// Coalesces repeated triggers so only the latest delayed callback runs.
+///
+/// The counter is only used as a generation token, so relaxed ordering is enough: each callback
+/// only needs to know whether another callback was scheduled after it.
+#[derive(Debug, Clone)]
+pub(crate) struct Debouncer {
+    state: Arc<DebounceState>,
+}
+
+impl Debouncer {
+    pub(crate) fn new(delay: Duration) -> Self {
+        Self {
+            state: Arc::new(DebounceState {
+                delay,
+                generation: AtomicU64::new(0),
+            }),
+        }
+    }
+
+    pub(crate) fn call(&self, callback: impl FnOnce() + Send + 'static) {
+        let generation = self.next_generation();
+        let state = Arc::clone(&self.state);
+
+        tokio::spawn(async move {
+            tokio::time::sleep(state.delay).await;
+            if state.generation.load(Ordering::Relaxed) == generation {
+                callback();
+            }
+        });
+    }
+
+    pub(crate) fn call_now(&self, callback: impl FnOnce()) {
+        self.next_generation();
+        callback();
+    }
+
+    fn next_generation(&self) -> u64 {
+        self.state
+            .generation
+            .fetch_add(1, Ordering::Relaxed)
+            .wrapping_add(1)
+    }
+}
+
+#[derive(Debug)]
+struct DebounceState {
+    delay: Duration,
+    generation: AtomicU64,
+}

--- a/crates/lsp/engine/src/engine/mod.rs
+++ b/crates/lsp/engine/src/engine/mod.rs
@@ -20,7 +20,8 @@ pub(crate) use self::command::EngineCommand;
 use self::debounce::Debouncer;
 use self::{command::EngineResponse, worker::EngineWorker};
 use crate::{
-    documents::{DirtyAnalysisHandle, DirtyDocumentSnapshotState, DocumentStore},
+    dirty_state::DirtyState,
+    documents::{DirtyDocumentSnapshotState, DocumentStore},
     memory::MemoryControl,
     service::ServiceNotificationsSink,
 };
@@ -37,7 +38,7 @@ pub(crate) struct EngineHandle {
     pub(crate) documents: Arc<Mutex<DocumentStore>>,
     inlay_hint_debouncer: Debouncer,
     notifications: ServiceNotificationsSink,
-    dirty_analysis: DirtyAnalysisHandle,
+    dirty_state: DirtyState,
 }
 
 /// Separates time spent waiting behind older commands from time spent executing this command.
@@ -64,12 +65,12 @@ impl EngineHandle {
         documents: Arc<Mutex<DocumentStore>>,
     ) -> Self {
         let (sender, receiver) = mpsc::channel();
-        let dirty_analysis = DirtyAnalysisHandle::default();
+        let dirty_state = DirtyState::default();
         let inlay_hint_debouncer = Debouncer::new(INLAY_HINT_REFRESH_DEBOUNCE);
 
         thread::spawn({
-            let dirty_analysis = dirty_analysis.clone();
-            move || EngineWorker::new(memory_control, dirty_analysis).run(receiver)
+            let dirty_state = dirty_state.clone();
+            move || EngineWorker::new(memory_control, dirty_state).run(receiver)
         });
 
         Self {
@@ -77,7 +78,7 @@ impl EngineHandle {
             documents,
             inlay_hint_debouncer,
             notifications,
-            dirty_analysis,
+            dirty_state,
         }
     }
 
@@ -136,12 +137,8 @@ impl EngineHandle {
         dirty
     }
 
-    pub(crate) fn sync_dirty_analysis_state(
-        &self,
-        path: &Path,
-        dirty: &DirtyDocumentSnapshotState,
-    ) {
-        self.dirty_analysis.sync_document(path, dirty);
+    pub(crate) fn sync_dirty_state(&self, path: &Path, dirty: &DirtyDocumentSnapshotState) {
+        self.dirty_state.sync_document(path, dirty);
     }
 
     pub(crate) async fn mark_dirty_after_failed_save(&self, path: PathBuf, error: anyhow::Error) {
@@ -149,7 +146,7 @@ impl EngineHandle {
         documents.mark_dirty_after_failed_save(path.clone());
         let freshness = documents.freshness(&path);
         let dirty = documents.dirty_snapshot(&path);
-        self.sync_dirty_analysis_state(&path, &dirty);
+        self.sync_dirty_state(&path, &dirty);
         drop(documents);
 
         tracing::trace!(

--- a/crates/lsp/engine/src/engine/mod.rs
+++ b/crates/lsp/engine/src/engine/mod.rs
@@ -16,7 +16,11 @@ use tokio::sync::{Mutex, oneshot};
 
 pub(crate) use self::command::EngineCommand;
 use self::{command::EngineResponse, worker::EngineWorker};
-use crate::{documents::DocumentStore, memory::MemoryControl, service::ServiceNotificationsSink};
+use crate::{
+    documents::{DirtyDocumentSnapshotState, DocumentStore},
+    memory::MemoryControl,
+    service::ServiceNotificationsSink,
+};
 
 /// Handle for the long-lived analysis worker.
 ///
@@ -64,8 +68,12 @@ impl EngineHandle {
             .context("while attempting to receive LSP engine response")?
     }
 
-    pub(crate) async fn is_dirty(&self, path: &Path) -> bool {
-        let freshness = self.documents.lock().await.freshness(path);
+    pub(crate) async fn dirty_document_snapshot(&self, path: &Path) -> DirtyDocumentSnapshotState {
+        let documents = self.documents.lock().await;
+        let freshness = documents.freshness(path);
+        let dirty = documents.dirty_snapshot(path);
+        drop(documents);
+
         tracing::trace!(
             path = %path.display(),
             tracked = freshness.tracked(),
@@ -78,14 +86,24 @@ impl EngineHandle {
             "checked document freshness"
         );
 
-        if freshness.dirty() {
-            tracing::debug!(
-                path = %path.display(),
-                "returning empty result for dirty document"
-            );
+        match &dirty {
+            DirtyDocumentSnapshotState::Dirty(snapshot) => {
+                tracing::debug!(
+                    path = %snapshot.path().display(),
+                    version = ?snapshot.version(),
+                    "using dirty document snapshot for analysis query"
+                );
+            }
+            DirtyDocumentSnapshotState::DirtyWithoutText => {
+                tracing::debug!(
+                    path = %path.display(),
+                    "dirty document has no full-text snapshot"
+                );
+            }
+            DirtyDocumentSnapshotState::Clean => {}
         }
 
-        freshness.dirty()
+        dirty
     }
 
     pub(crate) async fn mark_dirty_after_failed_save(&self, path: PathBuf, error: anyhow::Error) {

--- a/crates/lsp/engine/src/engine/mod.rs
+++ b/crates/lsp/engine/src/engine/mod.rs
@@ -8,6 +8,7 @@ use std::{
         mpsc::{self, Sender},
     },
     thread,
+    time::Instant,
 };
 
 use anyhow::Context as _;
@@ -28,9 +29,25 @@ use crate::{
 /// This handle is the async side used by the RPC-facing service.
 #[derive(Clone, Debug)]
 pub(crate) struct EngineHandle {
-    sender: Sender<EngineCommand>,
+    sender: Sender<QueuedEngineCommand>,
     pub(crate) documents: Arc<Mutex<DocumentStore>>,
     notifications: ServiceNotificationsSink,
+}
+
+/// Separates time spent waiting behind older commands from time spent executing this command.
+#[derive(Debug)]
+pub(crate) struct QueuedEngineCommand {
+    pub(crate) command: EngineCommand,
+    pub(crate) enqueued_at: Instant,
+}
+
+impl QueuedEngineCommand {
+    fn new(command: EngineCommand) -> Self {
+        Self {
+            command,
+            enqueued_at: Instant::now(),
+        }
+    }
 }
 
 impl EngineHandle {
@@ -60,7 +77,7 @@ impl EngineHandle {
     {
         let (respond_to, response) = oneshot::channel();
         self.sender
-            .send(build(respond_to))
+            .send(QueuedEngineCommand::new(build(respond_to)))
             .context("while attempting to send LSP engine command")?;
 
         response

--- a/crates/lsp/engine/src/engine/mod.rs
+++ b/crates/lsp/engine/src/engine/mod.rs
@@ -18,7 +18,7 @@ use tokio::sync::{Mutex, oneshot};
 pub(crate) use self::command::EngineCommand;
 use self::{command::EngineResponse, worker::EngineWorker};
 use crate::{
-    documents::{DirtyDocumentSnapshotState, DocumentStore},
+    documents::{DirtyAnalysisHandle, DirtyDocumentSnapshotState, DocumentStore},
     memory::MemoryControl,
     service::ServiceNotificationsSink,
 };
@@ -31,6 +31,7 @@ use crate::{
 pub(crate) struct EngineHandle {
     sender: Sender<QueuedEngineCommand>,
     pub(crate) documents: Arc<Mutex<DocumentStore>>,
+    dirty_analysis: DirtyAnalysisHandle,
     notifications: ServiceNotificationsSink,
 }
 
@@ -58,12 +59,17 @@ impl EngineHandle {
         documents: Arc<Mutex<DocumentStore>>,
     ) -> Self {
         let (sender, receiver) = mpsc::channel();
+        let dirty_analysis = DirtyAnalysisHandle::default();
 
-        thread::spawn(move || EngineWorker::new(memory_control).run(receiver));
+        thread::spawn({
+            let dirty_analysis = dirty_analysis.clone();
+            move || EngineWorker::new(memory_control, dirty_analysis).run(receiver)
+        });
 
         Self {
             sender,
             documents,
+            dirty_analysis,
             notifications,
         }
     }
@@ -123,10 +129,20 @@ impl EngineHandle {
         dirty
     }
 
+    pub(crate) fn sync_dirty_analysis_state(
+        &self,
+        path: &Path,
+        dirty: &DirtyDocumentSnapshotState,
+    ) {
+        self.dirty_analysis.sync_document(path, dirty);
+    }
+
     pub(crate) async fn mark_dirty_after_failed_save(&self, path: PathBuf, error: anyhow::Error) {
         let mut documents = self.documents.lock().await;
         documents.mark_dirty_after_failed_save(path.clone());
         let freshness = documents.freshness(&path);
+        let dirty = documents.dirty_snapshot(&path);
+        self.sync_dirty_analysis_state(&path, &dirty);
         drop(documents);
 
         tracing::trace!(

--- a/crates/lsp/engine/src/engine/mod.rs
+++ b/crates/lsp/engine/src/engine/mod.rs
@@ -1,4 +1,5 @@
 mod command;
+mod debounce;
 mod worker;
 
 use std::{
@@ -8,7 +9,7 @@ use std::{
         mpsc::{self, Sender},
     },
     thread,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use anyhow::Context as _;
@@ -16,12 +17,15 @@ use rg_lsp_proto::{ServiceLogLevel, ServiceNotification};
 use tokio::sync::{Mutex, oneshot};
 
 pub(crate) use self::command::EngineCommand;
+use self::debounce::Debouncer;
 use self::{command::EngineResponse, worker::EngineWorker};
 use crate::{
     documents::{DirtyAnalysisHandle, DirtyDocumentSnapshotState, DocumentStore},
     memory::MemoryControl,
     service::ServiceNotificationsSink,
 };
+
+const INLAY_HINT_REFRESH_DEBOUNCE: Duration = Duration::from_millis(150);
 
 /// Handle for the long-lived analysis worker.
 ///
@@ -31,8 +35,9 @@ use crate::{
 pub(crate) struct EngineHandle {
     sender: Sender<QueuedEngineCommand>,
     pub(crate) documents: Arc<Mutex<DocumentStore>>,
-    dirty_analysis: DirtyAnalysisHandle,
+    inlay_hint_debouncer: Debouncer,
     notifications: ServiceNotificationsSink,
+    dirty_analysis: DirtyAnalysisHandle,
 }
 
 /// Separates time spent waiting behind older commands from time spent executing this command.
@@ -60,6 +65,7 @@ impl EngineHandle {
     ) -> Self {
         let (sender, receiver) = mpsc::channel();
         let dirty_analysis = DirtyAnalysisHandle::default();
+        let inlay_hint_debouncer = Debouncer::new(INLAY_HINT_REFRESH_DEBOUNCE);
 
         thread::spawn({
             let dirty_analysis = dirty_analysis.clone();
@@ -69,8 +75,9 @@ impl EngineHandle {
         Self {
             sender,
             documents,
-            dirty_analysis,
+            inlay_hint_debouncer,
             notifications,
+            dirty_analysis,
         }
     }
 
@@ -179,8 +186,19 @@ impl EngineHandle {
         );
     }
 
-    pub(crate) fn refresh_inlay_hints(&self) {
-        self.notifications
-            .send(ServiceNotification::InlayHintRefresh);
+    /// Schedules an inlay-hint refresh after nearby edit notifications settle.
+    pub(crate) fn refresh_inlay_hints_debounced(&self) {
+        let notifications = self.notifications.clone();
+        self.inlay_hint_debouncer.call(move || {
+            notifications.send(ServiceNotification::InlayHintRefresh);
+        });
+    }
+
+    /// Sends an inlay-hint refresh immediately and cancels any pending debounced refresh.
+    pub(crate) fn refresh_inlay_hints_now(&self) {
+        let notifications = self.notifications.clone();
+        self.inlay_hint_debouncer.call_now(move || {
+            notifications.send(ServiceNotification::InlayHintRefresh);
+        });
     }
 }

--- a/crates/lsp/engine/src/engine/mod.rs
+++ b/crates/lsp/engine/src/engine/mod.rs
@@ -1,5 +1,6 @@
 mod command;
 mod debounce;
+mod project_proxy;
 mod worker;
 
 use std::{

--- a/crates/lsp/engine/src/engine/project_proxy.rs
+++ b/crates/lsp/engine/src/engine/project_proxy.rs
@@ -39,12 +39,11 @@ impl ProjectProxy {
             .saved
             .as_mut()
             .context("LSP engine is not initialized")?;
-        let result = mutation(saved)?;
 
-        // Dirty overlays are derived from a concrete saved-project state. A successful saved
-        // mutation makes the previous overlay obsolete; failed mutations leave both states intact.
+        // Any saved-project mutation attempt may leave the project in a different state even if it
+        // returns an error, so discard overlays derived from the previous saved state up front.
         self.dirty_overlay.clear();
-        Ok(result)
+        mutation(saved)
     }
 
     pub(super) fn saved_snapshot(&self) -> anyhow::Result<ProjectSnapshot<'_>> {

--- a/crates/lsp/engine/src/engine/project_proxy.rs
+++ b/crates/lsp/engine/src/engine/project_proxy.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use rg_project::{Project, ProjectSnapshot};
+
+use crate::{
+    dirty_state::DirtyOverlayCache, documents::DirtyDocumentSnapshot, memory::MemoryControl,
+};
+
+/// Owns the saved project and the disposable dirty overlay used by read-only queries.
+#[derive(Debug)]
+pub(super) struct ProjectProxy {
+    saved: Option<Project>,
+    dirty_overlay: DirtyOverlayCache,
+}
+
+impl ProjectProxy {
+    pub(super) fn new(memory_control: Arc<dyn MemoryControl>) -> Self {
+        Self {
+            saved: None,
+            dirty_overlay: DirtyOverlayCache::new(memory_control),
+        }
+    }
+
+    pub(super) fn is_initialized(&self) -> bool {
+        self.saved.is_some()
+    }
+
+    pub(super) fn replace_saved(&mut self, project: Project) {
+        self.saved = Some(project);
+        self.dirty_overlay.clear();
+    }
+
+    pub(super) fn mutate_saved<T>(
+        &mut self,
+        mutation: impl FnOnce(&mut Project) -> anyhow::Result<T>,
+    ) -> anyhow::Result<T> {
+        let saved = self
+            .saved
+            .as_mut()
+            .context("LSP engine is not initialized")?;
+        let result = mutation(saved)?;
+
+        // Dirty overlays are derived from a concrete saved-project state. A successful saved
+        // mutation makes the previous overlay obsolete; failed mutations leave both states intact.
+        self.dirty_overlay.clear();
+        Ok(result)
+    }
+
+    pub(super) fn saved_snapshot(&self) -> anyhow::Result<ProjectSnapshot<'_>> {
+        self.saved
+            .as_ref()
+            .map(Project::snapshot)
+            .context("LSP engine is not initialized")
+    }
+
+    pub(super) fn with_query_snapshot<T>(
+        &mut self,
+        dirty: Option<&DirtyDocumentSnapshot>,
+        query: impl FnOnce(ProjectSnapshot<'_>) -> anyhow::Result<T>,
+    ) -> anyhow::Result<T> {
+        let project = match dirty {
+            Some(dirty) => {
+                let saved = self
+                    .saved
+                    .as_ref()
+                    .context("LSP engine is not initialized")?;
+                self.dirty_overlay.project_for_dirty(saved, dirty)?
+            }
+            None => {
+                self.dirty_overlay.clear();
+                self.saved
+                    .as_ref()
+                    .context("LSP engine is not initialized")?
+            }
+        };
+
+        query(project.snapshot())
+    }
+}

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -9,13 +9,12 @@ use rg_analysis::{ReferenceQuery, TypeHint};
 use rg_def_map::TargetRef;
 use rg_lsp_proto::AnalysisConfig;
 use rg_parse::TextSpan;
-use rg_project::{
-    CacheProbeProfile, DirtyFileChange, FileContext, Project, ProjectSnapshot, SavedFileChange,
-};
+use rg_project::{CacheProbeProfile, FileContext, Project, ProjectSnapshot, SavedFileChange};
 use rg_workspace::{CargoMetadataTarget, SysrootSources, WorkspaceMetadata};
 
 use crate::{
-    documents::{DirtyAnalysisHandle, DirtyDocumentIdentity, DirtyDocumentSnapshot},
+    dirty_state::{DirtyDocumentIdentity, DirtyOverlayCache, DirtyState},
+    documents::DirtyDocumentSnapshot,
     engine::{
         QueuedEngineCommand,
         command::{EngineCommand, EngineResponse},
@@ -28,15 +27,9 @@ use crate::{
 #[derive(Debug)]
 pub(super) struct EngineWorker {
     project: Option<Project>,
-    dirty_overlay: Option<CachedDirtyOverlay>,
-    dirty_analysis: DirtyAnalysisHandle,
+    dirty_overlay: DirtyOverlayCache,
+    dirty_state: DirtyState,
     memory_control: Arc<dyn MemoryControl>,
-}
-
-#[derive(Debug)]
-struct CachedDirtyOverlay {
-    identity: DirtyDocumentIdentity,
-    project: Project,
 }
 
 #[derive(Debug)]
@@ -67,25 +60,19 @@ impl QueryContext {
         }
     }
 
-    fn stale_dirty_identity(
-        &self,
-        dirty_analysis: &DirtyAnalysisHandle,
-    ) -> Option<&DirtyDocumentIdentity> {
+    fn stale_dirty_identity(&self, dirty_state: &DirtyState) -> Option<&DirtyDocumentIdentity> {
         self.dirty_identity
             .as_ref()
-            .filter(|identity| !dirty_analysis.is_current_identity(identity))
+            .filter(|identity| !dirty_state.is_current_identity(identity))
     }
 }
 
 impl EngineWorker {
-    pub(super) fn new(
-        memory_control: Arc<dyn MemoryControl>,
-        dirty_analysis: DirtyAnalysisHandle,
-    ) -> Self {
+    pub(super) fn new(memory_control: Arc<dyn MemoryControl>, dirty_state: DirtyState) -> Self {
         Self {
             project: None,
-            dirty_overlay: None,
-            dirty_analysis,
+            dirty_overlay: DirtyOverlayCache::new(Arc::clone(&memory_control)),
+            dirty_state,
             memory_control,
         }
     }
@@ -375,7 +362,7 @@ impl EngineWorker {
         Self::log_project_snapshot(snapshot, "initial index");
 
         self.project = Some(project);
-        self.dirty_overlay = None;
+        self.dirty_overlay.clear();
         tracing::info!(
             workspace_root = %workspace_root.display(),
             elapsed_ms = started.elapsed().as_millis(),
@@ -396,7 +383,7 @@ impl EngineWorker {
         project
             .reindex_workspace()
             .context("while attempting to manually reindex workspace")?;
-        self.dirty_overlay = None;
+        self.dirty_overlay.clear();
         Self::log_project_snapshot(project.snapshot(), "manual reindex");
         tracing::info!(
             elapsed_ms = started.elapsed().as_millis(),
@@ -423,7 +410,7 @@ impl EngineWorker {
         let summary = project
             .apply_change(SavedFileChange::new(&path))
             .context("while attempting to apply saved file change")?;
-        self.dirty_overlay = None;
+        self.dirty_overlay.clear();
         tracing::info!(
             path = %path.display(),
             changed_files = summary.changed_files.len(),
@@ -960,9 +947,15 @@ impl EngineWorker {
         query: impl FnOnce(ProjectSnapshot<'_>) -> anyhow::Result<T>,
     ) -> anyhow::Result<T> {
         let project = match dirty {
-            Some(dirty) => self.dirty_overlay_project(dirty)?,
+            Some(dirty) => {
+                let base = self
+                    .project
+                    .as_ref()
+                    .context("LSP engine is not initialized")?;
+                self.dirty_overlay.project_for_dirty(base, dirty)?
+            }
             None => {
-                self.dirty_overlay = None;
+                self.dirty_overlay.clear();
                 self.project
                     .as_ref()
                     .context("LSP engine is not initialized")?
@@ -970,72 +963,6 @@ impl EngineWorker {
         };
 
         query(project.snapshot())
-    }
-
-    fn dirty_overlay_project(&mut self, dirty: &DirtyDocumentSnapshot) -> anyhow::Result<&Project> {
-        let identity = DirtyDocumentIdentity::from_snapshot(dirty);
-        let should_rebuild = match &self.dirty_overlay {
-            Some(cached) => cached.identity != identity,
-            None => true,
-        };
-
-        if should_rebuild {
-            let started = Instant::now();
-            let base = self
-                .project
-                .as_ref()
-                .context("LSP engine is not initialized")?;
-            let memory_before = MemoryReporter::log_checkpoint(
-                self.memory_control.as_ref(),
-                "dirty_overlay",
-                "before_rebuild",
-            );
-            let overlay = base
-                .dirty_overlay([DirtyFileChange::new(dirty.path(), dirty.text().to_string())])
-                .with_context(|| {
-                    format!(
-                        "while attempting to build dirty analysis overlay for {}",
-                        dirty.path().display()
-                    )
-                })?;
-            MemoryReporter::log_checkpoint_delta(
-                self.memory_control.as_ref(),
-                "dirty_overlay",
-                "after_rebuild",
-                memory_before,
-            );
-            // Dirty overlay rebuilds can temporarily materialize much more allocator memory than
-            // the retained overlay needs. Purge at this rebuild boundary without making every
-            // read-only query pay the same cost.
-            MemoryReporter::purge_and_report(self.memory_control.as_ref(), "after dirty overlay");
-            let changed_known_file = overlay.is_some();
-            let project = overlay.unwrap_or_else(|| base.clone());
-            tracing::debug!(
-                path = %dirty.path().display(),
-                version = ?dirty.version(),
-                text_len = dirty.text().len(),
-                dirty_overlay_cache_hit = false,
-                dirty_overlay_changed_known_file = changed_known_file,
-                dirty_overlay_build_ms = started.elapsed().as_millis(),
-                "dirty analysis overlay rebuilt"
-            );
-            self.dirty_overlay = Some(CachedDirtyOverlay { identity, project });
-        } else {
-            tracing::debug!(
-                path = %dirty.path().display(),
-                version = ?dirty.version(),
-                text_len = dirty.text().len(),
-                dirty_overlay_cache_hit = true,
-                dirty_overlay_build_ms = 0_u128,
-                "dirty analysis overlay cache hit"
-            );
-        }
-
-        Ok(&self
-            .dirty_overlay
-            .as_ref()
-            .expect("dirty overlay should be cached after successful build")
-            .project)
     }
 
     /// Runs a read-only request, responds immediately, then heals disposable cache failures.
@@ -1050,7 +977,7 @@ impl EngineWorker {
         // If a newer document version is already available, this queued dirty query can only
         // produce obsolete results. This is an internal optimization, not a replacement for LSP
         // request cancellation.
-        if let Some(dirty_identity) = context.stale_dirty_identity(&self.dirty_analysis) {
+        if let Some(dirty_identity) = context.stale_dirty_identity(&self.dirty_state) {
             tracing::debug!(
                 label = context.label,
                 path = %dirty_identity.path().display(),
@@ -1122,7 +1049,7 @@ impl EngineWorker {
 
         match project.recover_after_cache_load_failure() {
             Ok(()) => {
-                self.dirty_overlay = None;
+                self.dirty_overlay.clear();
                 let snapshot = project.snapshot();
                 Self::log_project_snapshot(snapshot, "after package cache recovery");
                 tracing::info!(
@@ -1214,7 +1141,7 @@ mod tests {
             panic!("dirty full-sync document should expose a snapshot");
         };
 
-        let mut worker = EngineWorker::new(Arc::new(()), DirtyAnalysisHandle::default());
+        let mut worker = EngineWorker::new(Arc::new(()), DirtyState::default());
         let (respond_to, response) = oneshot::channel();
         let context = QueryContext::document("hover", Duration::ZERO, Some(&snapshot));
 

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -9,10 +9,13 @@ use rg_analysis::{ReferenceQuery, TypeHint};
 use rg_def_map::TargetRef;
 use rg_lsp_proto::AnalysisConfig;
 use rg_parse::TextSpan;
-use rg_project::{CacheProbeProfile, FileContext, Project, ProjectSnapshot, SavedFileChange};
+use rg_project::{
+    CacheProbeProfile, DirtyFileChange, FileContext, Project, ProjectSnapshot, SavedFileChange,
+};
 use rg_workspace::{CargoMetadataTarget, SysrootSources, WorkspaceMetadata};
 
 use crate::{
+    documents::{DirtyDocumentSnapshot, TextFingerprint},
     engine::command::{EngineCommand, EngineResponse},
     memory::{MemoryControl, MemoryReporter},
     project_stats::{ProjectStats, log_retained_memory},
@@ -22,13 +25,38 @@ use crate::{
 #[derive(Debug)]
 pub(super) struct EngineWorker {
     project: Option<Project>,
+    dirty_overlay: Option<CachedDirtyOverlay>,
     memory_control: Arc<dyn MemoryControl>,
+}
+
+#[derive(Debug)]
+struct CachedDirtyOverlay {
+    key: DirtyOverlayKey,
+    project: Project,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DirtyOverlayKey {
+    path: PathBuf,
+    version: Option<i32>,
+    fingerprint: TextFingerprint,
+}
+
+impl DirtyOverlayKey {
+    fn from_snapshot(snapshot: &DirtyDocumentSnapshot) -> Self {
+        Self {
+            path: snapshot.path().to_path_buf(),
+            version: snapshot.version(),
+            fingerprint: snapshot.fingerprint(),
+        }
+    }
 }
 
 impl EngineWorker {
     pub(super) fn new(memory_control: Arc<dyn MemoryControl>) -> Self {
         Self {
             project: None,
+            dirty_overlay: None,
             memory_control,
         }
     }
@@ -62,6 +90,7 @@ impl EngineWorker {
                 EngineCommand::GotoDefinition {
                     path,
                     position,
+                    dirty,
                     respond_to,
                 } => {
                     tracing::trace!(
@@ -71,12 +100,13 @@ impl EngineWorker {
                         "engine command started: goto_definition"
                     );
                     self.respond_to_query("goto_definition", respond_to, |worker| {
-                        worker.goto_definition(path, position)
+                        worker.goto_definition(path, position, dirty)
                     });
                 }
                 EngineCommand::GotoTypeDefinition {
                     path,
                     position,
+                    dirty,
                     respond_to,
                 } => {
                     tracing::trace!(
@@ -86,12 +116,13 @@ impl EngineWorker {
                         "engine command started: goto_type_definition"
                     );
                     self.respond_to_query("goto_type_definition", respond_to, |worker| {
-                        worker.goto_type_definition(path, position)
+                        worker.goto_type_definition(path, position, dirty)
                     });
                 }
                 EngineCommand::GotoImplementation {
                     path,
                     position,
+                    dirty,
                     respond_to,
                 } => {
                     tracing::trace!(
@@ -101,13 +132,14 @@ impl EngineWorker {
                         "engine command started: goto_implementation"
                     );
                     self.respond_to_query("goto_implementation", respond_to, |worker| {
-                        worker.goto_implementation(path, position)
+                        worker.goto_implementation(path, position, dirty)
                     });
                 }
                 EngineCommand::References {
                     path,
                     position,
                     include_declaration,
+                    dirty,
                     respond_to,
                 } => {
                     tracing::trace!(
@@ -118,12 +150,13 @@ impl EngineWorker {
                         "engine command started: references"
                     );
                     self.respond_to_query("references", respond_to, |worker| {
-                        worker.references(path, position, include_declaration)
+                        worker.references(path, position, include_declaration, dirty)
                     });
                 }
                 EngineCommand::DocumentHighlight {
                     path,
                     position,
+                    dirty,
                     respond_to,
                 } => {
                     tracing::trace!(
@@ -133,12 +166,13 @@ impl EngineWorker {
                         "engine command started: document_highlight"
                     );
                     self.respond_to_query("document_highlight", respond_to, |worker| {
-                        worker.document_highlight(path, position)
+                        worker.document_highlight(path, position, dirty)
                     });
                 }
                 EngineCommand::Hover {
                     path,
                     position,
+                    dirty,
                     respond_to,
                 } => {
                     tracing::trace!(
@@ -148,12 +182,13 @@ impl EngineWorker {
                         "engine command started: hover"
                     );
                     self.respond_to_query("hover", respond_to, |worker| {
-                        worker.hover(path, position)
+                        worker.hover(path, position, dirty)
                     });
                 }
                 EngineCommand::Completion {
                     path,
                     position,
+                    dirty,
                     respond_to,
                 } => {
                     tracing::trace!(
@@ -163,21 +198,26 @@ impl EngineWorker {
                         "engine command started: completion"
                     );
                     self.respond_to_query("completion", respond_to, |worker| {
-                        worker.completion(path, position)
+                        worker.completion(path, position, dirty)
                     });
                 }
-                EngineCommand::DocumentSymbol { path, respond_to } => {
+                EngineCommand::DocumentSymbol {
+                    path,
+                    dirty,
+                    respond_to,
+                } => {
                     tracing::trace!(
                         path = %path.display(),
                         "engine command started: document_symbol"
                     );
                     self.respond_to_query("document_symbol", respond_to, |worker| {
-                        worker.document_symbol(path)
+                        worker.document_symbol(path, dirty)
                     });
                 }
                 EngineCommand::InlayHint {
                     path,
                     range,
+                    dirty,
                     respond_to,
                 } => {
                     tracing::trace!(
@@ -189,7 +229,7 @@ impl EngineWorker {
                         "engine command started: inlay_hint"
                     );
                     self.respond_to_query("inlay_hint", respond_to, |worker| {
-                        worker.inlay_hint(path, range)
+                        worker.inlay_hint(path, range, dirty)
                     });
                 }
                 EngineCommand::WorkspaceSymbol { query, respond_to } => {
@@ -280,6 +320,7 @@ impl EngineWorker {
         Self::post_project_build(self.memory_control.as_ref(), snapshot, "initial index");
 
         self.project = Some(project);
+        self.dirty_overlay = None;
         tracing::info!(
             workspace_root = %workspace_root.display(),
             elapsed_ms = started.elapsed().as_millis(),
@@ -301,6 +342,7 @@ impl EngineWorker {
         project
             .reindex_workspace()
             .context("while attempting to manually reindex workspace")?;
+        self.dirty_overlay = None;
         Self::post_project_build(
             memory_control.as_ref(),
             project.snapshot(),
@@ -331,6 +373,7 @@ impl EngineWorker {
         let summary = project
             .apply_change(SavedFileChange::new(&path))
             .context("while attempting to apply saved file change")?;
+        self.dirty_overlay = None;
         tracing::info!(
             path = %path.display(),
             changed_files = summary.changed_files.len(),
@@ -345,65 +388,72 @@ impl EngineWorker {
     }
 
     fn goto_definition(
-        &self,
+        &mut self,
         path: PathBuf,
         position: ls_types::Position,
+        dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::Location>> {
-        self.navigation_query(path, position, NavigationQuery::Definition)
+        self.navigation_query(path, position, NavigationQuery::Definition, dirty)
     }
 
     fn goto_type_definition(
-        &self,
+        &mut self,
         path: PathBuf,
         position: ls_types::Position,
+        dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::Location>> {
-        self.navigation_query(path, position, NavigationQuery::TypeDefinition)
+        self.navigation_query(path, position, NavigationQuery::TypeDefinition, dirty)
     }
 
     fn goto_implementation(
-        &self,
+        &mut self,
         path: PathBuf,
         position: ls_types::Position,
+        dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::Location>> {
-        self.navigation_query(path, position, NavigationQuery::Implementation)
+        self.navigation_query(path, position, NavigationQuery::Implementation, dirty)
     }
 
     fn references(
-        &self,
+        &mut self,
         path: PathBuf,
         position: ls_types::Position,
         include_declaration: bool,
+        dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::Location>> {
         let started = Instant::now();
-        let snapshot = self.snapshot()?;
-        let target_offsets = self.target_offsets(snapshot, &path, position)?;
-        let analysis = snapshot.full_analysis()?;
-        let mut locations = Vec::new();
+        let locations = self.with_query_snapshot(dirty.as_ref(), |snapshot| {
+            let target_offsets = Self::target_offsets(snapshot, &path, position)?;
+            let analysis = snapshot.full_analysis()?;
+            let mut locations = Vec::new();
 
-        for (context, target, offset) in target_offsets {
-            let declaration_targets = analysis
-                .goto_definition(target, context.file, offset)?
-                .into_iter()
-                .map(|target| target.target)
-                .collect::<Vec<_>>();
-            let search_targets =
-                snapshot.reference_search_targets(context.package, &declaration_targets);
+            for (context, target, offset) in target_offsets {
+                let declaration_targets = analysis
+                    .goto_definition(target, context.file, offset)?
+                    .into_iter()
+                    .map(|target| target.target)
+                    .collect::<Vec<_>>();
+                let search_targets =
+                    snapshot.reference_search_targets(context.package, &declaration_targets);
 
-            for reference in analysis.references(
-                target,
-                context.file,
-                offset,
-                ReferenceQuery::find_references(&search_targets, include_declaration),
-            )? {
-                let Some(location) = references::location_for_reference(snapshot, &reference)?
-                else {
-                    continue;
-                };
-                if !locations.contains(&location) {
-                    locations.push(location);
+                for reference in analysis.references(
+                    target,
+                    context.file,
+                    offset,
+                    ReferenceQuery::find_references(&search_targets, include_declaration),
+                )? {
+                    let Some(location) = references::location_for_reference(snapshot, &reference)?
+                    else {
+                        continue;
+                    };
+                    if !locations.contains(&location) {
+                        locations.push(location);
+                    }
                 }
             }
-        }
+
+            Ok(locations)
+        })?;
 
         tracing::debug!(
             path = %path.display(),
@@ -419,44 +469,49 @@ impl EngineWorker {
     }
 
     fn document_highlight(
-        &self,
+        &mut self,
         path: PathBuf,
         position: ls_types::Position,
+        dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::DocumentHighlight>> {
         let started = Instant::now();
-        let snapshot = self.snapshot()?;
-        let target_offsets = self.target_offsets(snapshot, &path, position)?;
+        let highlights = self.with_query_snapshot(dirty.as_ref(), |snapshot| {
+            let target_offsets = Self::target_offsets(snapshot, &path, position)?;
 
-        let analysis_targets = target_offsets
-            .iter()
-            .map(|(_, target, _)| *target)
-            .collect::<Vec<_>>();
-        let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
-        let mut highlights = Vec::new();
+            let analysis_targets = target_offsets
+                .iter()
+                .map(|(_, target, _)| *target)
+                .collect::<Vec<_>>();
+            let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
+            let mut highlights = Vec::new();
 
-        for (context, target, offset) in target_offsets {
-            for reference in analysis.references(
-                target,
-                context.file,
-                offset,
-                ReferenceQuery::file_scoped(target, context.file),
-            )? {
-                if reference.target.package != context.package || reference.file_id != context.file
-                {
-                    continue;
-                }
-
-                let highlight = references::document_highlight_for_reference(
-                    snapshot,
-                    context.package,
+            for (context, target, offset) in target_offsets {
+                for reference in analysis.references(
+                    target,
                     context.file,
-                    reference.span,
-                )?;
-                if !highlights.contains(&highlight) {
-                    highlights.push(highlight);
+                    offset,
+                    ReferenceQuery::file_scoped(target, context.file),
+                )? {
+                    if reference.target.package != context.package
+                        || reference.file_id != context.file
+                    {
+                        continue;
+                    }
+
+                    let highlight = references::document_highlight_for_reference(
+                        snapshot,
+                        context.package,
+                        context.file,
+                        reference.span,
+                    )?;
+                    if !highlights.contains(&highlight) {
+                        highlights.push(highlight);
+                    }
                 }
             }
-        }
+
+            Ok(highlights)
+        })?;
 
         tracing::debug!(
             path = %path.display(),
@@ -471,28 +526,32 @@ impl EngineWorker {
     }
 
     fn completion(
-        &self,
+        &mut self,
         path: PathBuf,
         position: ls_types::Position,
+        dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::CompletionItem>> {
         let started = Instant::now();
-        let snapshot = self.snapshot()?;
-        let target_offsets = self.target_offsets(snapshot, &path, position)?;
-        let analysis_targets = target_offsets
-            .iter()
-            .map(|(_, target, _)| *target)
-            .collect::<Vec<_>>();
-        let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
-        let mut completions = Vec::new();
+        let completions = self.with_query_snapshot(dirty.as_ref(), |snapshot| {
+            let target_offsets = Self::target_offsets(snapshot, &path, position)?;
+            let analysis_targets = target_offsets
+                .iter()
+                .map(|(_, target, _)| *target)
+                .collect::<Vec<_>>();
+            let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
+            let mut completions = Vec::new();
 
-        for (context, target, offset) in target_offsets {
-            for item in analysis.completions_at_dot(target, context.file, offset)? {
-                let item = completion::completion_item(item);
-                if !completions.contains(&item) {
-                    completions.push(item);
+            for (context, target, offset) in target_offsets {
+                for item in analysis.completions_at_dot(target, context.file, offset)? {
+                    let item = completion::completion_item(item);
+                    if !completions.contains(&item) {
+                        completions.push(item);
+                    }
                 }
             }
-        }
+
+            Ok(completions)
+        })?;
 
         tracing::debug!(
             path = %path.display(),
@@ -507,73 +566,77 @@ impl EngineWorker {
     }
 
     fn hover(
-        &self,
+        &mut self,
         path: PathBuf,
         position: ls_types::Position,
+        dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Option<ls_types::Hover>> {
         let started = Instant::now();
-        let snapshot = self.snapshot()?;
-        let target_offsets = self.target_offsets(snapshot, &path, position)?;
-        let analysis_targets = target_offsets
-            .iter()
-            .map(|(_, target, _)| *target)
-            .collect::<Vec<_>>();
-        let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
+        let hover = self.with_query_snapshot(dirty.as_ref(), |snapshot| {
+            let target_offsets = Self::target_offsets(snapshot, &path, position)?;
+            let analysis_targets = target_offsets
+                .iter()
+                .map(|(_, target, _)| *target)
+                .collect::<Vec<_>>();
+            let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
 
-        for (context, target, offset) in target_offsets {
-            let Some(info) = analysis.hover(target, context.file, offset)? else {
-                continue;
-            };
-            let Some(line_index) = snapshot.file_line_index(context.package, context.file) else {
-                continue;
-            };
-            let Some(hover) = hover::hover(info, line_index) else {
-                continue;
-            };
-            tracing::debug!(
-                path = %path.display(),
-                line = position.line,
-                character = position.character,
-                has_hover = true,
-                elapsed_ms = started.elapsed().as_millis(),
-                "hover query finished"
-            );
-            return Ok(Some(hover));
-        }
+            for (context, target, offset) in target_offsets {
+                let Some(info) = analysis.hover(target, context.file, offset)? else {
+                    continue;
+                };
+                let Some(line_index) = snapshot.file_line_index(context.package, context.file)
+                else {
+                    continue;
+                };
+                let Some(hover) = hover::hover(info, line_index) else {
+                    continue;
+                };
+                return Ok(Some(hover));
+            }
+
+            Ok(None)
+        })?;
 
         tracing::debug!(
             path = %path.display(),
             line = position.line,
             character = position.character,
-            has_hover = false,
+            has_hover = hover.is_some(),
             elapsed_ms = started.elapsed().as_millis(),
             "hover query finished"
         );
-        Ok(None)
+        Ok(hover)
     }
 
-    fn document_symbol(&self, path: PathBuf) -> anyhow::Result<Vec<ls_types::DocumentSymbol>> {
+    fn document_symbol(
+        &mut self,
+        path: PathBuf,
+        dirty: Option<DirtyDocumentSnapshot>,
+    ) -> anyhow::Result<Vec<ls_types::DocumentSymbol>> {
         let started = Instant::now();
-        let snapshot = self.snapshot()?;
-        let contexts = self.file_contexts(snapshot, &path)?;
-        let analysis_targets = contexts
-            .iter()
-            .flat_map(|context| context.targets.iter().copied())
-            .collect::<Vec<_>>();
-        let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
-        let mut lsp_symbols = Vec::new();
+        let lsp_symbols = self.with_query_snapshot(dirty.as_ref(), |snapshot| {
+            let contexts = Self::file_contexts(snapshot, &path)?;
+            let analysis_targets = contexts
+                .iter()
+                .flat_map(|context| context.targets.iter().copied())
+                .collect::<Vec<_>>();
+            let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
+            let mut lsp_symbols = Vec::new();
 
-        for context in contexts {
-            for target in context.targets {
-                let symbols = analysis.document_symbols(target, context.file)?;
-                for symbol in symbols {
-                    let symbol = symbols::document_symbol(snapshot, context.package, symbol)?;
-                    if !lsp_symbols.contains(&symbol) {
-                        lsp_symbols.push(symbol);
+            for context in contexts {
+                for target in context.targets {
+                    let symbols = analysis.document_symbols(target, context.file)?;
+                    for symbol in symbols {
+                        let symbol = symbols::document_symbol(snapshot, context.package, symbol)?;
+                        if !lsp_symbols.contains(&symbol) {
+                            lsp_symbols.push(symbol);
+                        }
                     }
                 }
             }
-        }
+
+            Ok(lsp_symbols)
+        })?;
 
         tracing::debug!(
             path = %path.display(),
@@ -586,44 +649,48 @@ impl EngineWorker {
     }
 
     fn inlay_hint(
-        &self,
+        &mut self,
         path: PathBuf,
         range: ls_types::Range,
+        dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::InlayHint>> {
         let started = Instant::now();
-        let snapshot = self.snapshot()?;
-        let contexts = self.file_contexts(snapshot, &path)?;
-        let analysis_targets = contexts
-            .iter()
-            .flat_map(|context| context.targets.iter().copied())
-            .collect::<Vec<_>>();
-        let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
-        let mut hints = Vec::<(rg_def_map::PackageSlot, TypeHint)>::new();
+        let lsp_hints = self.with_query_snapshot(dirty.as_ref(), |snapshot| {
+            let contexts = Self::file_contexts(snapshot, &path)?;
+            let analysis_targets = contexts
+                .iter()
+                .flat_map(|context| context.targets.iter().copied())
+                .collect::<Vec<_>>();
+            let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
+            let mut hints = Vec::<(rg_def_map::PackageSlot, TypeHint)>::new();
 
-        for context in contexts {
-            let Some(range) = self.text_span_for_context(snapshot, &context, range) else {
-                continue;
-            };
+            for context in contexts {
+                let Some(range) = Self::text_span_for_context(snapshot, &context, range) else {
+                    continue;
+                };
 
-            for target in context.targets {
-                for hint in analysis.type_hints(target, context.file, Some(range))? {
-                    if !hints
-                        .iter()
-                        .any(|(_, existing_hint)| existing_hint == &hint)
-                    {
-                        hints.push((context.package, hint));
+                for target in context.targets {
+                    for hint in analysis.type_hints(target, context.file, Some(range))? {
+                        if !hints
+                            .iter()
+                            .any(|(_, existing_hint)| existing_hint == &hint)
+                        {
+                            hints.push((context.package, hint));
+                        }
                     }
                 }
             }
-        }
 
-        let mut lsp_hints = Vec::new();
-        for (package, hint) in hints {
-            let Some(hint) = inlay_hint::type_hint(snapshot, package, hint)? else {
-                continue;
-            };
-            lsp_hints.push(hint);
-        }
+            let mut lsp_hints = Vec::new();
+            for (package, hint) in hints {
+                let Some(hint) = inlay_hint::type_hint(snapshot, package, hint)? else {
+                    continue;
+                };
+                lsp_hints.push(hint);
+            }
+
+            Ok(lsp_hints)
+        })?;
 
         tracing::debug!(
             path = %path.display(),
@@ -661,43 +728,47 @@ impl EngineWorker {
     }
 
     fn navigation_query(
-        &self,
+        &mut self,
         path: PathBuf,
         position: ls_types::Position,
         query: NavigationQuery,
+        dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::Location>> {
         let started = Instant::now();
-        let snapshot = self.snapshot()?;
-        let target_offsets = self.target_offsets(snapshot, &path, position)?;
-        let analysis_targets = target_offsets
-            .iter()
-            .map(|(_, target, _)| *target)
-            .collect::<Vec<_>>();
-        let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
-        let mut locations = Vec::new();
+        let locations = self.with_query_snapshot(dirty.as_ref(), |snapshot| {
+            let target_offsets = Self::target_offsets(snapshot, &path, position)?;
+            let analysis_targets = target_offsets
+                .iter()
+                .map(|(_, target, _)| *target)
+                .collect::<Vec<_>>();
+            let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
+            let mut locations = Vec::new();
 
-        for (context, target, offset) in target_offsets {
-            let targets = match query {
-                NavigationQuery::Definition => {
-                    analysis.goto_definition(target, context.file, offset)?
-                }
-                NavigationQuery::TypeDefinition => {
-                    analysis.goto_type_definition(target, context.file, offset)?
-                }
-                NavigationQuery::Implementation => {
-                    analysis.goto_implementation(target, context.file, offset)?
-                }
-            };
-
-            for target in targets {
-                let Some(location) = navigation::location_for_target(snapshot, &target)? else {
-                    continue;
+            for (context, target, offset) in target_offsets {
+                let targets = match query {
+                    NavigationQuery::Definition => {
+                        analysis.goto_definition(target, context.file, offset)?
+                    }
+                    NavigationQuery::TypeDefinition => {
+                        analysis.goto_type_definition(target, context.file, offset)?
+                    }
+                    NavigationQuery::Implementation => {
+                        analysis.goto_implementation(target, context.file, offset)?
+                    }
                 };
-                if !locations.contains(&location) {
-                    locations.push(location);
+
+                for target in targets {
+                    let Some(location) = navigation::location_for_target(snapshot, &target)? else {
+                        continue;
+                    };
+                    if !locations.contains(&location) {
+                        locations.push(location);
+                    }
                 }
             }
-        }
+
+            Ok(locations)
+        })?;
 
         tracing::debug!(
             query = query.name(),
@@ -713,16 +784,15 @@ impl EngineWorker {
     }
 
     fn target_offsets(
-        &self,
         snapshot: ProjectSnapshot<'_>,
         path: &Path,
         position: ls_types::Position,
     ) -> anyhow::Result<Vec<(FileContext, TargetRef, u32)>> {
         let mut targets = Vec::new();
 
-        let contexts = self.file_contexts(snapshot, path)?;
+        let contexts = Self::file_contexts(snapshot, path)?;
         for context in contexts {
-            let Some(offset) = self.offset_for_context(snapshot, &context, position) else {
+            let Some(offset) = Self::offset_for_context(snapshot, &context, position) else {
                 tracing::trace!(
                     path = %path.display(),
                     line = position.line,
@@ -751,7 +821,6 @@ impl EngineWorker {
     }
 
     fn file_contexts(
-        &self,
         snapshot: ProjectSnapshot<'_>,
         path: &Path,
     ) -> anyhow::Result<Vec<FileContext>> {
@@ -782,7 +851,6 @@ impl EngineWorker {
     }
 
     fn offset_for_context(
-        &self,
         snapshot: ProjectSnapshot<'_>,
         context: &FileContext,
         position: ls_types::Position,
@@ -801,7 +869,6 @@ impl EngineWorker {
     }
 
     fn text_span_for_context(
-        &self,
         snapshot: ProjectSnapshot<'_>,
         context: &FileContext,
         range: ls_types::Range,
@@ -832,16 +899,66 @@ impl EngineWorker {
             .context("LSP engine is not initialized")
     }
 
+    fn with_query_snapshot<T>(
+        &mut self,
+        dirty: Option<&DirtyDocumentSnapshot>,
+        query: impl FnOnce(ProjectSnapshot<'_>) -> anyhow::Result<T>,
+    ) -> anyhow::Result<T> {
+        let project = match dirty {
+            Some(dirty) => self.dirty_overlay_project(dirty)?,
+            None => {
+                self.dirty_overlay = None;
+                self.project
+                    .as_ref()
+                    .context("LSP engine is not initialized")?
+            }
+        };
+
+        query(project.snapshot())
+    }
+
+    fn dirty_overlay_project(&mut self, dirty: &DirtyDocumentSnapshot) -> anyhow::Result<&Project> {
+        let key = DirtyOverlayKey::from_snapshot(dirty);
+        let should_rebuild = match &self.dirty_overlay {
+            Some(cached) => cached.key != key,
+            None => true,
+        };
+
+        if should_rebuild {
+            let base = self
+                .project
+                .as_ref()
+                .context("LSP engine is not initialized")?;
+            let project = base
+                .dirty_overlay([DirtyFileChange::new(dirty.path(), dirty.text().to_string())])
+                .with_context(|| {
+                    format!(
+                        "while attempting to build dirty analysis overlay for {}",
+                        dirty.path().display()
+                    )
+                })?
+                .unwrap_or_else(|| base.clone());
+            self.dirty_overlay = Some(CachedDirtyOverlay { key, project });
+        }
+
+        Ok(&self
+            .dirty_overlay
+            .as_ref()
+            .expect("dirty overlay should be cached after successful build")
+            .project)
+    }
+
     /// Runs a read-only request, responds immediately, then heals disposable cache failures.
     fn respond_to_query<T>(
         &mut self,
         label: &'static str,
         respond_to: EngineResponse<T>,
-        query: impl FnOnce(&Self) -> anyhow::Result<T>,
+        query: impl FnOnce(&mut Self) -> anyhow::Result<T>,
     ) where
         T: Send + 'static,
     {
-        let result = MemoryReporter::report_op(self.memory_control.as_ref(), label, || query(self));
+        let memory_control = Arc::clone(&self.memory_control);
+        let result = MemoryReporter::report_op(memory_control.as_ref(), label, || query(self));
         let should_recover = result
             .as_ref()
             .err()
@@ -871,6 +988,7 @@ impl EngineWorker {
 
         match project.recover_after_cache_load_failure() {
             Ok(()) => {
+                self.dirty_overlay = None;
                 let snapshot = project.snapshot();
                 Self::post_project_build(
                     self.memory_control.as_ref(),

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -13,11 +13,12 @@ use rg_project::{CacheProbeProfile, FileContext, Project, ProjectSnapshot, Saved
 use rg_workspace::{CargoMetadataTarget, SysrootSources, WorkspaceMetadata};
 
 use crate::{
-    dirty_state::{DirtyDocumentIdentity, DirtyOverlayCache, DirtyState},
+    dirty_state::{DirtyDocumentIdentity, DirtyState},
     documents::DirtyDocumentSnapshot,
     engine::{
         QueuedEngineCommand,
         command::{EngineCommand, EngineResponse},
+        project_proxy::ProjectProxy,
     },
     memory::{MemoryControl, MemoryReporter},
     project_stats::{ProjectStats, log_retained_memory},
@@ -26,8 +27,7 @@ use crate::{
 
 #[derive(Debug)]
 pub(super) struct EngineWorker {
-    project: Option<Project>,
-    dirty_overlay: DirtyOverlayCache,
+    project: ProjectProxy,
     dirty_state: DirtyState,
     memory_control: Arc<dyn MemoryControl>,
 }
@@ -70,8 +70,7 @@ impl QueryContext {
 impl EngineWorker {
     pub(super) fn new(memory_control: Arc<dyn MemoryControl>, dirty_state: DirtyState) -> Self {
         Self {
-            project: None,
-            dirty_overlay: DirtyOverlayCache::new(Arc::clone(&memory_control)),
+            project: ProjectProxy::new(Arc::clone(&memory_control)),
             dirty_state,
             memory_control,
         }
@@ -357,12 +356,8 @@ impl EngineWorker {
                 .profile()
                 .and_then(|profile| profile.cache_probe()),
         );
-        let project = project_build.into_project();
-        let snapshot = project.snapshot();
-        Self::log_project_snapshot(snapshot, "initial index");
-
-        self.project = Some(project);
-        self.dirty_overlay.clear();
+        self.project.replace_saved(project_build.into_project());
+        Self::log_project_snapshot(self.project.saved_snapshot()?, "initial index");
         tracing::info!(
             workspace_root = %workspace_root.display(),
             elapsed_ms = started.elapsed().as_millis(),
@@ -374,17 +369,14 @@ impl EngineWorker {
 
     fn reindex_workspace(&mut self) -> anyhow::Result<()> {
         let started = Instant::now();
-        let project = self
-            .project
-            .as_mut()
-            .context("LSP engine is not initialized")?;
 
         tracing::info!("manual workspace reindex started");
-        project
-            .reindex_workspace()
-            .context("while attempting to manually reindex workspace")?;
-        self.dirty_overlay.clear();
-        Self::log_project_snapshot(project.snapshot(), "manual reindex");
+        self.project.mutate_saved(|project| {
+            project
+                .reindex_workspace()
+                .context("while attempting to manually reindex workspace")
+        })?;
+        Self::log_project_snapshot(self.project.saved_snapshot()?, "manual reindex");
         tracing::info!(
             elapsed_ms = started.elapsed().as_millis(),
             "manual workspace reindex finished"
@@ -396,10 +388,6 @@ impl EngineWorker {
     fn did_save(&mut self, path: PathBuf, text: Option<String>) -> anyhow::Result<()> {
         let started = Instant::now();
         let memory_control = Arc::clone(&self.memory_control);
-        let project = self
-            .project
-            .as_mut()
-            .context("LSP engine is not initialized")?;
 
         tracing::info!(
             path = %path.display(),
@@ -407,10 +395,11 @@ impl EngineWorker {
             "processing saved file"
         );
 
-        let summary = project
-            .apply_change(SavedFileChange::new(&path))
-            .context("while attempting to apply saved file change")?;
-        self.dirty_overlay.clear();
+        let summary = self.project.mutate_saved(|project| {
+            project
+                .apply_change(SavedFileChange::new(&path))
+                .context("while attempting to apply saved file change")
+        })?;
         tracing::info!(
             path = %path.display(),
             changed_files = summary.changed_files.len(),
@@ -422,7 +411,7 @@ impl EngineWorker {
         // Saved-file reindexing is the point where temporary analysis memory can legitimately
         // spike. Purging here keeps idle memory low without making every read-only query cold.
         MemoryReporter::purge_and_report(memory_control.as_ref(), "after save");
-        Self::log_project_snapshot(project.snapshot(), "after save");
+        Self::log_project_snapshot(self.project.saved_snapshot()?, "after save");
 
         Ok(())
     }
@@ -464,38 +453,41 @@ impl EngineWorker {
         let started = Instant::now();
         // Dirty overlays lower Body IR only for dirty files. Cross-file body references are
         // intentionally best-effort until the buffer is saved and the normal project catches up.
-        let locations = self.with_query_snapshot(dirty.as_ref(), |snapshot| {
-            let target_offsets = Self::target_offsets(snapshot, &path, position)?;
-            let analysis = snapshot.full_analysis()?;
-            let mut locations = Vec::new();
+        let locations = self
+            .project
+            .with_query_snapshot(dirty.as_ref(), |snapshot| {
+                let target_offsets = Self::target_offsets(snapshot, &path, position)?;
+                let analysis = snapshot.full_analysis()?;
+                let mut locations = Vec::new();
 
-            for (context, target, offset) in target_offsets {
-                let declaration_targets = analysis
-                    .goto_definition(target, context.file, offset)?
-                    .into_iter()
-                    .map(|target| target.target)
-                    .collect::<Vec<_>>();
-                let search_targets =
-                    snapshot.reference_search_targets(context.package, &declaration_targets);
+                for (context, target, offset) in target_offsets {
+                    let declaration_targets = analysis
+                        .goto_definition(target, context.file, offset)?
+                        .into_iter()
+                        .map(|target| target.target)
+                        .collect::<Vec<_>>();
+                    let search_targets =
+                        snapshot.reference_search_targets(context.package, &declaration_targets);
 
-                for reference in analysis.references(
-                    target,
-                    context.file,
-                    offset,
-                    ReferenceQuery::find_references(&search_targets, include_declaration),
-                )? {
-                    let Some(location) = references::location_for_reference(snapshot, &reference)?
-                    else {
-                        continue;
-                    };
-                    if !locations.contains(&location) {
-                        locations.push(location);
+                    for reference in analysis.references(
+                        target,
+                        context.file,
+                        offset,
+                        ReferenceQuery::find_references(&search_targets, include_declaration),
+                    )? {
+                        let Some(location) =
+                            references::location_for_reference(snapshot, &reference)?
+                        else {
+                            continue;
+                        };
+                        if !locations.contains(&location) {
+                            locations.push(location);
+                        }
                     }
                 }
-            }
 
-            Ok(locations)
-        })?;
+                Ok(locations)
+            })?;
 
         tracing::debug!(
             path = %path.display(),
@@ -517,43 +509,45 @@ impl EngineWorker {
         dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::DocumentHighlight>> {
         let started = Instant::now();
-        let highlights = self.with_query_snapshot(dirty.as_ref(), |snapshot| {
-            let target_offsets = Self::target_offsets(snapshot, &path, position)?;
+        let highlights = self
+            .project
+            .with_query_snapshot(dirty.as_ref(), |snapshot| {
+                let target_offsets = Self::target_offsets(snapshot, &path, position)?;
 
-            let analysis_targets = target_offsets
-                .iter()
-                .map(|(_, target, _)| *target)
-                .collect::<Vec<_>>();
-            let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
-            let mut highlights = Vec::new();
+                let analysis_targets = target_offsets
+                    .iter()
+                    .map(|(_, target, _)| *target)
+                    .collect::<Vec<_>>();
+                let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
+                let mut highlights = Vec::new();
 
-            for (context, target, offset) in target_offsets {
-                for reference in analysis.references(
-                    target,
-                    context.file,
-                    offset,
-                    ReferenceQuery::file_scoped(target, context.file),
-                )? {
-                    if reference.target.package != context.package
-                        || reference.file_id != context.file
-                    {
-                        continue;
-                    }
-
-                    let highlight = references::document_highlight_for_reference(
-                        snapshot,
-                        context.package,
+                for (context, target, offset) in target_offsets {
+                    for reference in analysis.references(
+                        target,
                         context.file,
-                        reference.span,
-                    )?;
-                    if !highlights.contains(&highlight) {
-                        highlights.push(highlight);
+                        offset,
+                        ReferenceQuery::file_scoped(target, context.file),
+                    )? {
+                        if reference.target.package != context.package
+                            || reference.file_id != context.file
+                        {
+                            continue;
+                        }
+
+                        let highlight = references::document_highlight_for_reference(
+                            snapshot,
+                            context.package,
+                            context.file,
+                            reference.span,
+                        )?;
+                        if !highlights.contains(&highlight) {
+                            highlights.push(highlight);
+                        }
                     }
                 }
-            }
 
-            Ok(highlights)
-        })?;
+                Ok(highlights)
+            })?;
 
         tracing::debug!(
             path = %path.display(),
@@ -574,26 +568,28 @@ impl EngineWorker {
         dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::CompletionItem>> {
         let started = Instant::now();
-        let completions = self.with_query_snapshot(dirty.as_ref(), |snapshot| {
-            let target_offsets = Self::target_offsets(snapshot, &path, position)?;
-            let analysis_targets = target_offsets
-                .iter()
-                .map(|(_, target, _)| *target)
-                .collect::<Vec<_>>();
-            let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
-            let mut completions = Vec::new();
+        let completions = self
+            .project
+            .with_query_snapshot(dirty.as_ref(), |snapshot| {
+                let target_offsets = Self::target_offsets(snapshot, &path, position)?;
+                let analysis_targets = target_offsets
+                    .iter()
+                    .map(|(_, target, _)| *target)
+                    .collect::<Vec<_>>();
+                let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
+                let mut completions = Vec::new();
 
-            for (context, target, offset) in target_offsets {
-                for item in analysis.completions_at_dot(target, context.file, offset)? {
-                    let item = completion::completion_item(item);
-                    if !completions.contains(&item) {
-                        completions.push(item);
+                for (context, target, offset) in target_offsets {
+                    for item in analysis.completions_at_dot(target, context.file, offset)? {
+                        let item = completion::completion_item(item);
+                        if !completions.contains(&item) {
+                            completions.push(item);
+                        }
                     }
                 }
-            }
 
-            Ok(completions)
-        })?;
+                Ok(completions)
+            })?;
 
         tracing::debug!(
             path = %path.display(),
@@ -614,30 +610,32 @@ impl EngineWorker {
         dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Option<ls_types::Hover>> {
         let started = Instant::now();
-        let hover = self.with_query_snapshot(dirty.as_ref(), |snapshot| {
-            let target_offsets = Self::target_offsets(snapshot, &path, position)?;
-            let analysis_targets = target_offsets
-                .iter()
-                .map(|(_, target, _)| *target)
-                .collect::<Vec<_>>();
-            let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
+        let hover = self
+            .project
+            .with_query_snapshot(dirty.as_ref(), |snapshot| {
+                let target_offsets = Self::target_offsets(snapshot, &path, position)?;
+                let analysis_targets = target_offsets
+                    .iter()
+                    .map(|(_, target, _)| *target)
+                    .collect::<Vec<_>>();
+                let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
 
-            for (context, target, offset) in target_offsets {
-                let Some(info) = analysis.hover(target, context.file, offset)? else {
-                    continue;
-                };
-                let Some(line_index) = snapshot.file_line_index(context.package, context.file)
-                else {
-                    continue;
-                };
-                let Some(hover) = hover::hover(info, line_index) else {
-                    continue;
-                };
-                return Ok(Some(hover));
-            }
+                for (context, target, offset) in target_offsets {
+                    let Some(info) = analysis.hover(target, context.file, offset)? else {
+                        continue;
+                    };
+                    let Some(line_index) = snapshot.file_line_index(context.package, context.file)
+                    else {
+                        continue;
+                    };
+                    let Some(hover) = hover::hover(info, line_index) else {
+                        continue;
+                    };
+                    return Ok(Some(hover));
+                }
 
-            Ok(None)
-        })?;
+                Ok(None)
+            })?;
 
         tracing::debug!(
             path = %path.display(),
@@ -656,29 +654,32 @@ impl EngineWorker {
         dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::DocumentSymbol>> {
         let started = Instant::now();
-        let lsp_symbols = self.with_query_snapshot(dirty.as_ref(), |snapshot| {
-            let contexts = Self::file_contexts(snapshot, &path)?;
-            let analysis_targets = contexts
-                .iter()
-                .flat_map(|context| context.targets.iter().copied())
-                .collect::<Vec<_>>();
-            let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
-            let mut lsp_symbols = Vec::new();
+        let lsp_symbols = self
+            .project
+            .with_query_snapshot(dirty.as_ref(), |snapshot| {
+                let contexts = Self::file_contexts(snapshot, &path)?;
+                let analysis_targets = contexts
+                    .iter()
+                    .flat_map(|context| context.targets.iter().copied())
+                    .collect::<Vec<_>>();
+                let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
+                let mut lsp_symbols = Vec::new();
 
-            for context in contexts {
-                for target in context.targets {
-                    let symbols = analysis.document_symbols(target, context.file)?;
-                    for symbol in symbols {
-                        let symbol = symbols::document_symbol(snapshot, context.package, symbol)?;
-                        if !lsp_symbols.contains(&symbol) {
-                            lsp_symbols.push(symbol);
+                for context in contexts {
+                    for target in context.targets {
+                        let symbols = analysis.document_symbols(target, context.file)?;
+                        for symbol in symbols {
+                            let symbol =
+                                symbols::document_symbol(snapshot, context.package, symbol)?;
+                            if !lsp_symbols.contains(&symbol) {
+                                lsp_symbols.push(symbol);
+                            }
                         }
                     }
                 }
-            }
 
-            Ok(lsp_symbols)
-        })?;
+                Ok(lsp_symbols)
+            })?;
 
         tracing::debug!(
             path = %path.display(),
@@ -697,42 +698,44 @@ impl EngineWorker {
         dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::InlayHint>> {
         let started = Instant::now();
-        let lsp_hints = self.with_query_snapshot(dirty.as_ref(), |snapshot| {
-            let contexts = Self::file_contexts(snapshot, &path)?;
-            let analysis_targets = contexts
-                .iter()
-                .flat_map(|context| context.targets.iter().copied())
-                .collect::<Vec<_>>();
-            let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
-            let mut hints = Vec::<(rg_def_map::PackageSlot, TypeHint)>::new();
+        let lsp_hints = self
+            .project
+            .with_query_snapshot(dirty.as_ref(), |snapshot| {
+                let contexts = Self::file_contexts(snapshot, &path)?;
+                let analysis_targets = contexts
+                    .iter()
+                    .flat_map(|context| context.targets.iter().copied())
+                    .collect::<Vec<_>>();
+                let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
+                let mut hints = Vec::<(rg_def_map::PackageSlot, TypeHint)>::new();
 
-            for context in contexts {
-                let Some(range) = Self::text_span_for_context(snapshot, &context, range) else {
-                    continue;
-                };
+                for context in contexts {
+                    let Some(range) = Self::text_span_for_context(snapshot, &context, range) else {
+                        continue;
+                    };
 
-                for target in context.targets {
-                    for hint in analysis.type_hints(target, context.file, Some(range))? {
-                        if !hints
-                            .iter()
-                            .any(|(_, existing_hint)| existing_hint == &hint)
-                        {
-                            hints.push((context.package, hint));
+                    for target in context.targets {
+                        for hint in analysis.type_hints(target, context.file, Some(range))? {
+                            if !hints
+                                .iter()
+                                .any(|(_, existing_hint)| existing_hint == &hint)
+                            {
+                                hints.push((context.package, hint));
+                            }
                         }
                     }
                 }
-            }
 
-            let mut lsp_hints = Vec::new();
-            for (package, hint) in hints {
-                let Some(hint) = inlay_hint::type_hint(snapshot, package, hint)? else {
-                    continue;
-                };
-                lsp_hints.push(hint);
-            }
+                let mut lsp_hints = Vec::new();
+                for (package, hint) in hints {
+                    let Some(hint) = inlay_hint::type_hint(snapshot, package, hint)? else {
+                        continue;
+                    };
+                    lsp_hints.push(hint);
+                }
 
-            Ok(lsp_hints)
-        })?;
+                Ok(lsp_hints)
+            })?;
 
         tracing::debug!(
             path = %path.display(),
@@ -746,7 +749,7 @@ impl EngineWorker {
 
     fn workspace_symbol(&self, query: &str) -> anyhow::Result<Vec<ls_types::WorkspaceSymbol>> {
         let started = Instant::now();
-        let snapshot = self.snapshot()?;
+        let snapshot = self.project.saved_snapshot()?;
         let analysis = snapshot.full_analysis()?;
         let mut lsp_symbols = Vec::new();
 
@@ -777,40 +780,43 @@ impl EngineWorker {
         dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::Location>> {
         let started = Instant::now();
-        let locations = self.with_query_snapshot(dirty.as_ref(), |snapshot| {
-            let target_offsets = Self::target_offsets(snapshot, &path, position)?;
-            let analysis_targets = target_offsets
-                .iter()
-                .map(|(_, target, _)| *target)
-                .collect::<Vec<_>>();
-            let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
-            let mut locations = Vec::new();
+        let locations = self
+            .project
+            .with_query_snapshot(dirty.as_ref(), |snapshot| {
+                let target_offsets = Self::target_offsets(snapshot, &path, position)?;
+                let analysis_targets = target_offsets
+                    .iter()
+                    .map(|(_, target, _)| *target)
+                    .collect::<Vec<_>>();
+                let analysis = snapshot.analysis_for_targets(&analysis_targets)?;
+                let mut locations = Vec::new();
 
-            for (context, target, offset) in target_offsets {
-                let targets = match query {
-                    NavigationQuery::Definition => {
-                        analysis.goto_definition(target, context.file, offset)?
-                    }
-                    NavigationQuery::TypeDefinition => {
-                        analysis.goto_type_definition(target, context.file, offset)?
-                    }
-                    NavigationQuery::Implementation => {
-                        analysis.goto_implementation(target, context.file, offset)?
-                    }
-                };
-
-                for target in targets {
-                    let Some(location) = navigation::location_for_target(snapshot, &target)? else {
-                        continue;
+                for (context, target, offset) in target_offsets {
+                    let targets = match query {
+                        NavigationQuery::Definition => {
+                            analysis.goto_definition(target, context.file, offset)?
+                        }
+                        NavigationQuery::TypeDefinition => {
+                            analysis.goto_type_definition(target, context.file, offset)?
+                        }
+                        NavigationQuery::Implementation => {
+                            analysis.goto_implementation(target, context.file, offset)?
+                        }
                     };
-                    if !locations.contains(&location) {
-                        locations.push(location);
+
+                    for target in targets {
+                        let Some(location) = navigation::location_for_target(snapshot, &target)?
+                        else {
+                            continue;
+                        };
+                        if !locations.contains(&location) {
+                            locations.push(location);
+                        }
                     }
                 }
-            }
 
-            Ok(locations)
-        })?;
+                Ok(locations)
+            })?;
 
         tracing::debug!(
             query = query.name(),
@@ -934,37 +940,6 @@ impl EngineWorker {
         Some(span)
     }
 
-    fn snapshot(&self) -> anyhow::Result<ProjectSnapshot<'_>> {
-        self.project
-            .as_ref()
-            .map(Project::snapshot)
-            .context("LSP engine is not initialized")
-    }
-
-    fn with_query_snapshot<T>(
-        &mut self,
-        dirty: Option<&DirtyDocumentSnapshot>,
-        query: impl FnOnce(ProjectSnapshot<'_>) -> anyhow::Result<T>,
-    ) -> anyhow::Result<T> {
-        let project = match dirty {
-            Some(dirty) => {
-                let base = self
-                    .project
-                    .as_ref()
-                    .context("LSP engine is not initialized")?;
-                self.dirty_overlay.project_for_dirty(base, dirty)?
-            }
-            None => {
-                self.dirty_overlay.clear();
-                self.project
-                    .as_ref()
-                    .context("LSP engine is not initialized")?
-            }
-        };
-
-        query(project.snapshot())
-    }
-
     /// Runs a read-only request, responds immediately, then heals disposable cache failures.
     fn respond_to_query<T>(
         &mut self,
@@ -1033,13 +1008,13 @@ impl EngineWorker {
     }
 
     fn recover_after_query_cache_failure(&mut self, label: &'static str) {
-        let Some(project) = self.project.as_mut() else {
+        if !self.project.is_initialized() {
             tracing::warn!(
                 label,
                 "analysis query hit invalid package cache before project initialization"
             );
             return;
-        };
+        }
 
         let started = Instant::now();
         tracing::warn!(
@@ -1047,10 +1022,15 @@ impl EngineWorker {
             "analysis query hit invalid package cache; rebuilding cache before next command"
         );
 
-        match project.recover_after_cache_load_failure() {
+        match self
+            .project
+            .mutate_saved(|project| project.recover_after_cache_load_failure())
+        {
             Ok(()) => {
-                self.dirty_overlay.clear();
-                let snapshot = project.snapshot();
+                let snapshot = self
+                    .project
+                    .saved_snapshot()
+                    .expect("project should remain initialized after cache recovery");
                 Self::log_project_snapshot(snapshot, "after package cache recovery");
                 tracing::info!(
                     label,

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -1,7 +1,7 @@
 use std::{
     path::{Path, PathBuf},
     sync::{Arc, mpsc::Receiver},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use anyhow::Context as _;
@@ -16,7 +16,10 @@ use rg_workspace::{CargoMetadataTarget, SysrootSources, WorkspaceMetadata};
 
 use crate::{
     documents::{DirtyDocumentSnapshot, TextFingerprint},
-    engine::command::{EngineCommand, EngineResponse},
+    engine::{
+        QueuedEngineCommand,
+        command::{EngineCommand, EngineResponse},
+    },
     memory::{MemoryControl, MemoryReporter},
     project_stats::{ProjectStats, log_retained_memory},
     proto::{completion, hover, inlay_hint, navigation, position, references, symbols},
@@ -61,10 +64,12 @@ impl EngineWorker {
         }
     }
 
-    pub(super) fn run(mut self, receiver: Receiver<EngineCommand>) {
+    pub(super) fn run(mut self, receiver: Receiver<QueuedEngineCommand>) {
         tracing::debug!("LSP engine worker started");
 
-        while let Ok(command) = receiver.recv() {
+        while let Ok(queued) = receiver.recv() {
+            let queue_elapsed = queued.enqueued_at.elapsed();
+            let command = queued.command;
             match command {
                 EngineCommand::Initialize {
                     root,
@@ -99,7 +104,7 @@ impl EngineWorker {
                         character = position.character,
                         "engine command started: goto_definition"
                     );
-                    self.respond_to_query("goto_definition", respond_to, |worker| {
+                    self.respond_to_query("goto_definition", queue_elapsed, respond_to, |worker| {
                         worker.goto_definition(path, position, dirty)
                     });
                 }
@@ -115,9 +120,12 @@ impl EngineWorker {
                         character = position.character,
                         "engine command started: goto_type_definition"
                     );
-                    self.respond_to_query("goto_type_definition", respond_to, |worker| {
-                        worker.goto_type_definition(path, position, dirty)
-                    });
+                    self.respond_to_query(
+                        "goto_type_definition",
+                        queue_elapsed,
+                        respond_to,
+                        |worker| worker.goto_type_definition(path, position, dirty),
+                    );
                 }
                 EngineCommand::GotoImplementation {
                     path,
@@ -131,9 +139,12 @@ impl EngineWorker {
                         character = position.character,
                         "engine command started: goto_implementation"
                     );
-                    self.respond_to_query("goto_implementation", respond_to, |worker| {
-                        worker.goto_implementation(path, position, dirty)
-                    });
+                    self.respond_to_query(
+                        "goto_implementation",
+                        queue_elapsed,
+                        respond_to,
+                        |worker| worker.goto_implementation(path, position, dirty),
+                    );
                 }
                 EngineCommand::References {
                     path,
@@ -149,7 +160,7 @@ impl EngineWorker {
                         include_declaration,
                         "engine command started: references"
                     );
-                    self.respond_to_query("references", respond_to, |worker| {
+                    self.respond_to_query("references", queue_elapsed, respond_to, |worker| {
                         worker.references(path, position, include_declaration, dirty)
                     });
                 }
@@ -165,9 +176,12 @@ impl EngineWorker {
                         character = position.character,
                         "engine command started: document_highlight"
                     );
-                    self.respond_to_query("document_highlight", respond_to, |worker| {
-                        worker.document_highlight(path, position, dirty)
-                    });
+                    self.respond_to_query(
+                        "document_highlight",
+                        queue_elapsed,
+                        respond_to,
+                        |worker| worker.document_highlight(path, position, dirty),
+                    );
                 }
                 EngineCommand::Hover {
                     path,
@@ -181,7 +195,7 @@ impl EngineWorker {
                         character = position.character,
                         "engine command started: hover"
                     );
-                    self.respond_to_query("hover", respond_to, |worker| {
+                    self.respond_to_query("hover", queue_elapsed, respond_to, |worker| {
                         worker.hover(path, position, dirty)
                     });
                 }
@@ -197,7 +211,7 @@ impl EngineWorker {
                         character = position.character,
                         "engine command started: completion"
                     );
-                    self.respond_to_query("completion", respond_to, |worker| {
+                    self.respond_to_query("completion", queue_elapsed, respond_to, |worker| {
                         worker.completion(path, position, dirty)
                     });
                 }
@@ -210,7 +224,7 @@ impl EngineWorker {
                         path = %path.display(),
                         "engine command started: document_symbol"
                     );
-                    self.respond_to_query("document_symbol", respond_to, |worker| {
+                    self.respond_to_query("document_symbol", queue_elapsed, respond_to, |worker| {
                         worker.document_symbol(path, dirty)
                     });
                 }
@@ -228,15 +242,18 @@ impl EngineWorker {
                         end_character = range.end.character,
                         "engine command started: inlay_hint"
                     );
-                    self.respond_to_query("inlay_hint", respond_to, |worker| {
+                    self.respond_to_query("inlay_hint", queue_elapsed, respond_to, |worker| {
                         worker.inlay_hint(path, range, dirty)
                     });
                 }
                 EngineCommand::WorkspaceSymbol { query, respond_to } => {
                     tracing::trace!(query = %query, "engine command started: workspace_symbol");
-                    self.respond_to_query("workspace_symbol", respond_to, |worker| {
-                        worker.workspace_symbol(&query)
-                    });
+                    self.respond_to_query(
+                        "workspace_symbol",
+                        queue_elapsed,
+                        respond_to,
+                        |worker| worker.workspace_symbol(&query),
+                    );
                 }
                 EngineCommand::ReindexWorkspace { respond_to } => {
                     tracing::trace!("engine command started: reindex_workspace");
@@ -927,20 +944,40 @@ impl EngineWorker {
         };
 
         if should_rebuild {
+            let started = Instant::now();
             let base = self
                 .project
                 .as_ref()
                 .context("LSP engine is not initialized")?;
-            let project = base
+            let overlay = base
                 .dirty_overlay([DirtyFileChange::new(dirty.path(), dirty.text().to_string())])
                 .with_context(|| {
                     format!(
                         "while attempting to build dirty analysis overlay for {}",
                         dirty.path().display()
                     )
-                })?
-                .unwrap_or_else(|| base.clone());
+                })?;
+            let changed_known_file = overlay.is_some();
+            let project = overlay.unwrap_or_else(|| base.clone());
+            tracing::debug!(
+                path = %dirty.path().display(),
+                version = ?dirty.version(),
+                text_len = dirty.text().len(),
+                dirty_overlay_cache_hit = false,
+                dirty_overlay_changed_known_file = changed_known_file,
+                dirty_overlay_build_ms = started.elapsed().as_millis(),
+                "dirty analysis overlay rebuilt"
+            );
             self.dirty_overlay = Some(CachedDirtyOverlay { key, project });
+        } else {
+            tracing::debug!(
+                path = %dirty.path().display(),
+                version = ?dirty.version(),
+                text_len = dirty.text().len(),
+                dirty_overlay_cache_hit = true,
+                dirty_overlay_build_ms = 0_u128,
+                "dirty analysis overlay cache hit"
+            );
         }
 
         Ok(&self
@@ -954,17 +991,33 @@ impl EngineWorker {
     fn respond_to_query<T>(
         &mut self,
         label: &'static str,
+        queue_elapsed: Duration,
         respond_to: EngineResponse<T>,
         query: impl FnOnce(&mut Self) -> anyhow::Result<T>,
     ) where
         T: Send + 'static,
     {
         let memory_control = Arc::clone(&self.memory_control);
+        tracing::debug!(
+            label,
+            queued_ms = queue_elapsed.as_millis(),
+            "analysis query dequeued"
+        );
+        let started = Instant::now();
         let result = MemoryReporter::report_op(memory_control.as_ref(), label, || query(self));
+        let query_elapsed = started.elapsed();
         let should_recover = result
             .as_ref()
             .err()
             .is_some_and(Project::is_recoverable_cache_load_failure);
+        tracing::debug!(
+            label,
+            queued_ms = queue_elapsed.as_millis(),
+            query_elapsed_ms = query_elapsed.as_millis(),
+            result_ok = result.is_ok(),
+            recoverable_cache_failure = should_recover,
+            "analysis query finished"
+        );
 
         let _ = respond_to.send(result);
 

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -372,7 +372,7 @@ impl EngineWorker {
         );
         let project = project_build.into_project();
         let snapshot = project.snapshot();
-        Self::post_project_build(self.memory_control.as_ref(), snapshot, "initial index");
+        Self::log_project_snapshot(snapshot, "initial index");
 
         self.project = Some(project);
         self.dirty_overlay = None;
@@ -387,7 +387,6 @@ impl EngineWorker {
 
     fn reindex_workspace(&mut self) -> anyhow::Result<()> {
         let started = Instant::now();
-        let memory_control = Arc::clone(&self.memory_control);
         let project = self
             .project
             .as_mut()
@@ -398,11 +397,7 @@ impl EngineWorker {
             .reindex_workspace()
             .context("while attempting to manually reindex workspace")?;
         self.dirty_overlay = None;
-        Self::post_project_build(
-            memory_control.as_ref(),
-            project.snapshot(),
-            "manual reindex",
-        );
+        Self::log_project_snapshot(project.snapshot(), "manual reindex");
         tracing::info!(
             elapsed_ms = started.elapsed().as_millis(),
             "manual workspace reindex finished"
@@ -437,7 +432,10 @@ impl EngineWorker {
             elapsed_ms = started.elapsed().as_millis(),
             "saved file reindex finished"
         );
-        Self::post_project_build(memory_control.as_ref(), project.snapshot(), "after save");
+        // Saved-file reindexing is the point where temporary analysis memory can legitimately
+        // spike. Purging here keeps idle memory low without making every read-only query cold.
+        MemoryReporter::purge_and_report(memory_control.as_ref(), "after save");
+        Self::log_project_snapshot(project.snapshot(), "after save");
 
         Ok(())
     }
@@ -987,6 +985,11 @@ impl EngineWorker {
                 .project
                 .as_ref()
                 .context("LSP engine is not initialized")?;
+            let memory_before = MemoryReporter::log_checkpoint(
+                self.memory_control.as_ref(),
+                "dirty_overlay",
+                "before_rebuild",
+            );
             let overlay = base
                 .dirty_overlay([DirtyFileChange::new(dirty.path(), dirty.text().to_string())])
                 .with_context(|| {
@@ -995,6 +998,16 @@ impl EngineWorker {
                         dirty.path().display()
                     )
                 })?;
+            MemoryReporter::log_checkpoint_delta(
+                self.memory_control.as_ref(),
+                "dirty_overlay",
+                "after_rebuild",
+                memory_before,
+            );
+            // Dirty overlay rebuilds can temporarily materialize much more allocator memory than
+            // the retained overlay needs. Purge at this rebuild boundary without making every
+            // read-only query pay the same cost.
+            MemoryReporter::purge_and_report(self.memory_control.as_ref(), "after dirty overlay");
             let changed_known_file = overlay.is_some();
             let project = overlay.unwrap_or_else(|| base.clone());
             tracing::debug!(
@@ -1051,19 +1064,27 @@ impl EngineWorker {
         }
 
         // From here on, clean and current-dirty requests share the same execution path. Keeping the
-        // stale check in the context layer lets timing, memory reporting, and cache recovery remain
-        // uniform for every analysis query.
+        // stale check in the context layer lets timing and cache recovery remain uniform for every
+        // analysis query.
         let label = context.label;
         let queue_elapsed = context.queue_elapsed;
-        let memory_control = Arc::clone(&self.memory_control);
         tracing::debug!(
             label,
             queued_ms = queue_elapsed.as_millis(),
             "analysis query dequeued"
         );
         let started = Instant::now();
-        let result = MemoryReporter::report_op(memory_control.as_ref(), label, || query(self));
+        let memory_control = Arc::clone(&self.memory_control);
+        let memory_before =
+            MemoryReporter::log_checkpoint(memory_control.as_ref(), label, "query_before");
+        let result = query(self);
         let query_elapsed = started.elapsed();
+        MemoryReporter::log_checkpoint_delta(
+            memory_control.as_ref(),
+            label,
+            "query_after",
+            memory_before,
+        );
         let should_recover = result
             .as_ref()
             .err()
@@ -1103,11 +1124,7 @@ impl EngineWorker {
             Ok(()) => {
                 self.dirty_overlay = None;
                 let snapshot = project.snapshot();
-                Self::post_project_build(
-                    self.memory_control.as_ref(),
-                    snapshot,
-                    "after package cache recovery",
-                );
+                Self::log_project_snapshot(snapshot, "after package cache recovery");
                 tracing::info!(
                     label,
                     elapsed_ms = started.elapsed().as_millis(),
@@ -1149,15 +1166,8 @@ impl EngineWorker {
         );
     }
 
-    /// Hook for activities to be run after the project (re-)build.
-    fn post_project_build(
-        memory_control: &dyn MemoryControl,
-        snapshot: ProjectSnapshot<'_>,
-        label: &'static str,
-    ) {
-        // Indexing can temporarily materialize most of the project. Once the snapshot is ready for
-        // editor queries, purge allocator caches and report memory separately from project shape.
-        MemoryReporter::report_current(memory_control, label);
+    /// Logs the retained project shape after the analysis project changes.
+    fn log_project_snapshot(snapshot: ProjectSnapshot<'_>, label: &'static str) {
         ProjectStats::capture(snapshot).log_info(label);
         log_retained_memory(snapshot, label);
     }

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -422,6 +422,8 @@ impl EngineWorker {
         dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::Location>> {
         let started = Instant::now();
+        // Dirty overlays lower Body IR only for dirty files. Cross-file body references are
+        // intentionally best-effort until the buffer is saved and the normal project catches up.
         let locations = self.with_query_snapshot(dirty.as_ref(), |snapshot| {
             let target_offsets = Self::target_offsets(snapshot, &path, position)?;
             let analysis = snapshot.full_analysis()?;

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -15,7 +15,7 @@ use rg_project::{
 use rg_workspace::{CargoMetadataTarget, SysrootSources, WorkspaceMetadata};
 
 use crate::{
-    documents::{DirtyDocumentSnapshot, TextFingerprint},
+    documents::{DirtyAnalysisHandle, DirtyDocumentIdentity, DirtyDocumentSnapshot},
     engine::{
         QueuedEngineCommand,
         command::{EngineCommand, EngineResponse},
@@ -29,37 +29,63 @@ use crate::{
 pub(super) struct EngineWorker {
     project: Option<Project>,
     dirty_overlay: Option<CachedDirtyOverlay>,
+    dirty_analysis: DirtyAnalysisHandle,
     memory_control: Arc<dyn MemoryControl>,
 }
 
 #[derive(Debug)]
 struct CachedDirtyOverlay {
-    key: DirtyOverlayKey,
+    identity: DirtyDocumentIdentity,
     project: Project,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct DirtyOverlayKey {
-    path: PathBuf,
-    version: Option<i32>,
-    fingerprint: TextFingerprint,
+#[derive(Debug)]
+struct QueryContext {
+    label: &'static str,
+    queue_elapsed: Duration,
+    dirty_identity: Option<DirtyDocumentIdentity>,
 }
 
-impl DirtyOverlayKey {
-    fn from_snapshot(snapshot: &DirtyDocumentSnapshot) -> Self {
+impl QueryContext {
+    fn new(label: &'static str, queue_elapsed: Duration) -> Self {
         Self {
-            path: snapshot.path().to_path_buf(),
-            version: snapshot.version(),
-            fingerprint: snapshot.fingerprint(),
+            label,
+            queue_elapsed,
+            dirty_identity: None,
         }
+    }
+
+    fn document(
+        label: &'static str,
+        queue_elapsed: Duration,
+        dirty: Option<&DirtyDocumentSnapshot>,
+    ) -> Self {
+        Self {
+            label,
+            queue_elapsed,
+            dirty_identity: dirty.map(DirtyDocumentIdentity::from_snapshot),
+        }
+    }
+
+    fn stale_dirty_identity(
+        &self,
+        dirty_analysis: &DirtyAnalysisHandle,
+    ) -> Option<&DirtyDocumentIdentity> {
+        self.dirty_identity
+            .as_ref()
+            .filter(|identity| !dirty_analysis.is_current_identity(identity))
     }
 }
 
 impl EngineWorker {
-    pub(super) fn new(memory_control: Arc<dyn MemoryControl>) -> Self {
+    pub(super) fn new(
+        memory_control: Arc<dyn MemoryControl>,
+        dirty_analysis: DirtyAnalysisHandle,
+    ) -> Self {
         Self {
             project: None,
             dirty_overlay: None,
+            dirty_analysis,
             memory_control,
         }
     }
@@ -104,7 +130,9 @@ impl EngineWorker {
                         character = position.character,
                         "engine command started: goto_definition"
                     );
-                    self.respond_to_query("goto_definition", queue_elapsed, respond_to, |worker| {
+                    let context =
+                        QueryContext::document("goto_definition", queue_elapsed, dirty.as_ref());
+                    self.respond_to_query(context, respond_to, |worker| {
                         worker.goto_definition(path, position, dirty)
                     });
                 }
@@ -120,12 +148,14 @@ impl EngineWorker {
                         character = position.character,
                         "engine command started: goto_type_definition"
                     );
-                    self.respond_to_query(
+                    let context = QueryContext::document(
                         "goto_type_definition",
                         queue_elapsed,
-                        respond_to,
-                        |worker| worker.goto_type_definition(path, position, dirty),
+                        dirty.as_ref(),
                     );
+                    self.respond_to_query(context, respond_to, |worker| {
+                        worker.goto_type_definition(path, position, dirty)
+                    });
                 }
                 EngineCommand::GotoImplementation {
                     path,
@@ -139,12 +169,14 @@ impl EngineWorker {
                         character = position.character,
                         "engine command started: goto_implementation"
                     );
-                    self.respond_to_query(
+                    let context = QueryContext::document(
                         "goto_implementation",
                         queue_elapsed,
-                        respond_to,
-                        |worker| worker.goto_implementation(path, position, dirty),
+                        dirty.as_ref(),
                     );
+                    self.respond_to_query(context, respond_to, |worker| {
+                        worker.goto_implementation(path, position, dirty)
+                    });
                 }
                 EngineCommand::References {
                     path,
@@ -160,7 +192,9 @@ impl EngineWorker {
                         include_declaration,
                         "engine command started: references"
                     );
-                    self.respond_to_query("references", queue_elapsed, respond_to, |worker| {
+                    let context =
+                        QueryContext::document("references", queue_elapsed, dirty.as_ref());
+                    self.respond_to_query(context, respond_to, |worker| {
                         worker.references(path, position, include_declaration, dirty)
                     });
                 }
@@ -176,12 +210,11 @@ impl EngineWorker {
                         character = position.character,
                         "engine command started: document_highlight"
                     );
-                    self.respond_to_query(
-                        "document_highlight",
-                        queue_elapsed,
-                        respond_to,
-                        |worker| worker.document_highlight(path, position, dirty),
-                    );
+                    let context =
+                        QueryContext::document("document_highlight", queue_elapsed, dirty.as_ref());
+                    self.respond_to_query(context, respond_to, |worker| {
+                        worker.document_highlight(path, position, dirty)
+                    });
                 }
                 EngineCommand::Hover {
                     path,
@@ -195,7 +228,8 @@ impl EngineWorker {
                         character = position.character,
                         "engine command started: hover"
                     );
-                    self.respond_to_query("hover", queue_elapsed, respond_to, |worker| {
+                    let context = QueryContext::document("hover", queue_elapsed, dirty.as_ref());
+                    self.respond_to_query(context, respond_to, |worker| {
                         worker.hover(path, position, dirty)
                     });
                 }
@@ -211,7 +245,9 @@ impl EngineWorker {
                         character = position.character,
                         "engine command started: completion"
                     );
-                    self.respond_to_query("completion", queue_elapsed, respond_to, |worker| {
+                    let context =
+                        QueryContext::document("completion", queue_elapsed, dirty.as_ref());
+                    self.respond_to_query(context, respond_to, |worker| {
                         worker.completion(path, position, dirty)
                     });
                 }
@@ -224,7 +260,9 @@ impl EngineWorker {
                         path = %path.display(),
                         "engine command started: document_symbol"
                     );
-                    self.respond_to_query("document_symbol", queue_elapsed, respond_to, |worker| {
+                    let context =
+                        QueryContext::document("document_symbol", queue_elapsed, dirty.as_ref());
+                    self.respond_to_query(context, respond_to, |worker| {
                         worker.document_symbol(path, dirty)
                     });
                 }
@@ -242,18 +280,18 @@ impl EngineWorker {
                         end_character = range.end.character,
                         "engine command started: inlay_hint"
                     );
-                    self.respond_to_query("inlay_hint", queue_elapsed, respond_to, |worker| {
+                    let context =
+                        QueryContext::document("inlay_hint", queue_elapsed, dirty.as_ref());
+                    self.respond_to_query(context, respond_to, |worker| {
                         worker.inlay_hint(path, range, dirty)
                     });
                 }
                 EngineCommand::WorkspaceSymbol { query, respond_to } => {
                     tracing::trace!(query = %query, "engine command started: workspace_symbol");
-                    self.respond_to_query(
-                        "workspace_symbol",
-                        queue_elapsed,
-                        respond_to,
-                        |worker| worker.workspace_symbol(&query),
-                    );
+                    let context = QueryContext::new("workspace_symbol", queue_elapsed);
+                    self.respond_to_query(context, respond_to, |worker| {
+                        worker.workspace_symbol(&query)
+                    });
                 }
                 EngineCommand::ReindexWorkspace { respond_to } => {
                     tracing::trace!("engine command started: reindex_workspace");
@@ -937,9 +975,9 @@ impl EngineWorker {
     }
 
     fn dirty_overlay_project(&mut self, dirty: &DirtyDocumentSnapshot) -> anyhow::Result<&Project> {
-        let key = DirtyOverlayKey::from_snapshot(dirty);
+        let identity = DirtyDocumentIdentity::from_snapshot(dirty);
         let should_rebuild = match &self.dirty_overlay {
-            Some(cached) => cached.key != key,
+            Some(cached) => cached.identity != identity,
             None => true,
         };
 
@@ -968,7 +1006,7 @@ impl EngineWorker {
                 dirty_overlay_build_ms = started.elapsed().as_millis(),
                 "dirty analysis overlay rebuilt"
             );
-            self.dirty_overlay = Some(CachedDirtyOverlay { key, project });
+            self.dirty_overlay = Some(CachedDirtyOverlay { identity, project });
         } else {
             tracing::debug!(
                 path = %dirty.path().display(),
@@ -990,13 +1028,33 @@ impl EngineWorker {
     /// Runs a read-only request, responds immediately, then heals disposable cache failures.
     fn respond_to_query<T>(
         &mut self,
-        label: &'static str,
-        queue_elapsed: Duration,
+        context: QueryContext,
         respond_to: EngineResponse<T>,
         query: impl FnOnce(&mut Self) -> anyhow::Result<T>,
     ) where
-        T: Send + 'static,
+        T: Default + Send + 'static,
     {
+        // If a newer document version is already available, this queued dirty query can only
+        // produce obsolete results. This is an internal optimization, not a replacement for LSP
+        // request cancellation.
+        if let Some(dirty_identity) = context.stale_dirty_identity(&self.dirty_analysis) {
+            tracing::debug!(
+                label = context.label,
+                path = %dirty_identity.path().display(),
+                version = ?dirty_identity.version(),
+                text_len = dirty_identity.text_len(),
+                queued_ms = context.queue_elapsed.as_millis(),
+                "stale dirty analysis query skipped"
+            );
+            let _ = respond_to.send(Ok(T::default()));
+            return;
+        }
+
+        // From here on, clean and current-dirty requests share the same execution path. Keeping the
+        // stale check in the context layer lets timing, memory reporting, and cache recovery remain
+        // uniform for every analysis query.
+        let label = context.label;
+        let queue_elapsed = context.queue_elapsed;
         let memory_control = Arc::clone(&self.memory_control);
         tracing::debug!(
             label,
@@ -1119,5 +1177,44 @@ impl NavigationQuery {
             Self::TypeDefinition => "type_definition",
             Self::Implementation => "implementation",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{path::PathBuf, sync::Arc};
+
+    use tokio::sync::oneshot;
+
+    use super::*;
+    use crate::documents::{DirtyDocumentSnapshotState, DocumentStore};
+
+    #[test]
+    fn stale_dirty_query_responds_without_running_analysis() {
+        let path = PathBuf::from("/workspace/src/lib.rs");
+        let mut documents = DocumentStore::default();
+        documents.did_open(path.clone(), Some(1), "fn main() {}\n");
+        documents.did_change(
+            path.clone(),
+            Some(2),
+            Some("fn main() {\n    dirty();\n}\n"),
+        );
+
+        let DirtyDocumentSnapshotState::Dirty(snapshot) = documents.dirty_snapshot(&path) else {
+            panic!("dirty full-sync document should expose a snapshot");
+        };
+
+        let mut worker = EngineWorker::new(Arc::new(()), DirtyAnalysisHandle::default());
+        let (respond_to, response) = oneshot::channel();
+        let context = QueryContext::document("hover", Duration::ZERO, Some(&snapshot));
+
+        worker.respond_to_query(context, respond_to, |_| {
+            panic!("stale query should not run analysis")
+        });
+
+        let result: Option<ls_types::Hover> = futures::executor::block_on(response)
+            .expect("stale query should send a response")
+            .expect("stale query should send a successful neutral result");
+        assert!(result.is_none());
     }
 }

--- a/crates/lsp/engine/src/lib.rs
+++ b/crates/lsp/engine/src/lib.rs
@@ -5,6 +5,7 @@
 //! delivery primitives; shared request and notification contracts live in `rg_lsp_proto`.
 
 mod diagnostics;
+mod dirty_state;
 mod documents;
 mod engine;
 mod memory;

--- a/crates/lsp/engine/src/memory/report.rs
+++ b/crates/lsp/engine/src/memory/report.rs
@@ -1,58 +1,56 @@
 //! Allocator memory reporting helpers.
 //!
 //! The core memory module defines what the executable can expose. This module owns the logging
-//! shape: scoped reporters, trace/info records, and human-readable byte formatting.
-
-use std::time::{Duration, Instant};
+//! shape: point-in-time records and human-readable byte formatting.
 
 use super::{MemoryControl, MemoryDelta, MemoryPurge, MemoryStats};
 
-/// Reports allocator memory for scoped operations and point-in-time checkpoints.
+/// Reports allocator memory at explicit retention checkpoints.
 pub(crate) struct MemoryReporter;
 
 impl MemoryReporter {
-    pub(crate) fn report_op<T>(
+    pub(crate) fn log_checkpoint(
         memory_control: &dyn MemoryControl,
         label: &'static str,
-        op: impl FnOnce() -> T,
-    ) -> T {
-        let trace_report =
-            tracing::enabled!(target: "rg_lsp_engine::memory", tracing::Level::TRACE);
-        let purge_enabled = memory_control.allocator_purge_enabled();
-        if !trace_report && !purge_enabled {
-            return op();
-        }
-
-        let before = if trace_report {
-            Some(MemoryStats::capture(memory_control))
-        } else {
-            None
-        };
-        let started = Instant::now();
-        let result = op();
-        let elapsed = started.elapsed();
-        let after_operation = MemoryStats::capture(memory_control);
-        let purge = if purge_enabled {
-            MemoryPurge::try_purge(memory_control, after_operation)
-        } else {
-            None
-        };
-
-        if let Some(before) = before {
-            Self::trace_operation(
-                memory_control,
-                label,
-                elapsed,
-                before,
-                after_operation,
-                purge,
-            );
-        }
-
-        result
+        phase: &'static str,
+    ) -> MemoryStats {
+        let stats = MemoryStats::capture(memory_control);
+        tracing::debug!(
+            target: "rg_lsp_engine::memory",
+            label,
+            phase,
+            allocator = memory_control.allocator_name(),
+            allocator_purge_enabled = memory_control.allocator_purge_enabled(),
+            allocator_purged = false,
+            stats = %stats,
+            "temporary allocation checkpoint"
+        );
+        stats
     }
 
-    pub(crate) fn report_current(memory_control: &dyn MemoryControl, label: &'static str) {
+    pub(crate) fn log_checkpoint_delta(
+        memory_control: &dyn MemoryControl,
+        label: &'static str,
+        phase: &'static str,
+        before: MemoryStats,
+    ) -> MemoryStats {
+        let after = MemoryStats::capture(memory_control);
+        tracing::debug!(
+            target: "rg_lsp_engine::memory",
+            label,
+            phase,
+            allocator = memory_control.allocator_name(),
+            allocator_purge_enabled = memory_control.allocator_purge_enabled(),
+            allocator_purged = false,
+            before = %before,
+            after = %after,
+            delta = %MemoryDelta::between(before, after),
+            "temporary allocation checkpoint delta"
+        );
+        after
+    }
+
+    pub(crate) fn purge_and_report(memory_control: &dyn MemoryControl, label: &'static str) {
         let before_purge = MemoryStats::capture(memory_control);
         let purge = if memory_control.allocator_purge_enabled() {
             MemoryPurge::try_purge(memory_control, before_purge)
@@ -78,46 +76,6 @@ impl MemoryReporter {
                 label,
                 purge = %purge,
                 "purge stats"
-            );
-        }
-    }
-
-    fn trace_operation(
-        memory_control: &dyn MemoryControl,
-        label: &'static str,
-        elapsed: Duration,
-        before: MemoryStats,
-        after_operation: MemoryStats,
-        purge: Option<MemoryPurge>,
-    ) {
-        tracing::trace!(
-            target: "rg_lsp_engine::memory",
-            label,
-            elapsed_ms = elapsed.as_millis(),
-            allocator = memory_control.allocator_name(),
-            allocator_purge_enabled = memory_control.allocator_purge_enabled(),
-            allocator_purged = purge.is_some(),
-            "memory report"
-        );
-        tracing::trace!(
-            target: "rg_lsp_engine::memory",
-            label,
-            before = %before,
-            "memory before"
-        );
-        tracing::trace!(
-            target: "rg_lsp_engine::memory",
-            label,
-            after = %after_operation,
-            delta = %MemoryDelta::between(before, after_operation),
-            "memory after operation"
-        );
-        if let Some(purge) = purge {
-            tracing::trace!(
-                target: "rg_lsp_engine::memory",
-                label,
-                purge = %purge,
-                "memory purge"
             );
         }
     }

--- a/crates/lsp/engine/src/service/service_impl.rs
+++ b/crates/lsp/engine/src/service/service_impl.rs
@@ -48,7 +48,7 @@ impl EngineService for Service {
         let mut documents = self.engine.documents.lock().await;
         documents.did_open(path.clone(), version, &text);
         let dirty = documents.dirty_snapshot(&path);
-        self.engine.sync_dirty_analysis_state(&path, &dirty);
+        self.engine.sync_dirty_state(&path, &dirty);
         drop(documents);
 
         tracing::debug!(path = %path.display(), "opened clean document snapshot");
@@ -75,7 +75,7 @@ impl EngineService for Service {
         let change = documents.did_change(path.clone(), version, full_text.as_deref());
         let freshness = documents.freshness(&path);
         let dirty = documents.dirty_snapshot(&path);
-        self.engine.sync_dirty_analysis_state(&path, &dirty);
+        self.engine.sync_dirty_state(&path, &dirty);
         drop(documents);
 
         tracing::debug!(
@@ -116,7 +116,7 @@ impl EngineService for Service {
         documents.did_save(path.clone(), text.as_deref());
         let freshness = documents.freshness(&path);
         let dirty = documents.dirty_snapshot(&path);
-        self.engine.sync_dirty_analysis_state(&path, &dirty);
+        self.engine.sync_dirty_state(&path, &dirty);
         drop(documents);
 
         tracing::debug!(path = %path.display(), "marked document clean before save reindex");
@@ -160,7 +160,7 @@ impl EngineService for Service {
         let freshness = documents.freshness(&path);
         documents.did_close(&path);
         let dirty = documents.dirty_snapshot(&path);
-        self.engine.sync_dirty_analysis_state(&path, &dirty);
+        self.engine.sync_dirty_state(&path, &dirty);
         drop(documents);
 
         tracing::debug!(path = %path.display(), "closed document");

--- a/crates/lsp/engine/src/service/service_impl.rs
+++ b/crates/lsp/engine/src/service/service_impl.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use rg_lsp_proto::{EngineConfig, EngineError, EngineResult, EngineService};
 use tarpc::context;
 
-use crate::engine::EngineCommand;
+use crate::{documents::DirtyDocumentSnapshotState, engine::EngineCommand};
 
 use super::Service;
 
@@ -181,14 +181,17 @@ impl EngineService for Service {
         path: PathBuf,
         position: ls_types::Position,
     ) -> EngineResult<Vec<ls_types::Location>> {
-        if self.engine.is_dirty(&path).await {
-            return Ok(Vec::new());
-        }
+        let dirty = match self.engine.dirty_document_snapshot(&path).await {
+            DirtyDocumentSnapshotState::Clean => None,
+            DirtyDocumentSnapshotState::Dirty(dirty) => Some(dirty),
+            DirtyDocumentSnapshotState::DirtyWithoutText => return Ok(Vec::new()),
+        };
 
         self.engine
             .request(|respond_to| EngineCommand::GotoDefinition {
                 path,
                 position,
+                dirty,
                 respond_to,
             })
             .await
@@ -201,14 +204,17 @@ impl EngineService for Service {
         path: PathBuf,
         position: ls_types::Position,
     ) -> EngineResult<Vec<ls_types::Location>> {
-        if self.engine.is_dirty(&path).await {
-            return Ok(Vec::new());
-        }
+        let dirty = match self.engine.dirty_document_snapshot(&path).await {
+            DirtyDocumentSnapshotState::Clean => None,
+            DirtyDocumentSnapshotState::Dirty(dirty) => Some(dirty),
+            DirtyDocumentSnapshotState::DirtyWithoutText => return Ok(Vec::new()),
+        };
 
         self.engine
             .request(|respond_to| EngineCommand::GotoTypeDefinition {
                 path,
                 position,
+                dirty,
                 respond_to,
             })
             .await
@@ -221,14 +227,17 @@ impl EngineService for Service {
         path: PathBuf,
         position: ls_types::Position,
     ) -> EngineResult<Vec<ls_types::Location>> {
-        if self.engine.is_dirty(&path).await {
-            return Ok(Vec::new());
-        }
+        let dirty = match self.engine.dirty_document_snapshot(&path).await {
+            DirtyDocumentSnapshotState::Clean => None,
+            DirtyDocumentSnapshotState::Dirty(dirty) => Some(dirty),
+            DirtyDocumentSnapshotState::DirtyWithoutText => return Ok(Vec::new()),
+        };
 
         self.engine
             .request(|respond_to| EngineCommand::GotoImplementation {
                 path,
                 position,
+                dirty,
                 respond_to,
             })
             .await
@@ -242,15 +251,18 @@ impl EngineService for Service {
         position: ls_types::Position,
         include_declaration: bool,
     ) -> EngineResult<Vec<ls_types::Location>> {
-        if self.engine.is_dirty(&path).await {
-            return Ok(Vec::new());
-        }
+        let dirty = match self.engine.dirty_document_snapshot(&path).await {
+            DirtyDocumentSnapshotState::Clean => None,
+            DirtyDocumentSnapshotState::Dirty(dirty) => Some(dirty),
+            DirtyDocumentSnapshotState::DirtyWithoutText => return Ok(Vec::new()),
+        };
 
         self.engine
             .request(|respond_to| EngineCommand::References {
                 path,
                 position,
                 include_declaration,
+                dirty,
                 respond_to,
             })
             .await
@@ -263,14 +275,17 @@ impl EngineService for Service {
         path: PathBuf,
         position: ls_types::Position,
     ) -> EngineResult<Vec<ls_types::DocumentHighlight>> {
-        if self.engine.is_dirty(&path).await {
-            return Ok(Vec::new());
-        }
+        let dirty = match self.engine.dirty_document_snapshot(&path).await {
+            DirtyDocumentSnapshotState::Clean => None,
+            DirtyDocumentSnapshotState::Dirty(dirty) => Some(dirty),
+            DirtyDocumentSnapshotState::DirtyWithoutText => return Ok(Vec::new()),
+        };
 
         self.engine
             .request(|respond_to| EngineCommand::DocumentHighlight {
                 path,
                 position,
+                dirty,
                 respond_to,
             })
             .await
@@ -283,14 +298,17 @@ impl EngineService for Service {
         path: PathBuf,
         position: ls_types::Position,
     ) -> EngineResult<Option<ls_types::Hover>> {
-        if self.engine.is_dirty(&path).await {
-            return Ok(None);
-        }
+        let dirty = match self.engine.dirty_document_snapshot(&path).await {
+            DirtyDocumentSnapshotState::Clean => None,
+            DirtyDocumentSnapshotState::Dirty(dirty) => Some(dirty),
+            DirtyDocumentSnapshotState::DirtyWithoutText => return Ok(None),
+        };
 
         self.engine
             .request(|respond_to| EngineCommand::Hover {
                 path,
                 position,
+                dirty,
                 respond_to,
             })
             .await
@@ -303,14 +321,17 @@ impl EngineService for Service {
         path: PathBuf,
         position: ls_types::Position,
     ) -> EngineResult<Vec<ls_types::CompletionItem>> {
-        if self.engine.is_dirty(&path).await {
-            return Ok(Vec::new());
-        }
+        let dirty = match self.engine.dirty_document_snapshot(&path).await {
+            DirtyDocumentSnapshotState::Clean => None,
+            DirtyDocumentSnapshotState::Dirty(dirty) => Some(dirty),
+            DirtyDocumentSnapshotState::DirtyWithoutText => return Ok(Vec::new()),
+        };
 
         self.engine
             .request(|respond_to| EngineCommand::Completion {
                 path,
                 position,
+                dirty,
                 respond_to,
             })
             .await
@@ -322,28 +343,18 @@ impl EngineService for Service {
         _: context::Context,
         path: PathBuf,
     ) -> EngineResult<Vec<ls_types::DocumentSymbol>> {
-        let freshness = self.engine.documents.lock().await.freshness(&path);
-        if freshness.dirty() {
-            // LSP has refresh requests for features like inlay hints, but not for document symbols.
-            // Returning an empty symbol tree while the document is dirty can leave VS Code's Outline
-            // empty after save, so document symbols intentionally use the last saved snapshot.
-            // TODO: This can show stale ranges while the dirty buffer shifts item spans. VSCode has
-            // an open issue to trigger outline refresh:
-            // https://github.com/microsoft/vscode/issues/108722
-            tracing::trace!(
-                path = %path.display(),
-                tracked = freshness.tracked(),
-                version = ?freshness.version(),
-                saved_len = ?freshness.saved_len(),
-                live_len = ?freshness.live_len(),
-                saved_hash = ?freshness.saved_hash(),
-                live_hash = ?freshness.live_hash(),
-                "document symbol request is using saved snapshot for dirty document"
-            );
-        }
+        let dirty = match self.engine.dirty_document_snapshot(&path).await {
+            DirtyDocumentSnapshotState::Clean => None,
+            DirtyDocumentSnapshotState::Dirty(dirty) => Some(dirty),
+            DirtyDocumentSnapshotState::DirtyWithoutText => None,
+        };
 
         self.engine
-            .request(|respond_to| EngineCommand::DocumentSymbol { path, respond_to })
+            .request(|respond_to| EngineCommand::DocumentSymbol {
+                path,
+                dirty,
+                respond_to,
+            })
             .await
             .map_err(EngineError::from)
     }
@@ -354,14 +365,17 @@ impl EngineService for Service {
         path: PathBuf,
         range: ls_types::Range,
     ) -> EngineResult<Vec<ls_types::InlayHint>> {
-        if self.engine.is_dirty(&path).await {
-            return Ok(Vec::new());
-        }
+        let dirty = match self.engine.dirty_document_snapshot(&path).await {
+            DirtyDocumentSnapshotState::Clean => None,
+            DirtyDocumentSnapshotState::Dirty(dirty) => Some(dirty),
+            DirtyDocumentSnapshotState::DirtyWithoutText => return Ok(Vec::new()),
+        };
 
         self.engine
             .request(|respond_to| EngineCommand::InlayHint {
                 path,
                 range,
+                dirty,
                 respond_to,
             })
             .await

--- a/crates/lsp/engine/src/service/service_impl.rs
+++ b/crates/lsp/engine/src/service/service_impl.rs
@@ -99,9 +99,7 @@ impl EngineService for Service {
             "document freshness after change"
         );
 
-        if change.became_dirty || change.became_clean {
-            self.engine.refresh_inlay_hints();
-        }
+        self.engine.refresh_inlay_hints_debounced();
 
         Ok(())
     }
@@ -152,7 +150,7 @@ impl EngineService for Service {
         }
 
         self.engine.log_freshness_after_save(&saved_path).await;
-        self.engine.refresh_inlay_hints();
+        self.engine.refresh_inlay_hints_now();
 
         Ok(())
     }

--- a/crates/lsp/engine/src/service/service_impl.rs
+++ b/crates/lsp/engine/src/service/service_impl.rs
@@ -45,11 +45,11 @@ impl EngineService for Service {
         text: String,
     ) -> EngineResult<()> {
         let text_len = text.len();
-        self.engine
-            .documents
-            .lock()
-            .await
-            .did_open(path.clone(), version, &text);
+        let mut documents = self.engine.documents.lock().await;
+        documents.did_open(path.clone(), version, &text);
+        let dirty = documents.dirty_snapshot(&path);
+        self.engine.sync_dirty_analysis_state(&path, &dirty);
+        drop(documents);
 
         tracing::debug!(path = %path.display(), "opened clean document snapshot");
         tracing::trace!(
@@ -74,6 +74,8 @@ impl EngineService for Service {
         let mut documents = self.engine.documents.lock().await;
         let change = documents.did_change(path.clone(), version, full_text.as_deref());
         let freshness = documents.freshness(&path);
+        let dirty = documents.dirty_snapshot(&path);
+        self.engine.sync_dirty_analysis_state(&path, &dirty);
         drop(documents);
 
         tracing::debug!(
@@ -115,6 +117,8 @@ impl EngineService for Service {
         let mut documents = self.engine.documents.lock().await;
         documents.did_save(path.clone(), text.as_deref());
         let freshness = documents.freshness(&path);
+        let dirty = documents.dirty_snapshot(&path);
+        self.engine.sync_dirty_analysis_state(&path, &dirty);
         drop(documents);
 
         tracing::debug!(path = %path.display(), "marked document clean before save reindex");
@@ -157,6 +161,8 @@ impl EngineService for Service {
         let mut documents = self.engine.documents.lock().await;
         let freshness = documents.freshness(&path);
         documents.did_close(&path);
+        let dirty = documents.dirty_snapshot(&path);
+        self.engine.sync_dirty_analysis_state(&path, &dirty);
         drop(documents);
 
         tracing::debug!(path = %path.display(), "closed document");


### PR DESCRIPTION
Introduces support for dirty buffers diagnostics & completion via partial reindexing.
The functionality is intentionally narrow, but it works, and it's pretty memory efficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dirty-overlay analysis: LSP queries can reflect unsaved editor changes without mutating saved project state.
  * Partial file-level rebuilds and targeted reparsing from in-memory text for faster incremental analysis.
  * Inlay-hint debouncing to reduce refresh overhead during active editing.

* **Bug Fixes / Stability**
  * Stale dirty snapshots are detected and ignored to avoid returning outdated results.

* **Chores**
  * Expanded Tokio feature set in the LSP engine.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/popzxc/rust-glancer/pull/31)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->