### PR TITLE
ci: Reconfigure renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -54,6 +54,19 @@
 
     "packageRules": [
         {
+            "description": "Do not update Cargo git dependencies pinned to refs/tags",
+            "matchManagers": [
+                "cargo"
+            ],
+            "matchDatasources": [
+                "git-refs",
+                "git-tags",
+                "github-tags",
+                "gitlab-tags"
+            ],
+            "enabled": false
+        },
+        {
             "description": "Group non-major Rust dependencies",
             "matchManagers": [
                 "cargo"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: taiki-e/install-action@285e94bf531e72a83c0923d52526fabb44c3b169 # nextest
+      - uses: taiki-e/install-action@6c1f7cf125e42770ff087ea443901b487cc5471a # v2.79.5
+        with:
+          tool: cargo-nextest@0.9.132
       - name: Run tests
         run: cargo nextest run --workspace
 
@@ -34,7 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: taiki-e/install-action@31aff3cbbd5cedd6280320e7d7871dd39147ed4c # just
+      - uses: taiki-e/install-action@6c1f7cf125e42770ff087ea443901b487cc5471a # v2.79.5
+        with:
+          tool: just@1.48.1
       - name: Check test targets
         run: just check-test-targets
 
@@ -71,7 +75,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: taiki-e/install-action@3a58a0b3ca97bb468adc27126d15973ca18bbfcb # cargo-deny
+      - uses: taiki-e/install-action@6c1f7cf125e42770ff087ea443901b487cc5471a # v2.79.5
+        with:
+          tool: cargo-deny@0.19.4
       - name: Run cargo deny
         run: cargo deny check
 

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -12,7 +12,6 @@ jobs:
     name: Run benchmarks
     runs-on: ubuntu-latest
     env:
-      CARGO_CODSPEED_VERSION: "4.6.0"
       RUST_GLANCER_BENCH_TARGETS: small_app
 
     permissions:
@@ -23,9 +22,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+        uses: taiki-e/install-action@6c1f7cf125e42770ff087ea443901b487cc5471a # v2.79.5
         with:
-          tool: cargo-codspeed@${{ env.CARGO_CODSPEED_VERSION }}
+          tool: cargo-codspeed@4.6.0
 
       - name: Build benchmark targets
         run: cargo codspeed build -p rg_project --bench analysis_pipeline

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -94,8 +94,6 @@ jobs:
   benchmark:
     name: benchmark
     runs-on: ubuntu-latest
-    env:
-      GUNGRAUN_RUNNER_VERSION: "0.18.2"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -105,9 +103,9 @@ jobs:
           version: valgrind-cache-v1
 
       - name: Install Gungraun runner
-        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+        uses: taiki-e/install-action@6c1f7cf125e42770ff087ea443901b487cc5471a # v2.79.5
         with:
-          tool: gungraun-runner@${{ env.GUNGRAUN_RUNNER_VERSION }}
+          tool: gungraun-runner@0.18.2
           fallback: none
 
       - name: Restore base Gungraun baseline

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ cargo_metadata = "0.23.1"
 derive_more = { version = "2.1.1" }
 divan = { package = "codspeed-divan-compat", version = "4.6.0" }
 drop_bomb = "0.1.5"
-edition = { git = "https://github.com/rust-lang/rust-analyzer", rev = "b8458013c217be4fccefc4e4f194026fa04ab4ca" }
 either = "1.15.0"
 expect-test = "1.5.1"
 futures = "0.3.32"
@@ -82,11 +81,9 @@ serde = "1.0.228"
 serde_json = "1.0.149"
 smallvec = "1.15.1"
 smol_str = "0.3.2"
-stdx = { git = "https://github.com/rust-lang/rust-analyzer", rev = "b8458013c217be4fccefc4e4f194026fa04ab4ca" }
 syn = "2.0"
 tarpc = "0.37"
 tempfile = "3.27.0"
-test-utils = { git = "https://github.com/rust-lang/rust-analyzer", rev = "b8458013c217be4fccefc4e4f194026fa04ab4ca" }
 text-size = "1.1.0"
 thiserror = "2.0.18"
 tokio = "1.52.3"
@@ -97,6 +94,11 @@ tikv-jemallocator = "0.6.1"
 tikv-jemalloc-sys = "0.6.1"
 ungrammar = "1.16.1"
 winnow = "0.7.13"
+
+# For vendored rust-analyzer crates
+stdx = { git = "https://github.com/rust-lang/rust-analyzer", rev = "b8458013c217be4fccefc4e4f194026fa04ab4ca" }
+edition = { git = "https://github.com/rust-lang/rust-analyzer", rev = "b8458013c217be4fccefc4e4f194026fa04ab4ca" }
+test-utils = { git = "https://github.com/rust-lang/rust-analyzer", rev = "b8458013c217be4fccefc4e4f194026fa04ab4ca" }
 
 rg_syntax = { path = "crates/engine/syntax" }
 rg_tt = { path = "crates/engine/tt" }


### PR DESCRIPTION
Renovate currently tries to update pinned git deps, which shouldn't happen; additionally, we currently pin install-action in a way that makes renovate noiser than it should be.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use pinned action versions for tool installations across linting, testing, benchmarking, and performance workflows.
  * Reorganized workspace dependency configurations to better manage vendored dependencies.
  * Updated Renovate configuration to control dependency update behavior for specific build dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rust-glancer/rust-glancer/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->