### PR TITLE
feat: Add engine supervision

### DIFF
--- a/crates/lsp/server/src/backend.rs
+++ b/crates/lsp/server/src/backend.rs
@@ -65,12 +65,17 @@ impl Backend {
     }
 
     async fn active_method_context(&self) -> Result<Option<MethodContext>> {
-        Ok(self
+        let Some(engine_client) = self
             .registry()
             .await?
             .active_engine()
             .await
-            .map(|engine_client| self.method_context(engine_client)))
+            .map_err(methods::internal_error)?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(self.method_context(engine_client)))
     }
 }
 
@@ -118,6 +123,7 @@ impl LanguageServer for Backend {
             return Ok(());
         };
 
+        registry.begin_shutdown().await;
         for engine_client in registry.engine_clients().await {
             let context = self.method_context(engine_client);
             if let Err(error) = methods::shutdown(context).await {

--- a/crates/lsp/server/src/engine_process.rs
+++ b/crates/lsp/server/src/engine_process.rs
@@ -1,4 +1,11 @@
-use std::{fmt, io::Write as _, net::SocketAddr, process::Stdio, sync::Arc, time::Duration};
+use std::{
+    fmt,
+    io::Write as _,
+    net::SocketAddr,
+    process::{ExitStatus, Stdio},
+    sync::{Arc, Weak},
+    time::Duration,
+};
 
 use anyhow::Context as _;
 use futures::prelude::*;
@@ -25,7 +32,6 @@ const ENGINE_ID_ENV: &str = "RUST_GLANCER_ENGINE_ID";
 ///
 /// Process lifetime lives here; request-specific logic belongs to method handlers through
 /// `EngineClient`, while multi-engine routing lives one level up in the registry.
-#[derive(Clone)]
 pub(crate) struct EngineProcess {
     engine_client: EngineClient,
     // Kept alive so `kill_on_drop` remains tied to the server-side engine handle.
@@ -33,7 +39,10 @@ pub(crate) struct EngineProcess {
 }
 
 impl EngineProcess {
-    pub(crate) async fn spawn(lsp_client: LspClient, engine_id: String) -> anyhow::Result<Self> {
+    pub(crate) async fn spawn(
+        lsp_client: LspClient,
+        engine_id: String,
+    ) -> anyhow::Result<(Self, EngineProcessExitMonitor)> {
         // Initialize transport for engine service.
         let (mut engine_listener, engine_addr) = {
             // Both JSON and TCP are chosen for convenience of debugging, not that we need too much speed.
@@ -63,6 +72,8 @@ impl EngineProcess {
         // Spawn the engine subprocess.
         let mut child = Self::spawn_worker(engine_addr, notifications_addr, &engine_id)?;
         Self::spawn_stderr_forwarder(&mut child, &engine_id);
+        let child = Arc::new(Mutex::new(child));
+        let exit_monitor = EngineProcessExitMonitor::new(Arc::downgrade(&child));
 
         // Spawn the notifications publisher.
         {
@@ -119,10 +130,13 @@ impl EngineProcess {
             EngineClient::new(engine_service_client)
         };
 
-        Ok(Self {
-            engine_client,
-            _child: Arc::new(Mutex::new(child)),
-        })
+        Ok((
+            Self {
+                engine_client,
+                _child: child,
+            },
+            exit_monitor,
+        ))
     }
 
     pub(crate) fn engine_client(&self) -> &EngineClient {
@@ -192,5 +206,99 @@ impl EngineProcess {
 impl fmt::Debug for EngineProcess {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("EngineProcess").finish_non_exhaustive()
+    }
+}
+
+/// Process-exit observer handed to the registry after startup succeeds.
+pub(crate) struct EngineProcessExitMonitor {
+    child: Weak<Mutex<Child>>,
+}
+
+impl EngineProcessExitMonitor {
+    fn new(child: Weak<Mutex<Child>>) -> Self {
+        Self { child }
+    }
+
+    pub(crate) async fn wait(self) -> Option<EngineProcessExit> {
+        const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+        loop {
+            let Some(child) = self.child.upgrade() else {
+                return None;
+            };
+
+            // Polling through a weak handle keeps shutdown ownership simple: when the server
+            // drops the engine handle, `kill_on_drop` is free to clean up the child process.
+            let status = {
+                let mut child = child.lock().await;
+                child.try_wait()
+            };
+            match status {
+                Ok(Some(status)) => {
+                    return Some(EngineProcessExit::Exited(status));
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    return Some(EngineProcessExit::WaitFailed(error.to_string()));
+                }
+            }
+
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+}
+
+impl fmt::Debug for EngineProcessExitMonitor {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("EngineProcessExitMonitor")
+            .finish_non_exhaustive()
+    }
+}
+
+/// Terminal process event observed by the parent-side supervisor.
+#[derive(Debug)]
+pub(crate) enum EngineProcessExit {
+    Exited(ExitStatus),
+    WaitFailed(String),
+}
+
+impl EngineProcessExit {
+    pub(crate) fn failure_message(&self) -> String {
+        match self {
+            Self::Exited(status) => {
+                format!("engine process exited unexpectedly: {status}")
+            }
+            Self::WaitFailed(error) => {
+                format!("failed to supervise engine process: {error}")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EngineProcessExit;
+
+    #[cfg(unix)]
+    #[test]
+    fn exit_message_includes_process_status() {
+        use std::os::unix::process::ExitStatusExt as _;
+
+        let exit = EngineProcessExit::Exited(std::process::ExitStatus::from_raw(101 << 8));
+
+        assert_eq!(
+            exit.failure_message(),
+            "engine process exited unexpectedly: exit status: 101"
+        );
+    }
+
+    #[test]
+    fn wait_failure_message_names_supervision_failure() {
+        let exit = EngineProcessExit::WaitFailed("process handle unavailable".to_string());
+
+        assert_eq!(
+            exit.failure_message(),
+            "failed to supervise engine process: process handle unavailable"
+        );
     }
 }

--- a/crates/lsp/server/src/engine_process.rs
+++ b/crates/lsp/server/src/engine_process.rs
@@ -223,9 +223,7 @@ impl EngineProcessExitMonitor {
         const POLL_INTERVAL: Duration = Duration::from_millis(250);
 
         loop {
-            let Some(child) = self.child.upgrade() else {
-                return None;
-            };
+            let child = self.child.upgrade()?;
 
             // Polling through a weak handle keeps shutdown ownership simple: when the server
             // drops the engine handle, `kill_on_drop` is free to clean up the child process.

--- a/crates/lsp/server/src/engine_registry/mod.rs
+++ b/crates/lsp/server/src/engine_registry/mod.rs
@@ -1,16 +1,16 @@
 use std::{
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Weak},
 };
 
 use rg_lsp_proto::EngineConfig;
 use tokio::sync::Mutex;
-use tower_lsp_server::Client as LspClient;
+use tower_lsp_server::{Client as LspClient, ls_types::MessageType};
 
 use crate::{
     client_notifications::{ActiveWorkspaceChanged, ActiveWorkspaceStatus},
     engine_client::EngineClient,
-    engine_process::EngineProcess,
+    engine_process::{EngineProcess, EngineProcessExit, EngineProcessExitMonitor},
 };
 
 mod document_owner;
@@ -32,7 +32,7 @@ use self::{
 #[derive(Debug)]
 pub(crate) struct EngineRegistry {
     lsp_client: LspClient,
-    inner: Mutex<EngineRegistryInner>,
+    inner: Arc<Mutex<EngineRegistryInner>>,
 }
 
 impl EngineRegistry {
@@ -44,7 +44,10 @@ impl EngineRegistry {
     ) -> Self {
         Self {
             lsp_client,
-            inner: Mutex::new(EngineRegistryInner::new(workspace_folders, config)),
+            inner: Arc::new(Mutex::new(EngineRegistryInner::new(
+                workspace_folders,
+                config,
+            ))),
         }
     }
 
@@ -62,13 +65,24 @@ impl EngineRegistry {
     }
 
     /// Returns the currently active ready engine, if one has been selected.
-    pub(crate) async fn active_engine(&self) -> Option<EngineClient> {
+    pub(crate) async fn active_engine(&self) -> anyhow::Result<Option<EngineClient>> {
         let inner = self.inner.lock().await;
-        let id = inner.routing.active_id()?;
-        inner
-            .engine(id)
-            .and_then(EngineSlot::ready)
-            .map(|engine| engine.process.engine_client().clone())
+        let Some(id) = inner.routing.active_id() else {
+            return Ok(None);
+        };
+        match inner.engine(id) {
+            Some(EngineSlot::Ready(engine)) => Ok(Some(engine.process.engine_client().clone())),
+            Some(EngineSlot::Starting { .. }) | None => Ok(None),
+            Some(EngineSlot::Failed { root, error }) => Err(anyhow::anyhow!(
+                "rust-glancer engine for `{}` is unavailable: {error}",
+                root.display()
+            )),
+        }
+    }
+
+    /// Prevents expected child exits during LSP shutdown from becoming user-facing failures.
+    pub(crate) async fn begin_shutdown(&self) {
+        self.inner.lock().await.begin_shutdown();
     }
 
     /// Routes a newly opened document and records exact file ownership until `didClose`.
@@ -157,12 +171,15 @@ impl EngineRegistry {
             inner.workspace_status_update()
         };
 
-        self.publish_active_workspace(status).await;
+        Self::publish_active_workspace(&self.lsp_client, status).await;
     }
 
-    async fn publish_active_workspace(&self, status: Option<ActiveWorkspaceStatus>) {
+    async fn publish_active_workspace(
+        lsp_client: &LspClient,
+        status: Option<ActiveWorkspaceStatus>,
+    ) {
         if let Some(status) = status {
-            self.lsp_client
+            lsp_client
                 .send_notification::<ActiveWorkspaceChanged>(ActiveWorkspaceChanged::params(
                     &status,
                 ))
@@ -175,7 +192,8 @@ impl EngineRegistry {
         &self,
         start: ReservedEngineStart,
     ) -> anyhow::Result<EngineClient> {
-        let engine = match self.spawn_engine(start.root.clone(), start.config).await {
+        let spawned = self.spawn_engine(start.root.clone(), start.config).await;
+        let (engine, exit_monitor) = match spawned {
             Ok(engine) => engine,
             Err(error) => {
                 self.mark_failed(start.id, start.root, error.to_string())
@@ -204,6 +222,24 @@ impl EngineRegistry {
         }
 
         self.mark_ready(start.id, engine).await;
+
+        let inner = Arc::downgrade(&self.inner);
+        let lsp_client = self.lsp_client.clone();
+        let id = start.id;
+        let root = start.root;
+        // This is deliberately supervision, not recovery. An engine panic is a bug that should stay
+        // visible enough to report and fix, while automatic replacement would risk hiding the real
+        // problem or confusing server-side routing state.
+        // Once startup succeeds, this task is the whole supervision layer for the child process:
+        // it waits for one terminal event and marks the ready engine failed.
+        tokio::spawn(async move {
+            let Some(exit) = exit_monitor.wait().await else {
+                return;
+            };
+
+            Self::mark_exited(inner, lsp_client, id, root, exit).await;
+        });
+
         Ok(engine_client)
     }
 
@@ -220,7 +256,7 @@ impl EngineRegistry {
                     Some(EngineSlot::Starting { notify, .. }) => Some(notify.clone()),
                     Some(EngineSlot::Failed { root, error }) => {
                         return Err(anyhow::anyhow!(
-                            "rust-glancer engine for `{}` failed to start: {error}",
+                            "rust-glancer engine for `{}` is unavailable: {error}",
                             root.display()
                         ));
                     }
@@ -249,7 +285,7 @@ impl EngineRegistry {
             (notify, status)
         };
         notify.notify_waiters();
-        self.publish_active_workspace(status).await;
+        Self::publish_active_workspace(&self.lsp_client, status).await;
     }
 
     /// Replaces a starting slot with a failure and wakes waiters.
@@ -267,7 +303,50 @@ impl EngineRegistry {
         if let Some(notify) = notify {
             notify.notify_waiters();
         }
-        self.publish_active_workspace(status).await;
+        Self::publish_active_workspace(&self.lsp_client, status).await;
+    }
+
+    async fn mark_exited(
+        inner: Weak<Mutex<EngineRegistryInner>>,
+        lsp_client: LspClient,
+        id: EngineId,
+        root: PathBuf,
+        exit: EngineProcessExit,
+    ) {
+        let Some(inner) = inner.upgrade() else {
+            return;
+        };
+        let error = exit.failure_message();
+        let status = {
+            let mut inner = inner.lock().await;
+            if inner.shutting_down() {
+                return;
+            }
+
+            match inner.engine(id) {
+                Some(EngineSlot::Ready(_)) => {
+                    inner.engines[id.index()] = EngineSlot::Failed {
+                        root: root.clone(),
+                        error: Arc::from(error.as_str()),
+                    };
+                    inner.workspace_status_update()
+                }
+                _ => {
+                    return;
+                }
+            }
+        };
+
+        tracing::error!(
+            engine_id = id.index(),
+            root = %root.display(),
+            error = %error,
+            "rust-glancer engine became unavailable"
+        );
+        lsp_client
+            .log_message(MessageType::ERROR, format!("Rust Glancer {error}"))
+            .await;
+        Self::publish_active_workspace(&lsp_client, status).await;
     }
 
     /// Spawns the engine subprocess and sends its protocol initialize request.
@@ -275,8 +354,9 @@ impl EngineRegistry {
         &self,
         root: PathBuf,
         config: EngineConfig,
-    ) -> anyhow::Result<EngineProcess> {
-        let engine = EngineProcess::spawn(self.lsp_client.clone(), Self::engine_id(&root)).await?;
+    ) -> anyhow::Result<(EngineProcess, EngineProcessExitMonitor)> {
+        let (engine, exit_monitor) =
+            EngineProcess::spawn(self.lsp_client.clone(), Self::engine_id(&root)).await?;
         let engine_client = engine.engine_client().clone();
         let initialize_root = root.clone();
         engine_client
@@ -291,7 +371,7 @@ impl EngineRegistry {
             .await?;
 
         tracing::info!(root = %root.display(), "started rust-glancer engine");
-        Ok(engine)
+        Ok((engine, exit_monitor))
     }
 
     fn engine_id(root: &Path) -> String {
@@ -460,6 +540,42 @@ pub struct External;
         assert_eq!(failed.root, workspace_root);
         assert_eq!(failed.state, ActiveWorkspaceState::Failed);
         assert_eq!(failed.message.as_deref(), Some("startup failed"));
+    }
+
+    #[tokio::test]
+    async fn active_engine_reports_failed_slot() {
+        let fixture = fixture_crate(WORKSPACE_FIXTURE);
+        let (service, _socket) = initialized_service(&fixture);
+        let registry = &service.inner().registry;
+        let document = fixture.path("workspace/project_a/src/lib.rs");
+        let workspace_root = normalize_path(fixture.path("workspace"));
+
+        let id = {
+            let mut inner = registry.inner.lock().await;
+            let owner = DocumentOwner::new(&mut inner, &document, OpenFileCachePolicy::Record)
+                .expect("open document should route through Cargo workspace")
+                .expect("workspace document should have an owner");
+            inner.set_active_id(owner.id());
+            inner.engines[owner.id().index()] = EngineSlot::Failed {
+                root: workspace_root.clone(),
+                error: Arc::from("engine process exited unexpectedly: exit status: 101"),
+            };
+            owner.id()
+        };
+
+        let error = registry
+            .active_engine()
+            .await
+            .expect_err("failed active engine should be user-visible");
+
+        assert_eq!(id.index(), 0);
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "rust-glancer engine for `{}` is unavailable: engine process exited unexpectedly: exit status: 101",
+                workspace_root.display()
+            )
+        );
     }
 
     fn initialized_service(fixture: &CrateFixture) -> (LspService<TestBackend>, ClientSocket) {

--- a/crates/lsp/server/src/engine_registry/state.rs
+++ b/crates/lsp/server/src/engine_registry/state.rs
@@ -23,6 +23,7 @@ pub(super) struct EngineRegistryInner {
     pub(super) engines: Vec<EngineSlot>,
     config: EngineConfig,
     last_published_workspace_status: Option<ActiveWorkspaceStatus>,
+    shutting_down: bool,
 }
 
 impl EngineRegistryInner {
@@ -38,6 +39,7 @@ impl EngineRegistryInner {
             engines: Vec::new(),
             config,
             last_published_workspace_status: None,
+            shutting_down: false,
         }
     }
 
@@ -77,6 +79,14 @@ impl EngineRegistryInner {
 
     pub(super) fn set_active_id(&mut self, id: EngineId) {
         self.routing.set_active_id(id);
+    }
+
+    pub(super) fn begin_shutdown(&mut self) {
+        self.shutting_down = true;
+    }
+
+    pub(super) fn shutting_down(&self) -> bool {
+        self.shutting_down
     }
 
     /// Returns the active-workspace status if the client has not seen this exact state yet.


### PR DESCRIPTION
Watches for spawned engine processes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background supervision for engine processes to detect exits and report status.
  * Server now initiates registry shutdown sequence to coordinate engine shutdowns.

* **Bug Fixes**
  * Improved detection and user-visible reporting when engines become unavailable or fail.
  * Active-workspace status updates more reliably reflect engine readiness and failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rust-glancer/rust-glancer/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->