### PR TITLE
feat: Do not interleave ParseDB / ItemTreeDB lifetimes in allocations

### DIFF
--- a/crates/engine/item-tree/src/db.rs
+++ b/crates/engine/item-tree/src/db.rs
@@ -126,6 +126,14 @@ impl ItemTreeDb {
         interner: &mut rg_text::NameInterner,
     ) -> anyhow::Result<Package> {
         let package_name = package.package_name().to_owned();
+        // Important: `ItemTreeDb` is dropped during indexing, while retained parse syntax stays alive
+        // until Body IR lowering finishes. So these two DBs have different lifetimes, and it is
+        // important to make sure that their allocations are not mixed up.
+        // If allocations _will_ be mixed up, then dropping `ItemTreeDb` will create a lot of holes,
+        // which will cause severe (measured and observed in the past!) fragmentation issues.
+        package.discover_modules().with_context(|| {
+            format!("while attempting to discover modules for package {package_name}")
+        })?;
         lower::build_package(package, interner)
             .with_context(|| {
                 format!("while attempting to build item trees for package {package_name}")

--- a/crates/engine/item-tree/src/lower.rs
+++ b/crates/engine/item-tree/src/lower.rs
@@ -4,19 +4,16 @@
 //! and targets only point at their root file. Out-of-line modules therefore reuse the same lowered
 //! file tree whenever multiple targets reach them.
 
-use std::{
-    collections::HashSet,
-    path::{Path, PathBuf},
-};
+use std::collections::HashSet;
 
 use anyhow::Context as _;
 use ra_syntax::{
     AstNode as _,
-    ast::{self, HasAttrs, HasDocComments, HasModuleItem, HasName, HasVisibility},
+    ast::{self, HasDocComments, HasModuleItem, HasName, HasVisibility},
 };
 use rg_arena::Arena;
 
-use rg_parse::{FileId, LineIndex, Package as ParsePackage};
+use rg_parse::{FileId, LineIndex, ModuleFileContext, Package as ParsePackage};
 use rg_text::{Name, NameInterner};
 
 use super::{
@@ -391,22 +388,7 @@ impl<'db> PackageLowering<'db> {
             });
         }
 
-        // A nameless out-of-line module cannot be resolved to a file path.
-        let Some(module_name) = item.name().map(|name| name.text().to_string()) else {
-            return Ok(ModuleItem {
-                inner_docs: None,
-                source: ModuleSource::OutOfLine {
-                    definition_file: None,
-                },
-            });
-        };
-        let module_file_path = if let Some(path_attr) = module_path_attr(item) {
-            module_file_context.resolve_path_attr_file(&path_attr)
-        } else {
-            module_file_context.resolve_child_file(&module_name)
-        };
-
-        let Some(module_file_path) = module_file_path else {
+        let Some(module_file_path) = module_file_context.resolve_module_file(item) else {
             return Ok(ModuleItem {
                 inner_docs: None,
                 source: ModuleSource::OutOfLine {
@@ -611,95 +593,6 @@ impl<'a> FileTreeBuilder<'a> {
             self.current_file_id,
         ))
     }
-}
-
-/// Filesystem context for resolving out-of-line child modules of the current logical module.
-#[derive(Debug, Clone)]
-struct ModuleFileContext {
-    child_module_dir: PathBuf,
-}
-
-impl ModuleFileContext {
-    /// Builds the child-module directory for a file-backed module.
-    fn from_definition_file(definition_file: &Path) -> Self {
-        let parent_dir = definition_file
-            .parent()
-            .expect("definition file should have a parent directory");
-        let file_name = definition_file
-            .file_name()
-            .and_then(|name| name.to_str())
-            .expect("definition file name should be UTF-8");
-        let file_stem = definition_file
-            .file_stem()
-            .and_then(|stem| stem.to_str())
-            .expect("definition file stem should be UTF-8");
-
-        let child_module_dir = match file_name {
-            "lib.rs" | "main.rs" | "mod.rs" => parent_dir.to_path_buf(),
-            _ => parent_dir.join(file_stem),
-        };
-
-        Self { child_module_dir }
-    }
-
-    /// Builds the child-module directory for an inline child module.
-    fn descend(&self, module_name: &str) -> Self {
-        Self {
-            child_module_dir: self.child_module_dir.join(module_name),
-        }
-    }
-
-    /// Resolves `mod name;` according to conventional Rust module file rules.
-    fn resolve_child_file(&self, module_name: &str) -> Option<PathBuf> {
-        let flat_file = self.child_module_dir.join(format!("{module_name}.rs"));
-        if flat_file.exists() {
-            return Some(flat_file);
-        }
-
-        let nested_file = self.child_module_dir.join(module_name).join("mod.rs");
-        if nested_file.exists() {
-            return Some(nested_file);
-        }
-
-        None
-    }
-
-    /// Resolves the basic literal form of `#[path = "..."]` relative to the current module.
-    fn resolve_path_attr_file(&self, path_attr: &str) -> Option<PathBuf> {
-        let path_attr = Path::new(path_attr);
-        if path_attr.as_os_str().is_empty() || path_attr.is_absolute() {
-            return None;
-        }
-
-        let file = self.child_module_dir.join(path_attr);
-        file.exists().then_some(file)
-    }
-}
-
-/// Extracts the basic `#[path = "..."]` module override.
-///
-/// This intentionally handles only direct string-literal attributes. More advanced forms such as
-/// `cfg_attr` can be added later when the rest of the module system needs them.
-fn module_path_attr(item: &ast::Module) -> Option<String> {
-    for attr in item.attrs() {
-        if !attr.kind().is_outer() || attr.simple_name().as_deref() != Some("path") {
-            continue;
-        }
-
-        let Some(ast::Meta::KeyValueMeta(meta)) = attr.meta() else {
-            continue;
-        };
-        let Some(ast::Expr::Literal(literal)) = meta.expr() else {
-            continue;
-        };
-        let ast::LiteralKind::String(path) = literal.kind() else {
-            continue;
-        };
-
-        return path.value().ok().map(|path| path.into_owned());
-    }
-
-    None
 }
 
 /// Keeps the original `use ...` text in a compact, human-readable form for debugging and tests.

--- a/crates/engine/parse/src/lib.rs
+++ b/crates/engine/parse/src/lib.rs
@@ -2,6 +2,7 @@ mod db;
 mod file;
 mod line_index;
 mod memsize;
+mod module;
 mod package;
 mod span;
 mod target;
@@ -13,6 +14,7 @@ pub use self::{
     db::{PackageFileRef, ParseDb},
     file::{FileId, ParsedFile, ParsedFileSnapshot},
     line_index::{LineIndex, LineIndexSnapshot},
+    module::ModuleFileContext,
     package::{Package, PackageParseSnapshot},
     span::{LineColumnSpan, Position, Span, TextSpan},
     target::{Target, TargetId},

--- a/crates/engine/parse/src/module.rs
+++ b/crates/engine/parse/src/module.rs
@@ -1,0 +1,262 @@
+//! Package-local module graph discovery.
+//!
+//! Parsing starts with Cargo target roots, but later lowering phases need every reachable
+//! out-of-line module file to already be present in the package file cache. This pass walks the
+//! Rust module declarations without allocating item-tree payloads, so syntax retention and
+//! item-tree lowering stay in separate lifetime windows.
+
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Context as _;
+use ra_syntax::ast::{self, HasAttrs, HasModuleItem, HasName};
+
+use crate::{FileId, Package};
+
+impl Package {
+    /// Discovers reachable out-of-line module files before AST-consuming lowering allocates.
+    pub fn discover_modules(&mut self) -> anyhow::Result<()> {
+        ModuleDiscovery::new(self).discover()
+    }
+}
+
+/// Filesystem context for resolving out-of-line child modules of the current logical module.
+#[derive(Debug, Clone)]
+pub struct ModuleFileContext {
+    child_module_dir: PathBuf,
+}
+
+impl ModuleFileContext {
+    /// Builds the child-module directory for a file-backed module.
+    pub fn from_definition_file(definition_file: &Path) -> Self {
+        let parent_dir = definition_file
+            .parent()
+            .expect("definition file should have a parent directory");
+        let file_name = definition_file
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("definition file name should be UTF-8");
+        let file_stem = definition_file
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .expect("definition file stem should be UTF-8");
+
+        let child_module_dir = match file_name {
+            "lib.rs" | "main.rs" | "mod.rs" => parent_dir.to_path_buf(),
+            _ => parent_dir.join(file_stem),
+        };
+
+        Self { child_module_dir }
+    }
+
+    /// Builds the child-module directory for an inline child module.
+    pub fn descend(&self, module_name: &str) -> Self {
+        Self {
+            child_module_dir: self.child_module_dir.join(module_name),
+        }
+    }
+
+    /// Resolves one out-of-line module declaration according to the supported Rust file rules.
+    ///
+    /// The resolver intentionally handles only the module forms that lowering already supports.
+    /// More advanced attribute expansion belongs with a broader module-system implementation.
+    pub fn resolve_module_file(&self, module: &ast::Module) -> Option<PathBuf> {
+        let module_name = module.name().map(|name| name.text().to_string())?;
+        if let Some(path_attr) = module_path_attr(module) {
+            return self.resolve_path_attr_file(&path_attr);
+        }
+
+        self.resolve_child_file(&module_name)
+    }
+
+    /// Resolves `mod name;` according to conventional Rust module file rules.
+    fn resolve_child_file(&self, module_name: &str) -> Option<PathBuf> {
+        let flat_file = self.child_module_dir.join(format!("{module_name}.rs"));
+        if flat_file.exists() {
+            return Some(flat_file);
+        }
+
+        let nested_file = self.child_module_dir.join(module_name).join("mod.rs");
+        if nested_file.exists() {
+            return Some(nested_file);
+        }
+
+        None
+    }
+
+    /// Resolves the basic literal form of `#[path = "..."]` relative to the current module.
+    fn resolve_path_attr_file(&self, path_attr: &str) -> Option<PathBuf> {
+        let path_attr = Path::new(path_attr);
+        if path_attr.as_os_str().is_empty() || path_attr.is_absolute() {
+            return None;
+        }
+
+        let file = self.child_module_dir.join(path_attr);
+        file.exists().then_some(file)
+    }
+}
+
+struct ModuleDiscovery<'db> {
+    package: &'db mut Package,
+    visited: HashSet<FileId>,
+    active_stack: HashSet<FileId>,
+}
+
+impl<'db> ModuleDiscovery<'db> {
+    fn new(package: &'db mut Package) -> Self {
+        Self {
+            package,
+            visited: HashSet::default(),
+            active_stack: HashSet::default(),
+        }
+    }
+
+    fn discover(mut self) -> anyhow::Result<()> {
+        let roots = self
+            .package
+            .targets()
+            .iter()
+            .map(|target| (target.name.clone(), target.root_file))
+            .collect::<Vec<_>>();
+
+        for (target_name, root_file) in roots {
+            self.discover_file(root_file).with_context(|| {
+                format!("while attempting to discover modules for target {target_name}")
+            })?;
+        }
+
+        Ok(())
+    }
+
+    fn discover_file(&mut self, current_file_id: FileId) -> anyhow::Result<()> {
+        if self.visited.contains(&current_file_id) {
+            return Ok(());
+        }
+
+        // Recursive module graphs can revisit a file before the first traversal finishes.
+        if !self.active_stack.insert(current_file_id) {
+            return Ok(());
+        }
+
+        self.package
+            .ensure_file_syntax(current_file_id)
+            .with_context(|| {
+                format!("while attempting to load syntax for {:?}", current_file_id)
+            })?;
+
+        let (items, module_file_context) = {
+            let parsed_file = self.package.parsed_file(current_file_id).with_context(|| {
+                format!(
+                    "while attempting to fetch parsed file {:?}",
+                    current_file_id
+                )
+            })?;
+            let syntax = parsed_file.syntax().with_context(|| {
+                format!(
+                    "while attempting to access retained syntax for {:?}",
+                    current_file_id
+                )
+            })?;
+            (
+                syntax.items().collect::<Vec<_>>(),
+                ModuleFileContext::from_definition_file(parsed_file.path()),
+            )
+        };
+
+        self.discover_items(items, &module_file_context)
+            .with_context(|| {
+                format!(
+                    "while attempting to discover module items for {:?}",
+                    current_file_id
+                )
+            })?;
+
+        self.active_stack.remove(&current_file_id);
+        self.visited.insert(current_file_id);
+        Ok(())
+    }
+
+    fn discover_items(
+        &mut self,
+        items: Vec<ast::Item>,
+        module_file_context: &ModuleFileContext,
+    ) -> anyhow::Result<()> {
+        for item in items {
+            let ast::Item::Module(module) = item else {
+                continue;
+            };
+
+            self.discover_module(&module, module_file_context)
+                .context("while attempting to discover module declaration")?;
+        }
+
+        Ok(())
+    }
+
+    fn discover_module(
+        &mut self,
+        module: &ast::Module,
+        module_file_context: &ModuleFileContext,
+    ) -> anyhow::Result<()> {
+        if let Some(item_list) = module.item_list() {
+            // Inline modules do not introduce a file, but their out-of-line children resolve under
+            // a directory named after the inline module path.
+            let inline_module_context = module
+                .name()
+                .map(|name| module_file_context.descend(name.text().as_str()))
+                .unwrap_or_else(|| module_file_context.clone());
+            let inline_items = item_list.items().collect::<Vec<_>>();
+            return self
+                .discover_items(inline_items, &inline_module_context)
+                .context("while attempting to discover inline module items");
+        }
+
+        let Some(module_file_path) = module_file_context.resolve_module_file(module) else {
+            return Ok(());
+        };
+        let module_file_id = self
+            .package
+            .parse_file(&module_file_path)
+            .with_context(|| {
+                format!(
+                    "while attempting to parse module file {}",
+                    module_file_path.display()
+                )
+            })?;
+
+        self.discover_file(module_file_id).with_context(|| {
+            format!(
+                "while attempting to discover modules from {}",
+                module_file_path.display()
+            )
+        })
+    }
+}
+
+/// Extracts the basic `#[path = "..."]` module override.
+///
+/// This intentionally handles only direct string-literal attributes. More advanced forms such as
+/// `cfg_attr` can be added later when the rest of the module system needs them.
+fn module_path_attr(item: &ast::Module) -> Option<String> {
+    for attr in item.attrs() {
+        if !attr.kind().is_outer() || attr.simple_name().as_deref() != Some("path") {
+            continue;
+        }
+
+        let Some(ast::Meta::KeyValueMeta(meta)) = attr.meta() else {
+            continue;
+        };
+        let Some(ast::Expr::Literal(literal)) = meta.expr() else {
+            continue;
+        };
+        let ast::LiteralKind::String(path) = literal.kind() else {
+            continue;
+        };
+
+        return path.value().ok().map(|path| path.into_owned());
+    }
+
+    None
+}

--- a/crates/engine/parse/src/tests/mod.rs
+++ b/crates/engine/parse/src/tests/mod.rs
@@ -2,7 +2,7 @@ mod utils;
 
 use expect_test::expect;
 
-use self::utils::check_parse_db;
+use self::utils::{check_parse_db, check_parse_db_after_module_discovery};
 
 #[test]
 fn dumps_workspace_packages_targets_and_dependencies() {
@@ -115,6 +115,127 @@ fn parses_shared_files_once_across_targets() {
             - shared-bin [bin] -> src/shared.rs
             files
             - src/shared.rs
+        "#]],
+    );
+}
+
+#[test]
+fn module_discovery_parses_reachable_out_of_line_files() {
+    check_parse_db_after_module_discovery(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "module_discovery"
+        version = "0.1.0"
+        edition = "2024"
+
+        //- /src/lib.rs
+        pub mod flat;
+        pub mod nested;
+        pub mod inline {
+            pub mod child;
+        }
+        #[path = "generated/api.rs"]
+        pub mod api;
+        pub mod missing;
+
+        //- /src/flat.rs
+        pub struct Flat;
+
+        //- /src/nested/mod.rs
+        pub struct Nested;
+
+        //- /src/inline/child.rs
+        pub struct Child;
+
+        //- /src/generated/api.rs
+        pub struct Api;
+        "#,
+        expect![[r#"
+            packages 1 (workspace members: 1, dependencies: 0)
+
+            package module_discovery [member]
+            targets
+            - module_discovery [lib] -> src/lib.rs
+            files
+            - src/flat.rs
+            - src/generated/api.rs
+            - src/inline/child.rs
+            - src/lib.rs
+            - src/nested/mod.rs
+        "#]],
+    );
+}
+
+#[test]
+fn module_discovery_shares_files_across_targets() {
+    check_parse_db_after_module_discovery(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "shared_discovery"
+        version = "0.1.0"
+        edition = "2024"
+
+        [lib]
+        path = "src/lib.rs"
+
+        [[bin]]
+        name = "shared-discovery"
+        path = "src/main.rs"
+
+        //- /src/lib.rs
+        pub mod shared;
+
+        //- /src/main.rs
+        mod shared;
+
+        fn main() {}
+
+        //- /src/shared.rs
+        pub struct Shared;
+        "#,
+        expect![[r#"
+            packages 1 (workspace members: 1, dependencies: 0)
+
+            package shared_discovery [member]
+            targets
+            - shared_discovery [lib] -> src/lib.rs
+            - shared-discovery [bin] -> src/main.rs
+            files
+            - src/lib.rs
+            - src/main.rs
+            - src/shared.rs
+        "#]],
+    );
+}
+
+#[test]
+fn module_discovery_terminates_on_module_cycles() {
+    check_parse_db_after_module_discovery(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "cycle_discovery"
+        version = "0.1.0"
+        edition = "2024"
+
+        //- /src/lib.rs
+        pub mod a;
+
+        //- /src/a/mod.rs
+        #[path = "../lib.rs"]
+        pub mod root_again;
+        "#,
+        expect![[r#"
+            packages 1 (workspace members: 1, dependencies: 0)
+
+            package cycle_discovery [member]
+            targets
+            - cycle_discovery [lib] -> src/lib.rs
+            files
+            - src/a/mod.rs
+            - src/lib.rs
         "#]],
     );
 }

--- a/crates/engine/parse/src/tests/utils.rs
+++ b/crates/engine/parse/src/tests/utils.rs
@@ -7,6 +7,14 @@ use test_fixture::fixture_crate;
 use crate::{Package, ParseDb, Target};
 
 pub(super) fn check_parse_db(fixture: &str, expect: Expect) {
+    check_parse_db_with(fixture, ParseFixtureMode::RootsOnly, expect);
+}
+
+pub(super) fn check_parse_db_after_module_discovery(fixture: &str, expect: Expect) {
+    check_parse_db_with(fixture, ParseFixtureMode::DiscoverModules, expect);
+}
+
+fn check_parse_db_with(fixture: &str, mode: ParseFixtureMode, expect: Expect) {
     let fixture = fixture_crate(fixture);
     let root = fixture
         .path("")
@@ -15,10 +23,23 @@ pub(super) fn check_parse_db(fixture: &str, expect: Expect) {
     let display_root = fixture.path("");
     let workspace = WorkspaceMetadata::from_cargo(fixture.metadata())
         .expect("fixture workspace metadata should build");
-    let parse = ParseDb::build(&workspace).expect("fixture parse db should build");
+    let mut parse = ParseDb::build(&workspace).expect("fixture parse db should build");
+    if matches!(mode, ParseFixtureMode::DiscoverModules) {
+        for package in parse.packages_mut() {
+            package
+                .discover_modules()
+                .expect("fixture module discovery should succeed");
+        }
+    }
     let actual = ProjectParseSnapshot::new(&parse, &root, &display_root).render();
     let actual = format!("{}\n", actual.trim_end());
     expect.assert_eq(&actual);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParseFixtureMode {
+    RootsOnly,
+    DiscoverModules,
 }
 
 struct ProjectParseSnapshot<'a> {

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -358,6 +358,10 @@ impl EngineWorker {
                 .and_then(|profile| profile.cache_probe()),
         );
         self.project.replace_saved(project_build.into_project());
+        // Full indexing materializes large temporary phase data that is dropped before the saved
+        // project is installed. Purge after that boundary so idle editor memory reflects the
+        // retained analysis graph instead of allocator pages left dirty by startup indexing.
+        MemoryReporter::purge_and_report(self.memory_control.as_ref(), "after initial index");
         Self::log_project_snapshot(self.project.saved_snapshot()?, "initial index");
         tracing::info!(
             workspace_root = %workspace_root.display(),
@@ -377,6 +381,8 @@ impl EngineWorker {
                 .reindex_workspace()
                 .context("while attempting to manually reindex workspace")
         })?;
+        // Manual reindexing has the same temporary-memory profile as startup indexing.
+        MemoryReporter::purge_and_report(self.memory_control.as_ref(), "after manual reindex");
         Self::log_project_snapshot(self.project.saved_snapshot()?, "manual reindex");
         tracing::info!(
             elapsed_ms = started.elapsed().as_millis(),


### PR DESCRIPTION
This optimization significantly reduces memory fragmentation.

Main manifestation is that, thanks to this change, memory does not grow as much on dirty buffer edits (where we do a lot of partial reparsing). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Precomputes reachable out-of-line Rust module files in a package before AST lowering (supports #[path] overrides and cycle detection).

* **Improvements**
  * Enriched error messages during module discovery with package context.
  * Exposed module-file resolution support from the parsing layer.
  * Memory is now purged and reported immediately after initial and manual workspace indexing.

* **Tests**
  * Added tests for discovery, multi-target sharing, and cycle termination; test utilities refactored to support discovery mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/popzxc/rust-glancer/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->