### PR TITLE
chore: Remove debugging server build from extension

### DIFF
--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -14,17 +14,19 @@ npm run compile
 Launch `Run Rust Glancer Extension` from VS Code. The launch configuration
 opens the repository root in an Extension Development Host.
 
-During development the extension starts the server through Cargo:
+During development the extension starts the configured `rust-glancer`
+executable, or `rust-glancer` from `PATH` when no path is configured. Build the
+server binary first if needed:
 
 ```text
-cargo run --release -p rust-glancer -- lsp
+cargo build --release -p rust-glancer
 ```
 
-To force a specific server binary, set:
+Then point the extension at that binary:
 
 ```json
 {
-  "rust-glancer.server.path": "/path/to/rust-glancer"
+  "rust-glancer.server.path": "/absolute/path/to/rust-glancer/target/release/rust-glancer"
 }
 ```
 

--- a/editors/code/src/extension-controller.ts
+++ b/editors/code/src/extension-controller.ts
@@ -22,12 +22,11 @@ export class ExtensionController implements vscode.Disposable {
 
   /** Wires VS Code workspace/editor events to the window-level LSP client lifecycle. */
   public constructor(
-    extensionPath: string,
     private readonly extensionLog: vscode.LogOutputChannel,
     serverOutput: vscode.OutputChannel,
     private readonly status: StatusView,
   ) {
-    this.clientSlot = new LanguageClientSlot(extensionPath, extensionLog, serverOutput, status);
+    this.clientSlot = new LanguageClientSlot(extensionLog, serverOutput, status);
     this.workspaceListeners = vscode.Disposable.from(
       vscode.window.onDidChangeActiveTextEditor((editor) => {
         void this.activateForEditor(editor);

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -34,7 +34,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const extensionLog = recordingExtensionLog ?? rawExtensionLog;
   const serverOutput = new ServerOutputChannel(recordingServerLog ?? rawServerLog);
   const status = new StatusView();
-  controller = new ExtensionController(context.extensionPath, extensionLog, serverOutput, status);
+  controller = new ExtensionController(extensionLog, serverOutput, status);
 
   // Extension-host tests need a stable synchronization point. Keep this command out of the
   // package manifest so it is available only when the test runner opts in through the environment.

--- a/editors/code/src/language-client/language-client-session.ts
+++ b/editors/code/src/language-client/language-client-session.ts
@@ -36,7 +36,6 @@ export class LanguageClientSession implements vscode.Disposable {
   private readonly clientStatus: ClientStatus;
 
   public constructor(
-    private readonly extensionPath: string,
     private readonly extensionLog: vscode.LogOutputChannel,
     private readonly serverOutput: vscode.OutputChannel,
     status: StatusView,
@@ -63,7 +62,7 @@ export class LanguageClientSession implements vscode.Disposable {
     }
 
     const config = ExtensionConfig.read();
-    const server = ResolvedServer.discover(config, this.workspaceFolder, this.extensionPath);
+    const server = ResolvedServer.discover(config, this.workspaceFolder);
     const statusDetails = {
       workspaceRoot: this.workspaceFolder.uri.fsPath,
       serverCommand: ResolvedServer.commandLine(server),

--- a/editors/code/src/language-client/language-client-slot.ts
+++ b/editors/code/src/language-client/language-client-slot.ts
@@ -16,7 +16,6 @@ export class LanguageClientSlot implements vscode.Disposable {
   private generation = 0;
 
   public constructor(
-    private readonly extensionPath: string,
     private readonly extensionLog: vscode.LogOutputChannel,
     private readonly serverOutput: vscode.OutputChannel,
     private readonly status: StatusView,
@@ -77,7 +76,6 @@ export class LanguageClientSlot implements vscode.Disposable {
     generation: number,
   ): Promise<LanguageClientSession | undefined> {
     const session = new LanguageClientSession(
-      this.extensionPath,
       this.extensionLog,
       this.serverOutput,
       this.status,

--- a/editors/code/src/language-client/server.ts
+++ b/editors/code/src/language-client/server.ts
@@ -1,12 +1,10 @@
 /**
  * Resolves and launches the rust-glancer language-server process for the window client.
  *
- * This module chooses between explicit settings, test overrides, development checkouts, and PATH,
- * then converts that decision into `vscode-languageclient` server options.
+ * This module chooses between explicit settings, test overrides, and PATH, then converts that
+ * decision into `vscode-languageclient` server options.
  */
 import { spawn, type ChildProcess } from "child_process";
-import * as fs from "fs";
-import * as path from "path";
 import * as vscode from "vscode";
 import type { ServerOptions } from "vscode-languageclient/node";
 
@@ -27,7 +25,6 @@ export namespace ResolvedServer {
   export function discover(
     config: ExtensionConfig,
     workspaceFolder: vscode.WorkspaceFolder,
-    extensionPath: string,
   ): ResolvedServer {
     if (config.serverPath !== undefined) {
       return executableServer(
@@ -41,17 +38,6 @@ export namespace ResolvedServer {
     const envServer = normalizeOptionalString(process.env[SERVER_ENV_OVERRIDE]);
     if (envServer !== undefined) {
       return executableServer(envServer, SERVER_ENV_OVERRIDE, config, workspaceFolder);
-    }
-
-    const repositoryRoot = path.resolve(extensionPath, "..", "..");
-    if (isDevelopmentCheckout(repositoryRoot)) {
-      return {
-        command: "cargo",
-        args: ["run", "--release", "-p", "rust-glancer", "--", "lsp"],
-        cwd: repositoryRoot,
-        env: buildEnv(config),
-        source: "development checkout",
-      };
     }
 
     return executableServer("rust-glancer", "PATH", config, workspaceFolder);
@@ -127,13 +113,6 @@ function expandEnv(value: string, env: NodeJS.ProcessEnv): string {
     const key = plain ?? braced;
     return env[key] ?? "";
   });
-}
-
-function isDevelopmentCheckout(repositoryRoot: string): boolean {
-  return (
-    fs.existsSync(path.join(repositoryRoot, "Cargo.toml")) &&
-    fs.existsSync(path.join(repositoryRoot, "crates", "rust-glancer", "Cargo.toml"))
-  );
 }
 
 function normalizeOptionalString(value: string | undefined): string | undefined {


### PR DESCRIPTION
It never really worked and never was used, so it's just wrong dead code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated VS Code extension setup instructions to use the built `rust-glancer` executable via configuration instead of development-mode commands.

* **Refactor**
  * Simplified extension server discovery mechanism by removing development checkout detection logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rust-glancer/rust-glancer/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->