### PR TITLE
feat: Render rustdoc markdown properly in hover

### DIFF
--- a/crates/lsp/engine/src/proto/completion.rs
+++ b/crates/lsp/engine/src/proto/completion.rs
@@ -7,7 +7,7 @@ use rg_analysis::{
 };
 use rg_parse::LineIndex;
 
-use crate::proto::position;
+use crate::proto::{markdown, position};
 
 pub(crate) fn completion_item(item: CompletionItem, line_index: &LineIndex) -> LspCompletionItem {
     let detail = completion_detail(item.detail, item.applicability);
@@ -66,8 +66,8 @@ fn completion_detail(
 }
 
 fn markdown_documentation(value: String) -> Option<Documentation> {
-    let value = value.trim().to_string();
-    (!value.is_empty()).then_some(Documentation::MarkupContent(MarkupContent {
+    let value = markdown::render_rustdoc_markdown(&value)?;
+    Some(Documentation::MarkupContent(MarkupContent {
         kind: MarkupKind::Markdown,
         value,
     }))

--- a/crates/lsp/engine/src/proto/hover.rs
+++ b/crates/lsp/engine/src/proto/hover.rs
@@ -2,7 +2,7 @@ use ls_types::{Hover, HoverContents, MarkupContent, MarkupKind};
 use rg_analysis::HoverInfo;
 use rg_parse::LineIndex;
 
-use crate::proto::position;
+use crate::proto::{markdown, position};
 
 pub(crate) fn hover(info: HoverInfo, line_index: &LineIndex) -> Option<Hover> {
     let range = info.range.map(|span| position::range(line_index, span));
@@ -39,11 +39,10 @@ impl HoverMarkdown {
                     block_sections.push(format!("```text\nType: {ty}\n```"));
                 }
 
-                if let Some(docs) = block.docs {
-                    let docs = docs.trim();
-                    if !docs.is_empty() {
-                        block_sections.push(docs.to_string());
-                    }
+                if let Some(docs) = block.docs
+                    && let Some(docs) = markdown::render_rustdoc_markdown(&docs)
+                {
+                    block_sections.push(docs);
                 }
 
                 (!block_sections.is_empty()).then(|| block_sections.join("\n\n"))
@@ -81,6 +80,26 @@ mod tests {
         assert_eq!(
             markdown.as_deref(),
             Some("```rust\napp::User\n```\n\n```rust\npub struct User\n```\n\nUser account.")
+        );
+    }
+
+    #[test]
+    fn normalizes_rustdoc_docs() {
+        let markdown = HoverMarkdown::from_info(HoverInfo {
+            range: None,
+            blocks: vec![HoverBlock {
+                kind: SymbolKind::Function,
+                path: None,
+                signature: Some("pub fn make_user()".to_string()),
+                ty: None,
+                docs: Some("```rust,no_run\n# use app::User;\nUser::new();\n```".to_string()),
+            }],
+        })
+        .finish();
+
+        assert_eq!(
+            markdown.as_deref(),
+            Some("```rust\npub fn make_user()\n```\n\n```rust\nUser::new();\n```")
         );
     }
 }

--- a/crates/lsp/engine/src/proto/markdown.rs
+++ b/crates/lsp/engine/src/proto/markdown.rs
@@ -1,0 +1,249 @@
+//! Markdown rendering helpers for LSP clients.
+
+/// Render documentation comments as Markdown that regular LSP clients can display.
+///
+/// Rustdoc treats Rust code fences as examples and supports extra fence attributes plus
+/// hidden setup lines. LSP clients mostly see ordinary Markdown, so keep the document text
+/// intact while normalizing only the Rust example fences that need rustdoc-specific handling.
+pub(crate) fn render_rustdoc_markdown(markdown: &str) -> Option<String> {
+    let markdown = markdown.trim();
+    (!markdown.is_empty()).then(|| RustdocMarkdown::new(markdown).render())
+}
+
+struct RustdocMarkdown<'a> {
+    markdown: &'a str,
+}
+
+impl<'a> RustdocMarkdown<'a> {
+    fn new(markdown: &'a str) -> Self {
+        Self { markdown }
+    }
+
+    fn render(&self) -> String {
+        let mut rendered = Vec::new();
+        let mut open_fence: Option<MarkdownFence> = None;
+
+        for line in self.markdown.lines() {
+            if let Some(fence) = open_fence {
+                // Once inside a fence, only the matching closing marker returns us to
+                // regular Markdown. Non-Rust blocks pass through without inspection.
+                if fence.closes_with(line) {
+                    rendered.push(line.to_string());
+                    open_fence = None;
+                    continue;
+                }
+
+                if fence.is_rust
+                    && let Some(line) = Self::rustdoc_example_line(line)
+                {
+                    rendered.push(line);
+                } else if !fence.is_rust {
+                    rendered.push(line.to_string());
+                }
+                continue;
+            }
+
+            // Outside code fences we preserve Markdown verbatim, except for Rust example
+            // openings whose rustdoc attributes need to be hidden from the LSP client.
+            if let Some(fence) = MarkdownFence::opening(line) {
+                rendered.push(fence.render_opening(line));
+                open_fence = Some(fence);
+            } else {
+                rendered.push(line.to_string());
+            }
+        }
+
+        rendered.join("\n")
+    }
+
+    fn rustdoc_example_line(line: &str) -> Option<String> {
+        // Rustdoc hides setup lines that begin with `#` inside Rust examples. Doubling the
+        // marker escapes a visible leading hash, so `##[allow(...)]` renders as `#[allow(...)]`.
+        let content_start = line
+            .find(|ch| ch != ' ' && ch != '\t')
+            .unwrap_or(line.len());
+        let (indent, content) = line.split_at(content_start);
+
+        if let Some(content) = content.strip_prefix("##") {
+            return Some(format!("{indent}#{content}"));
+        }
+
+        (!content.starts_with('#')).then(|| line.to_string())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MarkdownFence {
+    // The original marker shape is enough to find the close and keep long fences valid.
+    marker: char,
+    len: usize,
+    is_rust: bool,
+}
+
+impl MarkdownFence {
+    fn opening(line: &str) -> Option<Self> {
+        let (_, rest) = Self::split_fence_indent(line)?;
+        let marker = rest.chars().next()?;
+        if marker != '`' && marker != '~' {
+            return None;
+        }
+
+        let len = rest.chars().take_while(|ch| *ch == marker).count();
+        if len < 3 {
+            return None;
+        }
+
+        let info = rest[len..].trim();
+        Some(Self {
+            marker,
+            len,
+            is_rust: Self::is_rustdoc_rust_info(info),
+        })
+    }
+
+    fn closes_with(self, line: &str) -> bool {
+        let Some((_, rest)) = Self::split_fence_indent(line) else {
+            return false;
+        };
+        let len = rest.chars().take_while(|ch| *ch == self.marker).count();
+        len >= self.len && rest[len..].trim().is_empty()
+    }
+
+    fn render_opening(self, original: &str) -> String {
+        if !self.is_rust {
+            return original.to_string();
+        }
+
+        let indent_len = original
+            .chars()
+            .take_while(|ch| *ch == ' ')
+            .map(char::len_utf8)
+            .sum::<usize>();
+        format!(
+            "{}{}rust",
+            &original[..indent_len],
+            self.marker.to_string().repeat(self.len)
+        )
+    }
+
+    fn split_fence_indent(line: &str) -> Option<(&str, &str)> {
+        let indent_len = line
+            .chars()
+            .take_while(|ch| *ch == ' ')
+            .map(char::len_utf8)
+            .sum::<usize>();
+        (indent_len <= 3).then(|| line.split_at(indent_len))
+    }
+
+    fn is_rustdoc_rust_info(info: &str) -> bool {
+        // Rustdoc treats bare fences and modifier-only fences as Rust examples. Unknown
+        // first attributes are left untouched so non-Rust Markdown keeps its original shape.
+        if info.is_empty() {
+            return true;
+        }
+
+        let Some(first_attribute) = info
+            .split(|ch: char| ch == ',' || ch.is_whitespace())
+            .find(|part| !part.is_empty())
+        else {
+            return true;
+        };
+
+        matches!(
+            first_attribute,
+            "rust"
+                | "rs"
+                | "allow_fail"
+                | "compile_fail"
+                | "edition2015"
+                | "edition2018"
+                | "edition2021"
+                | "edition2024"
+                | "ignore"
+                | "no_crate_inject"
+                | "no_run"
+                | "should_panic"
+                | "standalone_crate"
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_rustdoc_markdown;
+
+    #[test]
+    fn preserves_regular_markdown() {
+        let rendered = render_rustdoc_markdown(
+            r#"User account.
+
+- Stores profile data.
+
+```text
+# this is visible text
+```"#,
+        );
+
+        assert_eq!(
+            rendered.as_deref(),
+            Some(
+                r#"User account.
+
+- Stores profile data.
+
+```text
+# this is visible text
+```"#
+            )
+        );
+    }
+
+    #[test]
+    fn normalizes_rustdoc_rust_fences() {
+        let rendered = render_rustdoc_markdown(
+            r#"```rust,no_run
+# use app::User;
+let user = User::new();
+##[allow(unused)]
+```
+
+```compile_fail
+let value: u8 = "nope";
+```"#,
+        );
+
+        assert_eq!(
+            rendered.as_deref(),
+            Some(
+                r#"```rust
+let user = User::new();
+#[allow(unused)]
+```
+
+```rust
+let value: u8 = "nope";
+```"#
+            )
+        );
+    }
+
+    #[test]
+    fn keeps_unknown_fences_untouched() {
+        let rendered = render_rustdoc_markdown(
+            r#"```mermaid
+graph TD
+# node comment
+```"#,
+        );
+
+        assert_eq!(
+            rendered.as_deref(),
+            Some(
+                r#"```mermaid
+graph TD
+# node comment
+```"#
+            )
+        );
+    }
+}

--- a/crates/lsp/engine/src/proto/mod.rs
+++ b/crates/lsp/engine/src/proto/mod.rs
@@ -3,6 +3,7 @@
 pub(crate) mod completion;
 pub(crate) mod hover;
 pub(crate) mod inlay_hint;
+pub(crate) mod markdown;
 pub(crate) mod navigation;
 pub(crate) mod position;
 pub(crate) mod references;


### PR DESCRIPTION
fixes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced documentation rendering in hover information and completions with improved Rustdoc code example normalization for clearer documentation display

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rust-glancer/rust-glancer/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->