### PR TITLE
fix: Fix target visibility bug

### DIFF
--- a/crates/engine/analysis/src/query/completion/candidates.rs
+++ b/crates/engine/analysis/src/query/completion/candidates.rs
@@ -332,7 +332,7 @@ impl<'a, 'db> CompletionCandidateSource<'a, 'db> {
 
         let members = MemberView::new(self.db);
         let mut fields = Vec::new();
-        for field in members.field_candidates_for_ty(&receiver_ty)? {
+        for field in members.field_candidates_for_ty(receiver.body_ir().target, &receiver_ty)? {
             fields.push(field.field_ref());
         }
 
@@ -382,7 +382,7 @@ impl<'a, 'db> CompletionCandidateSource<'a, 'db> {
 
         let members = MemberView::new(self.db);
         let mut methods = Vec::new();
-        for method in members.method_candidates_for_ty(&receiver_ty)? {
+        for method in members.method_candidates_for_ty(receiver.body_ir().target, &receiver_ty)? {
             methods.push(Self::dot_method_candidate(method));
         }
 

--- a/crates/engine/analysis/src/query/member.rs
+++ b/crates/engine/analysis/src/query/member.rs
@@ -5,10 +5,10 @@
 
 use rg_body_ir::BodyScopeQuery;
 use rg_ir_model::{
-    BodyRef, FieldRef, FunctionRef, ItemOwner, ScopeId, TypePathResolution,
+    BodyRef, FieldRef, FunctionRef, ItemOwner, ScopeId, TargetRef, TypePathResolution,
     hir::items::{FieldData, FunctionData},
 };
-use rg_ir_storage::{ItemStoreQuery, Path};
+use rg_ir_storage::{ItemStoreQuery, Path, TargetItemQuery};
 use rg_ir_view::{IndexedViewDb, item::path::PathView};
 use rg_item_tree::{Documentation, FieldKey, ParamItem};
 pub(crate) use rg_ty::MemberMethodOrigin;
@@ -125,10 +125,14 @@ impl<'a, 'db> MemberView<'a, 'db> {
 
     pub(crate) fn field_candidates_for_ty<'view>(
         &'view self,
+        use_site: TargetRef,
         ty: &Ty,
     ) -> anyhow::Result<Vec<MemberField<'view>>> {
         let mut fields = Vec::new();
-        let member_query = MemberQuery::new(ItemPathQuery::new(self.db, self.db));
+        let member_query = MemberQuery::new(
+            ItemPathQuery::new(self.db, self.db),
+            TargetItemQuery::new(self.db, self.db, use_site),
+        );
         for field_ref in member_query.fields_for_ty(ty)? {
             let Some(field) = self.field(field_ref)? else {
                 continue;
@@ -151,7 +155,10 @@ impl<'a, 'db> MemberView<'a, 'db> {
             .resolve_type_path_in_scope(scope, path)?;
 
         let mut fields = Vec::new();
-        let member_query = MemberQuery::new(ItemPathQuery::new(self.db, self.db));
+        let member_query = MemberQuery::new(
+            ItemPathQuery::new(self.db, self.db),
+            TargetItemQuery::new(self.db, self.db, body.target),
+        );
         if let TypePathResolution::SelfType(types) | TypePathResolution::TypeDefs(types) =
             resolution
         {
@@ -185,10 +192,14 @@ impl<'a, 'db> MemberView<'a, 'db> {
 
     pub(crate) fn method_candidates_for_ty<'view>(
         &'view self,
+        use_site: TargetRef,
         ty: &Ty,
     ) -> anyhow::Result<Vec<MemberMethodCandidate<'view>>> {
         let mut methods = Vec::new();
-        let member_query = MemberQuery::new(ItemPathQuery::new(self.db, self.db));
+        let member_query = MemberQuery::new(
+            ItemPathQuery::new(self.db, self.db),
+            TargetItemQuery::new(self.db, self.db, use_site),
+        );
         for candidate in member_query.method_candidates_for_ty(ty)? {
             let Some(function) = self.function(candidate.function())? else {
                 continue;

--- a/crates/engine/analysis/src/query/navigation/implementation.rs
+++ b/crates/engine/analysis/src/query/navigation/implementation.rs
@@ -5,7 +5,7 @@ use rg_ir_model::{
     FunctionRef, ImplRef, SemanticItemRef, TargetRef,
     identity::{DeclarationRef, ExprRef},
 };
-use rg_ir_storage::ItemStoreQuery;
+use rg_ir_storage::{ItemStoreQuery, TargetItemQuery};
 use rg_parse::FileId;
 use rg_ty::{ImplementationQuery, ItemPathQuery, Ty};
 
@@ -50,14 +50,17 @@ impl<'a, 'db> ImplementationResolver<'a, 'db> {
         for declaration in source_symbols.declarations_for_symbol(symbol.clone())? {
             Self::extend_unique_declarations(
                 &mut declarations,
-                self.implementations_for_declaration(declaration)?,
+                self.implementations_for_declaration(target, declaration)?,
             );
         }
 
         if declarations.is_empty()
             && let Some(ty) = source_symbols.ty_for_symbol(symbol)?
         {
-            Self::extend_unique_declarations(&mut declarations, self.implementations_for_ty(&ty)?);
+            Self::extend_unique_declarations(
+                &mut declarations,
+                self.implementations_for_ty(target, &ty)?,
+            );
         }
 
         NavigationTargetProjection::new(self.0.view_db()).targets_for_declarations(declarations)
@@ -88,8 +91,10 @@ impl<'a, 'db> ImplementationResolver<'a, 'db> {
             return Ok(None);
         }
 
-        let implementation_query =
-            ImplementationQuery::new(ItemPathQuery::new(self.0.view_db(), self.0.view_db()));
+        let implementation_query = ImplementationQuery::new(
+            ItemPathQuery::new(self.0.view_db(), self.0.view_db()),
+            TargetItemQuery::new(self.0.view_db(), self.0.view_db(), body_ref.target),
+        );
         let mut implementations = Vec::new();
         for declaration in declarations {
             let Some(function) = self.function_ref_for_declaration(declaration)? else {
@@ -105,10 +110,13 @@ impl<'a, 'db> ImplementationResolver<'a, 'db> {
 
     fn implementations_for_declaration(
         &self,
+        use_site: TargetRef,
         declaration: DeclarationRef,
     ) -> anyhow::Result<Vec<DeclarationRef>> {
-        let implementation_query =
-            ImplementationQuery::new(ItemPathQuery::new(self.0.view_db(), self.0.view_db()));
+        let implementation_query = ImplementationQuery::new(
+            ItemPathQuery::new(self.0.view_db(), self.0.view_db()),
+            TargetItemQuery::new(self.0.view_db(), self.0.view_db(), use_site),
+        );
         let mut implementations = Vec::new();
 
         match declaration {
@@ -167,9 +175,15 @@ impl<'a, 'db> ImplementationResolver<'a, 'db> {
         Ok(implementations)
     }
 
-    fn implementations_for_ty(&self, ty: &Ty) -> anyhow::Result<Vec<DeclarationRef>> {
-        let implementation_query =
-            ImplementationQuery::new(ItemPathQuery::new(self.0.view_db(), self.0.view_db()));
+    fn implementations_for_ty(
+        &self,
+        use_site: TargetRef,
+        ty: &Ty,
+    ) -> anyhow::Result<Vec<DeclarationRef>> {
+        let implementation_query = ImplementationQuery::new(
+            ItemPathQuery::new(self.0.view_db(), self.0.view_db()),
+            TargetItemQuery::new(self.0.view_db(), self.0.view_db(), use_site),
+        );
         let mut implementations = Vec::new();
         Self::extend_impl_refs(&mut implementations, implementation_query.impls_for_ty(ty)?);
         Ok(implementations)

--- a/crates/engine/analysis/src/query/symbols/indexed.rs
+++ b/crates/engine/analysis/src/query/symbols/indexed.rs
@@ -221,7 +221,7 @@ impl<'a, 'db> SymbolItemIndex<'a, 'db> {
     }
 
     fn included_targets(&self) -> Result<Vec<TargetRef>> {
-        Ok(ItemStoreQuery::new(self.db).visible_target_refs()?)
+        Ok(ItemStoreQuery::new(self.db).included_target_refs()?)
     }
 
     fn module_declarations(&self, target: TargetRef) -> Result<Vec<DeclarationRef>> {

--- a/crates/engine/analysis/src/tests/hover.rs
+++ b/crates/engine/analysis/src/tests/hover.rs
@@ -389,6 +389,79 @@ pub fn use_roots(_: cra$crate_root_hover$te::Api, _: de$dep_root_hover$p::Thing)
 }
 
 #[test]
+fn hovers_over_method_when_unrelated_workspace_crate_has_same_named_trait_method() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["crates/shared", "crates/unrelated", "crates/app"]
+resolver = "3"
+
+//- /crates/shared/Cargo.toml
+[package]
+name = "shared"
+version = "0.1.0"
+edition = "2024"
+
+//- /crates/shared/src/lib.rs
+pub struct Maybe<T>(T);
+pub struct User;
+pub struct Label;
+
+impl<T> Maybe<T> {
+    pub fn and_then(self) -> Label {
+        Label
+    }
+}
+
+//- /crates/unrelated/Cargo.toml
+[package]
+name = "unrelated"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+shared = { path = "../shared" }
+
+//- /crates/unrelated/src/lib.rs
+pub trait Layer<S> {
+    fn and_then(self) -> S;
+}
+
+impl<T, S> Layer<S> for shared::Maybe<T> {
+    fn and_then(self) -> S {
+        loop {}
+    }
+}
+
+//- /crates/app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+shared = { path = "../shared" }
+
+//- /crates/app/src/lib.rs
+pub fn demo(maybe: shared::Maybe<shared::User>) {
+    let _label = maybe.an$method_hover$d_then();
+}
+"#,
+        &[AnalysisQuery::hover("hover visible method", "method_hover").in_lib("app")],
+        expect![[r#"
+            hover visible method
+            - range: 2:18-2:34
+            - block:
+              kind: method
+              path: shared::Maybe::and_then
+              signature:
+                pub fn and_then(self) -> Label
+        "#]],
+    );
+}
+
+#[test]
 fn hovers_with_bounded_item_previews() {
     check_analysis_queries(
         r#"

--- a/crates/engine/body-ir/src/build/resolve.rs
+++ b/crates/engine/body-ir/src/build/resolve.rs
@@ -4,7 +4,7 @@ use anyhow::Context as _;
 use rayon::prelude::*;
 use rg_def_map::{DefMapReadTxn, PackageSlot};
 use rg_ir_model::{BodyId, BodyRef, TargetRef};
-use rg_ir_storage::{ItemLookupIndex, ItemStoreQuery};
+use rg_ir_storage::{ItemLookupIndex, TargetItemQuery};
 use rg_package_store::PackageStoreError;
 use rg_parse::TargetId;
 use rg_semantic_ir::SemanticIrReadTxn;
@@ -24,19 +24,9 @@ pub(super) fn resolve_packages(
     def_map: &DefMapReadTxn<'_>,
     semantic_ir: &SemanticIrReadTxn<'_>,
 ) -> anyhow::Result<()> {
-    let item_query = ItemStoreQuery::new(semantic_ir);
-    let semantic_index = ItemLookupIndex::build(&item_query)
-        .context("while attempting to build semantic index for body resolution")?;
-
     if packages.len() <= 1 {
         for (package_idx, package) in packages.iter_mut().enumerate() {
-            resolve_package(
-                PackageSlot(package_idx),
-                package,
-                def_map,
-                semantic_ir,
-                &semantic_index,
-            )?;
+            resolve_package(PackageSlot(package_idx), package, def_map, semantic_ir)?;
         }
         return Ok(());
     }
@@ -46,13 +36,7 @@ pub(super) fn resolve_packages(
         .install(|| {
             packages.par_iter_mut().enumerate().try_for_each(
                 |(package_idx, package)| -> Result<(), PackageStoreError> {
-                    resolve_package(
-                        PackageSlot(package_idx),
-                        package,
-                        def_map,
-                        semantic_ir,
-                        &semantic_index,
-                    )
+                    resolve_package(PackageSlot(package_idx), package, def_map, semantic_ir)
                 },
             )
         })
@@ -64,19 +48,9 @@ pub(super) fn resolve_selected_packages(
     def_map: &DefMapReadTxn<'_>,
     semantic_ir: &SemanticIrReadTxn<'_>,
 ) -> anyhow::Result<()> {
-    let item_query = ItemStoreQuery::new(semantic_ir);
-    let semantic_index = ItemLookupIndex::build(&item_query)
-        .context("while attempting to build semantic index for body resolution")?;
-
     if packages.len() <= 1 {
         for (package_slot, package) in packages {
-            resolve_package(
-                *package_slot,
-                package,
-                def_map,
-                semantic_ir,
-                &semantic_index,
-            )?;
+            resolve_package(*package_slot, package, def_map, semantic_ir)?;
         }
         return Ok(());
     }
@@ -88,13 +62,7 @@ pub(super) fn resolve_selected_packages(
                 .par_iter_mut()
                 .try_for_each(|entry| -> Result<(), PackageStoreError> {
                     let package_slot = entry.0;
-                    resolve_package(
-                        package_slot,
-                        &mut entry.1,
-                        def_map,
-                        semantic_ir,
-                        &semantic_index,
-                    )
+                    resolve_package(package_slot, &mut entry.1, def_map, semantic_ir)
                 })
         })
         .context("while attempting to resolve selected body IR packages")
@@ -105,7 +73,6 @@ fn resolve_package(
     package: &mut PackageBodies,
     def_map_txn: &DefMapReadTxn<'_>,
     semantic_ir: &SemanticIrReadTxn<'_>,
-    semantic_index: &ItemLookupIndex,
 ) -> Result<(), PackageStoreError> {
     // Resolution is a mutation pass over already-lowered bodies. Skipped targets intentionally
     // keep their body stores empty so dependency body internals stay cheap by default.
@@ -118,6 +85,10 @@ fn resolve_package(
             package: package_slot,
             target: TargetId(target_idx),
         };
+
+        let target_items = TargetItemQuery::new(def_map_txn, semantic_ir, target_ref);
+        let semantic_index = ItemLookupIndex::build_from(&target_items)?;
+
         for (body_idx, body) in target.bodies_mut().iter_mut().enumerate() {
             let body_ref = BodyRef {
                 target: target_ref,
@@ -131,7 +102,7 @@ fn resolve_package(
             body.body_def_map = Some(body_def_map);
             body.body_item_store = Some(body_item_store);
 
-            BodyResolver::new(def_map_txn, semantic_ir, semantic_index, body_ref, body)
+            BodyResolver::new(def_map_txn, semantic_ir, &semantic_index, body_ref, body)
                 .resolve()?;
         }
     }

--- a/crates/engine/body-ir/src/resolution/body.rs
+++ b/crates/engine/body-ir/src/resolution/body.rs
@@ -10,7 +10,7 @@ use rg_ir_model::{
 };
 use rg_ir_storage::{
     DefMapQuery, DefMapSource, ItemLookupIndex, ItemStoreQuery, ItemStoreSource,
-    NameResolutionFilter, Path, PathSegment, TypePathContext,
+    NameResolutionFilter, Path, PathSegment, TargetItemQuery, TypePathContext,
 };
 use rg_item_tree::FieldKey;
 use rg_package_store::PackageStoreError;
@@ -69,14 +69,18 @@ where
 
     fn autoderef(&self) -> Autoderef<'_, BodyQuerySource<'_, &D, &I>, BodyQuerySource<'_, &D, &I>> {
         let source = self.query_source();
-        Autoderef::with_index(ItemPathQuery::new(source, source), self.semantic_index)
+        let item_paths = ItemPathQuery::new(source, source);
+        let target_items = TargetItemQuery::new(source, source, self.body_ref.target);
+        Autoderef::with_index(item_paths, target_items, self.semantic_index)
     }
 
     fn impl_matcher(
         &self,
     ) -> ImplMatcher<'_, BodyQuerySource<'_, &D, &I>, BodyQuerySource<'_, &D, &I>> {
         let source = self.query_source();
-        ImplMatcher::new(ItemPathQuery::new(source, source))
+        let item_paths = ItemPathQuery::new(source, source);
+        let target_items = TargetItemQuery::new(source, source, self.body_ref.target);
+        ImplMatcher::new(item_paths, target_items)
     }
 
     fn item_query(&self) -> ItemStoreQuery<'_, BodyQuerySource<'_, &D, &I>> {
@@ -596,8 +600,10 @@ where
     ) -> Result<Vec<FunctionRef>, PackageStoreError> {
         let mut functions = Vec::new();
         if ty.def.origin == DefMapRef::Body(self.body_ref) {
+            let source = self.query_source();
             let item_query = self.item_query();
-            for function in item_query.inherent_functions_for_type(ty.def)? {
+            let target_items = TargetItemQuery::new(source, source, self.body_ref.target);
+            for function in target_items.inherent_functions_for_type(ty.def)? {
                 let Some(function_data) = item_query.function_data(function)? else {
                     continue;
                 };
@@ -617,21 +623,26 @@ where
 
         let source = self.query_source();
         let item_paths = ItemPathQuery::new(source, source);
+        let target_items = TargetItemQuery::new(source, source, self.body_ref.target);
         for function in self
             .semantic_index
             .inherent_functions_for_type_and_name(ty.def, method_name)
             .to_vec()
         {
-            if ImplMatcher::new(item_paths.clone()).function_applies_to_receiver(function, ty)? {
+            if ImplMatcher::new(item_paths.clone(), target_items.clone())
+                .function_applies_to_receiver(function, ty)?
+            {
                 functions.push(function);
             }
         }
 
-        for (function, _) in ImplMatcher::new(item_paths).trait_function_candidates_for_receiver(
-            Some(self.semantic_index),
-            ty,
-            Some(method_name),
-        )? {
+        for (function, _) in ImplMatcher::new(item_paths, target_items)
+            .trait_function_candidates_for_receiver(
+                Some(self.semantic_index),
+                ty,
+                Some(method_name),
+            )?
+        {
             push_unique(&mut functions, function);
         }
         Ok(functions)
@@ -855,7 +866,9 @@ where
         &self,
     ) -> ImplMatcher<'query, BodyQuerySource<'query, D, I>, BodyQuerySource<'query, D, I>> {
         let source = self.source;
-        ImplMatcher::new(ItemPathQuery::new(source, source))
+        let item_paths = ItemPathQuery::new(source, source);
+        let target_items = TargetItemQuery::new(source, source, self.source.body_ref().target);
+        ImplMatcher::new(item_paths, target_items)
     }
 
     fn item_query(&self) -> ItemStoreQuery<'query, BodyQuerySource<'query, D, I>> {
@@ -1222,8 +1235,10 @@ where
     ) -> Result<Vec<FunctionRef>, PackageStoreError> {
         let mut functions = Vec::new();
         if ty.def.origin == DefMapRef::Body(self.source.body_ref()) {
+            let source = self.source;
             let item_query = self.item_query();
-            for function in item_query.inherent_functions_for_type(ty.def)? {
+            let target_items = TargetItemQuery::new(source, source, self.source.body_ref().target);
+            for function in target_items.inherent_functions_for_type(ty.def)? {
                 let Some(function_data) = item_query.function_data(function)? else {
                     continue;
                 };
@@ -1240,22 +1255,23 @@ where
 
         let source = self.source;
         let item_paths = ItemPathQuery::new(source, source);
+        let target_items = TargetItemQuery::new(source, source, self.source.body_ref().target);
         let inherent_functions = match self.semantic_index {
             Some(index) => index.inherent_functions_for_type(item_paths.items(), ty.def)?,
-            None => item_paths.items().inherent_functions_for_type(ty.def)?,
+            None => target_items.inherent_functions_for_type(ty.def)?,
         };
 
         for function in inherent_functions {
-            if ImplMatcher::new(item_paths.clone()).function_applies_to_receiver(function, ty)? {
+            if ImplMatcher::new(item_paths.clone(), target_items.clone())
+                .function_applies_to_receiver(function, ty)?
+            {
                 functions.push(function);
             }
         }
 
-        for (function, _) in ImplMatcher::new(item_paths).trait_function_candidates_for_receiver(
-            self.semantic_index,
-            ty,
-            None,
-        )? {
+        for (function, _) in ImplMatcher::new(item_paths, target_items)
+            .trait_function_candidates_for_receiver(self.semantic_index, ty, None)?
+        {
             push_unique(&mut functions, function);
         }
         Ok(functions)
@@ -1266,8 +1282,10 @@ where
         ty: &NominalTy,
         name: &str,
     ) -> Result<Option<(ConstRef, Ty)>, PackageStoreError> {
+        let source = self.source;
         let item_query = self.item_query();
-        for impl_ref in item_query.inherent_impls_for_type(ty.def)? {
+        let target_items = TargetItemQuery::new(source, source, self.source.body_ref().target);
+        for impl_ref in target_items.inherent_impls_for_type(ty.def)? {
             let Some(impl_data) = item_query.impl_data(impl_ref)? else {
                 continue;
             };

--- a/crates/engine/body-ir/src/resolution/query_source.rs
+++ b/crates/engine/body-ir/src/resolution/query_source.rs
@@ -94,7 +94,7 @@ where
         }
     }
 
-    fn visible_stores(&self) -> Result<Vec<&'a ItemStore>, Self::Error> {
-        self.item_stores.visible_stores()
+    fn included_stores(&self) -> Result<Vec<&'a ItemStore>, Self::Error> {
+        self.item_stores.included_stores()
     }
 }

--- a/crates/engine/body-ir/src/resolution/type_path.rs
+++ b/crates/engine/body-ir/src/resolution/type_path.rs
@@ -9,7 +9,7 @@ use rg_ir_model::{
 };
 use rg_ir_storage::{
     DefMapQuery, DefMapSource, ItemStoreQuery, ItemStoreSource, NameResolutionFilter, Path,
-    PathSegment, TypePathContext,
+    PathSegment, TargetItemQuery, TypePathContext,
 };
 use rg_item_tree::{GenericArg as ItemGenericArg, TypePath, TypeRef};
 use rg_package_store::PackageStoreError;
@@ -34,7 +34,9 @@ where
         &self,
     ) -> ImplMatcher<'query, BodyQuerySource<'query, D, I>, BodyQuerySource<'query, D, I>> {
         let source = self.source;
-        ImplMatcher::new(ItemPathQuery::new(source, source))
+        let item_paths = ItemPathQuery::new(source, source);
+        let target_items = TargetItemQuery::new(source, source, self.source.body_ref().target);
+        ImplMatcher::new(item_paths, target_items)
     }
 
     fn item_query(&self) -> ItemStoreQuery<'query, BodyQuerySource<'query, D, I>> {
@@ -360,7 +362,9 @@ where
         }
 
         let item_query = self.item_query();
-        for impl_ref in item_query.inherent_impls_for_type(ty.def)? {
+        let source = self.source;
+        let target_items = TargetItemQuery::new(source, source, self.source.body_ref().target);
+        for impl_ref in target_items.inherent_impls_for_type(ty.def)? {
             let Some(impl_data) = item_query.impl_data(impl_ref)? else {
                 continue;
             };

--- a/crates/engine/body-ir/src/tests/trait_methods.rs
+++ b/crates/engine/body-ir/src/tests/trait_methods.rs
@@ -126,3 +126,124 @@ pub fn use_it(user: User, wrapper: Wrapper<Error>) {
         "#]],
     );
 }
+
+#[test]
+fn method_lookup_excludes_traits_from_unrelated_workspace_targets() {
+    check_project_body_ir(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["crates/shared", "crates/app", "crates/other"]
+resolver = "3"
+
+//- /crates/shared/Cargo.toml
+[package]
+name = "shared"
+version = "0.1.0"
+edition = "2024"
+
+//- /crates/shared/src/lib.rs
+pub struct Maybe;
+
+impl Maybe {
+    pub fn is_some(&self) -> bool {
+        true
+    }
+}
+
+//- /crates/app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+shared = { path = "../shared" }
+
+//- /crates/app/src/lib.rs
+use shared::Maybe;
+
+pub fn use_it(maybe: Maybe) {
+    let ok = maybe.is_some();
+    let missing = maybe.and_then();
+}
+
+//- /crates/other/Cargo.toml
+[package]
+name = "other"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+shared = { path = "../shared" }
+
+//- /crates/other/src/lib.rs
+use shared::Maybe;
+
+pub trait OtherExt {
+    fn and_then(&self) -> bool;
+}
+
+impl OtherExt for Maybe {
+    fn and_then(&self) -> bool {
+        true
+    }
+}
+"#,
+        expect![[r#"
+            package app
+
+            app [lib]
+            body b0 fn app[lib]::crate::use_it @ 3:1-6:2
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: v1, v2
+            bindings
+            - v0 param maybe `maybe`: Maybe => nominal struct shared[lib]::crate::Maybe @ 3:15-3:20
+            - v1 let ok `ok` => bool @ 4:9-4:11
+            - v2 let missing `missing` => <unknown> @ 5:9-5:16
+            body
+            expr e4 block s1 => () @ 3:29-6:2
+              stmt s0 let v1 @ 4:5-4:30
+                initializer
+                  expr e1 method_call is_some -> fn impl Maybe::is_some => bool @ 4:14-4:29
+                    receiver
+                      expr e0 path maybe -> local v0 => nominal struct shared[lib]::crate::Maybe @ 4:14-4:19
+              stmt s1 let v2 @ 5:5-5:36
+                initializer
+                  expr e3 method_call and_then => <unknown> @ 5:19-5:35
+                    receiver
+                      expr e2 path maybe -> local v0 => nominal struct shared[lib]::crate::Maybe @ 5:19-5:24
+
+
+            package other
+
+            other [lib]
+            body b0 fn impl OtherExt for Maybe::and_then @ 8:5-10:6
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: <none>
+            bindings
+            - v0 self_param self `&self` => &Self struct shared[lib]::crate::Maybe @ 8:17-8:22
+            body
+            expr e1 block s1 => <unknown> @ 8:32-10:6
+              tail
+                expr e0 literal bool `true` => <unknown> @ 9:9-9:13
+
+
+            package shared
+
+            shared [lib]
+            body b0 fn impl Maybe::is_some @ 4:5-6:6
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: <none>
+            bindings
+            - v0 self_param self `&self` => &Self struct shared[lib]::crate::Maybe @ 4:20-4:25
+            body
+            expr e1 block s1 => <unknown> @ 4:35-6:6
+              tail
+                expr e0 literal bool `true` => <unknown> @ 5:9-5:13
+        "#]],
+    );
+}

--- a/crates/engine/ir-storage/src/def_map/query/def_map_query.rs
+++ b/crates/engine/ir-storage/src/def_map/query/def_map_query.rs
@@ -128,6 +128,37 @@ where
             .unwrap_or_default())
     }
 
+    /// Returns targets whose DefMap roots are visible from `root`.
+    ///
+    /// This is the target-level language visibility closure: the target itself plus targets named
+    /// by external roots and preludes reachable from it. It is intentionally separate from package
+    /// transaction inclusion, which is only a storage/materialization boundary.
+    pub fn visible_targets_from(&self, root: TargetRef) -> Result<Vec<TargetRef>, S::Error> {
+        let mut visible_targets = Vec::new();
+        let mut pending_targets = vec![root];
+
+        while let Some(target) = pending_targets.pop() {
+            if visible_targets.contains(&target) {
+                continue;
+            }
+            visible_targets.push(target);
+
+            for (_, module) in self.source.extern_roots(target)? {
+                if let Some(target) = module.origin.as_target_ref() {
+                    pending_targets.push(target);
+                }
+            }
+
+            if let Some(module) = self.source.prelude_module(target)?
+                && let Some(target) = module.origin.as_target_ref()
+            {
+                pending_targets.push(target);
+            }
+        }
+
+        Ok(visible_targets)
+    }
+
     pub fn local_def_data(
         &self,
         local_def_ref: LocalDefRef,

--- a/crates/engine/ir-storage/src/item/lookup_index.rs
+++ b/crates/engine/ir-storage/src/item/lookup_index.rs
@@ -9,9 +9,9 @@ use std::collections::HashMap;
 use rg_ir_model::{AssocItemId, FunctionRef, ImplRef, TraitImplRef, TraitRef, TypeDefRef};
 use rg_text::Name;
 
-use crate::{ItemStoreQuery, ItemStoreSource, push_unique};
+use crate::{ItemStoreQuery, ItemStoreSource, TargetItemQuery, push_unique};
 
-/// Receiver-oriented lookup cache built from the stores visible to an `ItemStoreQuery`.
+/// Receiver-oriented lookup cache built from the stores visible from one use-site target.
 #[derive(Debug, Default)]
 pub struct ItemLookupIndex {
     // Method lookup starts from a receiver type. These maps let callers jump directly to impls
@@ -26,16 +26,19 @@ pub struct ItemLookupIndex {
 }
 
 impl ItemLookupIndex {
-    /// Builds an index from the stores that are visible to broad item lookup.
-    pub fn build<'item, S>(item_query: &ItemStoreQuery<'item, S>) -> Result<Self, S::Error>
+    /// Builds an index from the stores visible from one use-site target.
+    pub fn build_from<'item, D, I>(
+        target_items: &TargetItemQuery<'item, D, I>,
+    ) -> Result<Self, I::Error>
     where
-        S: ItemStoreSource<'item>,
+        D: crate::DefMapSource<Error = I::Error>,
+        I: ItemStoreSource<'item>,
     {
         let mut index = Self::default();
 
-        // The index mirrors broad item-store lookup helpers, but pays the store scan once up front
-        // instead of once per method expression.
-        for store in item_query.visible_stores()? {
+        // The index mirrors target-scoped item-store lookup helpers, but pays the store scan once
+        // up front instead of once per method expression.
+        for store in target_items.visible_stores()? {
             // Trait methods are independent of a receiver type, so cache them by trait before
             // processing impls that later point back to these traits.
             for (trait_ref, trait_data) in store.traits_with_refs() {
@@ -51,7 +54,9 @@ impl ItemLookupIndex {
                             id: *id,
                         };
                         push_unique(functions, function_ref);
-                        if let Some(function_data) = item_query.function_data(function_ref)? {
+                        if let Some(function_data) =
+                            target_items.items().function_data(function_ref)?
+                        {
                             push_unique(
                                 index
                                     .trait_functions_by_trait_and_name
@@ -82,7 +87,8 @@ impl ItemLookupIndex {
                                     origin: impl_ref.origin,
                                     id: *id,
                                 };
-                                let Some(function_data) = item_query.function_data(function_ref)?
+                                let Some(function_data) =
+                                    target_items.items().function_data(function_ref)?
                                 else {
                                     continue;
                                 };

--- a/crates/engine/ir-storage/src/item/mod.rs
+++ b/crates/engine/ir-storage/src/item/mod.rs
@@ -7,7 +7,7 @@ mod view;
 pub use self::{
     context::TypePathContext,
     lookup_index::ItemLookupIndex,
-    query::{ItemStoreQuery, ItemStoreSource},
+    query::{ItemStoreQuery, ItemStoreSource, TargetItemQuery},
     store::{ItemStore, ItemStoreBuilder},
     view::SemanticItemView,
 };

--- a/crates/engine/ir-storage/src/item/query/item_store.rs
+++ b/crates/engine/ir-storage/src/item/query/item_store.rs
@@ -5,8 +5,7 @@
 
 use rg_ir_model::{
     ConstRef, DefMapRef, EnumVariantRef, FieldRef, FunctionRef, ImplRef, ItemOwner, LocalDefRef,
-    SemanticItemRef, StaticRef, TargetRef, TraitImplRef, TraitRef, TypeAliasRef, TypeDefId,
-    TypeDefRef,
+    SemanticItemRef, StaticRef, TargetRef, TraitRef, TypeAliasRef, TypeDefId, TypeDefRef,
     hir::items::{
         ConstData, EnumData, EnumVariantData, FieldData, FunctionData, ImplData, StaticData,
         TraitData, TypeAliasData,
@@ -14,26 +13,8 @@ use rg_ir_model::{
 };
 use rg_item_tree::{FieldKey, FieldList, GenericParams};
 
-use crate::{ItemStore, SemanticItemView, TypePathContext, push_unique};
-
-/// Provides the stores that semantic-shaped item refs can point into.
-///
-/// Layer-specific code implements this once, and the query code below can then treat target items
-/// and body-local items as the same kind of data.
-pub trait ItemStoreSource<'a> {
-    type Error;
-
-    /// Finds the store that owns refs with this origin.
-    ///
-    /// `None` means the origin is outside of the source's view, for example a different body.
-    fn item_store_for_origin(
-        &self,
-        origin: DefMapRef,
-    ) -> Result<Option<&'a ItemStore>, Self::Error>;
-
-    /// Defines how far queries such as target-item impl search are allowed to look.
-    fn visible_stores(&self) -> Result<Vec<&'a ItemStore>, Self::Error>;
-}
+use super::ItemStoreSource;
+use crate::{ItemStore, SemanticItemView, TypePathContext};
 
 /// Shared item queries over any storage that can route `DefMapRef` origins to item stores.
 ///
@@ -65,20 +46,32 @@ where
         self.source.item_store_for_origin(origin)
     }
 
-    /// Returns the stores that broad lookup/indexing is allowed to scan.
-    ///
-    /// This keeps broad scans on the same visibility boundary as direct impl queries.
-    pub fn visible_stores(&self) -> Result<Vec<&'a ItemStore>, S::Error> {
-        self.source.visible_stores()
+    /// Returns the stores that are materialized by this query source.
+    pub fn included_stores(&self) -> Result<Vec<&'a ItemStore>, S::Error> {
+        self.source.included_stores()
     }
 
-    /// Returns target refs for all stores visible to broad item queries.
-    pub fn visible_target_refs(&self) -> Result<Vec<TargetRef>, S::Error> {
+    /// Returns target refs for all stores materialized by this query source.
+    pub fn included_target_refs(&self) -> Result<Vec<TargetRef>, S::Error> {
         Ok(self
-            .visible_stores()?
+            .included_stores()?
             .into_iter()
             .map(|store| store.target_ref())
             .collect())
+    }
+
+    /// Returns stores for the exact targets selected by a language-visibility query.
+    pub fn stores_for_targets(
+        &self,
+        targets: &[TargetRef],
+    ) -> Result<Vec<&'a ItemStore>, S::Error> {
+        let mut stores = Vec::new();
+        for target in targets {
+            if let Some(store) = self.item_store_for_origin(DefMapRef::Target(*target))? {
+                stores.push(store);
+            }
+        }
+        Ok(stores)
     }
 
     /// Enumerates item views from one routed origin without exposing store iteration to callers.
@@ -370,130 +363,5 @@ where
         Ok(self
             .item_store_for_origin(static_ref.origin)?
             .and_then(|items| items.static_data(static_ref.id)))
-    }
-
-    /// Searches the impl index visible from the type's origin, not just the type's own store.
-    pub fn impls_for_type(&self, ty: TypeDefRef) -> Result<Vec<ImplRef>, S::Error> {
-        let mut impls = Vec::new();
-        for store in self.impl_stores_for_origin(ty.origin)? {
-            impls.extend(store.impls_with_refs().filter_map(|(impl_ref, data)| {
-                data.resolved_self_tys.contains(&ty).then_some(impl_ref)
-            }));
-        }
-        Ok(impls)
-    }
-
-    /// Searches visible impls for a trait ref while keeping duplicate refs out of the result.
-    pub fn impls_for_trait(&self, trait_ref: TraitRef) -> Result<Vec<ImplRef>, S::Error> {
-        let mut impls = Vec::new();
-        for store in self.impl_stores_for_origin(trait_ref.origin)? {
-            for (impl_ref, data) in store.impls_with_refs() {
-                if data.resolved_trait_refs.contains(&trait_ref) {
-                    push_unique(&mut impls, impl_ref);
-                }
-            }
-        }
-        Ok(impls)
-    }
-
-    /// Narrows type impl lookup to inherent impls, which is the path used for method completion.
-    pub fn inherent_impls_for_type(&self, ty: TypeDefRef) -> Result<Vec<ImplRef>, S::Error> {
-        let mut impls = Vec::new();
-        for impl_ref in self.impls_for_type(ty)? {
-            let Some(data) = self.impl_data(impl_ref)? else {
-                continue;
-            };
-            if data.trait_ref.is_none() {
-                impls.push(impl_ref);
-            }
-        }
-        Ok(impls)
-    }
-
-    /// Collects inherent functions for callers that care about callable members, not impl blocks.
-    pub fn inherent_functions_for_type(
-        &self,
-        ty: TypeDefRef,
-    ) -> Result<Vec<FunctionRef>, S::Error> {
-        let mut functions = Vec::new();
-        for impl_ref in self.inherent_impls_for_type(ty)? {
-            let Some(data) = self.impl_data(impl_ref)? else {
-                continue;
-            };
-            functions.extend(data.functions());
-        }
-        Ok(functions)
-    }
-
-    /// Expands matching trait impl blocks into the trait refs they actually implement.
-    pub fn trait_impls_for_type(&self, ty: TypeDefRef) -> Result<Vec<TraitImplRef>, S::Error> {
-        let mut trait_impls = Vec::new();
-        for impl_ref in self.impls_for_type(ty)? {
-            let Some(data) = self.impl_data(impl_ref)? else {
-                continue;
-            };
-
-            for trait_ref in &data.resolved_trait_refs {
-                push_unique(
-                    &mut trait_impls,
-                    TraitImplRef {
-                        impl_ref,
-                        trait_ref: *trait_ref,
-                    },
-                );
-            }
-        }
-        Ok(trait_impls)
-    }
-
-    /// Lists trait declarations implemented by the visible impls for a nominal type.
-    pub fn traits_for_type(&self, ty: TypeDefRef) -> Result<Vec<TraitRef>, S::Error> {
-        let mut traits = Vec::new();
-        for trait_impl in self.trait_impls_for_type(ty)? {
-            push_unique(&mut traits, trait_impl.trait_ref);
-        }
-        Ok(traits)
-    }
-
-    /// Collects trait-declared functions available for a nominal type.
-    pub fn trait_functions_for_type(&self, ty: TypeDefRef) -> Result<Vec<FunctionRef>, S::Error> {
-        let mut functions = Vec::new();
-        for trait_ref in self.traits_for_type(ty)? {
-            let Some(data) = self.trait_data(trait_ref)? else {
-                continue;
-            };
-            for function in data.functions() {
-                push_unique(&mut functions, function);
-            }
-        }
-        Ok(functions)
-    }
-
-    /// Collects concrete trait-impl functions available for a nominal type.
-    pub fn trait_impl_functions_for_type(
-        &self,
-        ty: TypeDefRef,
-    ) -> Result<Vec<FunctionRef>, S::Error> {
-        let mut functions = Vec::new();
-        for trait_impl in self.trait_impls_for_type(ty)? {
-            let Some(data) = self.impl_data(trait_impl.impl_ref)? else {
-                continue;
-            };
-            functions.extend(data.functions());
-        }
-        Ok(functions)
-    }
-
-    /// Target-origin impl lookup can see all visible semantic stores; body-local refs stay scoped
-    /// to their owning body store.
-    fn impl_stores_for_origin(&self, origin: DefMapRef) -> Result<Vec<&'a ItemStore>, S::Error> {
-        if origin.as_target_ref().is_some() {
-            return self.source.visible_stores();
-        }
-
-        Ok(self
-            .item_store_for_origin(origin)?
-            .into_iter()
-            .collect::<Vec<_>>())
     }
 }

--- a/crates/engine/ir-storage/src/item/query/mod.rs
+++ b/crates/engine/ir-storage/src/item/query/mod.rs
@@ -1,0 +1,36 @@
+//! Shared queries over semantic-shaped item stores.
+//!
+//! Target and body IR store item data in the same `ItemStore` shape. This module separates raw
+//! store routing from queries that need a concrete Rust visibility universe.
+
+mod item_store;
+mod target;
+
+use rg_ir_model::DefMapRef;
+
+use crate::ItemStore;
+
+pub use self::{item_store::ItemStoreQuery, target::TargetItemQuery};
+
+/// Provides the stores that semantic-shaped item refs can point into.
+///
+/// Layer-specific code implements this once, and the query modules can then treat target items and
+/// body-local items as the same kind of data.
+pub trait ItemStoreSource<'a> {
+    type Error;
+
+    /// Finds the store that owns refs with this origin.
+    ///
+    /// `None` means the origin is outside of the source's view, for example a different body.
+    fn item_store_for_origin(
+        &self,
+        origin: DefMapRef,
+    ) -> Result<Option<&'a ItemStore>, Self::Error>;
+
+    /// Enumerates all stores materialized by the source.
+    ///
+    /// This is a storage boundary, not a language visibility boundary. Impl and method lookup use
+    /// `TargetItemQuery`, which derives visibility from a concrete use-site target through DefMap
+    /// data.
+    fn included_stores(&self) -> Result<Vec<&'a ItemStore>, Self::Error>;
+}

--- a/crates/engine/ir-storage/src/item/query/target.rs
+++ b/crates/engine/ir-storage/src/item/query/target.rs
@@ -1,0 +1,167 @@
+//! Target-scoped item lookup.
+
+use rg_ir_model::{DefMapRef, FunctionRef, ImplRef, TargetRef, TraitImplRef, TraitRef, TypeDefRef};
+
+use super::{ItemStoreQuery, ItemStoreSource};
+use crate::{DefMapQuery, DefMapSource, ItemStore, push_unique};
+
+/// Item queries that need a Rust language visibility context.
+///
+/// Raw item refs can be read directly from `ItemStoreQuery`. Impl and method lookup are different:
+/// they need the set of item stores visible from the target where lookup happens.
+#[derive(Clone)]
+pub struct TargetItemQuery<'item, D, I> {
+    def_maps: DefMapQuery<D>,
+    items: ItemStoreQuery<'item, I>,
+    use_site: TargetRef,
+}
+
+impl<'item, D, I> TargetItemQuery<'item, D, I>
+where
+    D: DefMapSource<Error = I::Error>,
+    I: ItemStoreSource<'item>,
+{
+    pub fn new(def_maps: D, items: I, use_site: TargetRef) -> Self {
+        Self {
+            def_maps: DefMapQuery::new(def_maps),
+            items: ItemStoreQuery::new(items),
+            use_site,
+        }
+    }
+
+    pub fn items(&self) -> &ItemStoreQuery<'item, I> {
+        &self.items
+    }
+
+    /// Returns stores visible from this query's use-site target.
+    pub fn visible_stores(&self) -> Result<Vec<&'item ItemStore>, I::Error> {
+        let targets = self.def_maps.visible_targets_from(self.use_site)?;
+        self.items.stores_for_targets(&targets)
+    }
+
+    /// Searches impls visible from the use-site target, not from the receiver type's origin.
+    pub fn impls_for_type(&self, ty: TypeDefRef) -> Result<Vec<ImplRef>, I::Error> {
+        let mut impls = Vec::new();
+        for store in self.impl_stores_for_origin(ty.origin)? {
+            impls.extend(store.impls_with_refs().filter_map(|(impl_ref, data)| {
+                data.resolved_self_tys.contains(&ty).then_some(impl_ref)
+            }));
+        }
+        Ok(impls)
+    }
+
+    /// Searches visible impls for a trait ref while keeping duplicate refs out of the result.
+    pub fn impls_for_trait(&self, trait_ref: TraitRef) -> Result<Vec<ImplRef>, I::Error> {
+        let mut impls = Vec::new();
+        for store in self.impl_stores_for_origin(trait_ref.origin)? {
+            for (impl_ref, data) in store.impls_with_refs() {
+                if data.resolved_trait_refs.contains(&trait_ref) {
+                    push_unique(&mut impls, impl_ref);
+                }
+            }
+        }
+        Ok(impls)
+    }
+
+    /// Narrows type impl lookup to inherent impls, which is the path used for method completion.
+    pub fn inherent_impls_for_type(&self, ty: TypeDefRef) -> Result<Vec<ImplRef>, I::Error> {
+        let mut impls = Vec::new();
+        for impl_ref in self.impls_for_type(ty)? {
+            let Some(data) = self.items.impl_data(impl_ref)? else {
+                continue;
+            };
+            if data.trait_ref.is_none() {
+                impls.push(impl_ref);
+            }
+        }
+        Ok(impls)
+    }
+
+    /// Collects inherent functions for callers that care about callable members, not impl blocks.
+    pub fn inherent_functions_for_type(
+        &self,
+        ty: TypeDefRef,
+    ) -> Result<Vec<FunctionRef>, I::Error> {
+        let mut functions = Vec::new();
+        for impl_ref in self.inherent_impls_for_type(ty)? {
+            let Some(data) = self.items.impl_data(impl_ref)? else {
+                continue;
+            };
+            functions.extend(data.functions());
+        }
+        Ok(functions)
+    }
+
+    /// Expands matching trait impl blocks into the trait refs they actually implement.
+    pub fn trait_impls_for_type(&self, ty: TypeDefRef) -> Result<Vec<TraitImplRef>, I::Error> {
+        let mut trait_impls = Vec::new();
+        for impl_ref in self.impls_for_type(ty)? {
+            let Some(data) = self.items.impl_data(impl_ref)? else {
+                continue;
+            };
+
+            for trait_ref in &data.resolved_trait_refs {
+                push_unique(
+                    &mut trait_impls,
+                    TraitImplRef {
+                        impl_ref,
+                        trait_ref: *trait_ref,
+                    },
+                );
+            }
+        }
+        Ok(trait_impls)
+    }
+
+    /// Lists trait declarations implemented by the visible impls for a nominal type.
+    pub fn traits_for_type(&self, ty: TypeDefRef) -> Result<Vec<TraitRef>, I::Error> {
+        let mut traits = Vec::new();
+        for trait_impl in self.trait_impls_for_type(ty)? {
+            push_unique(&mut traits, trait_impl.trait_ref);
+        }
+        Ok(traits)
+    }
+
+    /// Collects trait-declared functions available for a nominal type.
+    pub fn trait_functions_for_type(&self, ty: TypeDefRef) -> Result<Vec<FunctionRef>, I::Error> {
+        let mut functions = Vec::new();
+        for trait_ref in self.traits_for_type(ty)? {
+            let Some(data) = self.items.trait_data(trait_ref)? else {
+                continue;
+            };
+            for function in data.functions() {
+                push_unique(&mut functions, function);
+            }
+        }
+        Ok(functions)
+    }
+
+    /// Collects concrete trait-impl functions available for a nominal type.
+    pub fn trait_impl_functions_for_type(
+        &self,
+        ty: TypeDefRef,
+    ) -> Result<Vec<FunctionRef>, I::Error> {
+        let mut functions = Vec::new();
+        for trait_impl in self.trait_impls_for_type(ty)? {
+            let Some(data) = self.items.impl_data(trait_impl.impl_ref)? else {
+                continue;
+            };
+            functions.extend(data.functions());
+        }
+        Ok(functions)
+    }
+
+    /// Target-origin impl lookup sees the use-site target's visible semantic stores; body-local refs
+    /// stay scoped to their owning body store.
+    fn impl_stores_for_origin(&self, origin: DefMapRef) -> Result<Vec<&'item ItemStore>, I::Error> {
+        if origin.as_target_ref().is_some() {
+            return self.visible_stores();
+        }
+
+        Ok(self
+            .items
+            .item_store_for_origin(origin)?
+            .into_iter()
+            .collect::<Vec<_>>())
+    }
+}

--- a/crates/engine/ir-storage/src/lib.rs
+++ b/crates/engine/ir-storage/src/lib.rs
@@ -13,7 +13,7 @@ pub use self::{
     },
     item::{
         ItemLookupIndex, ItemStore, ItemStoreBuilder, ItemStoreQuery, ItemStoreSource,
-        SemanticItemView, TypePathContext,
+        SemanticItemView, TargetItemQuery, TypePathContext,
     },
 };
 

--- a/crates/engine/ir-view/src/db.rs
+++ b/crates/engine/ir-view/src/db.rs
@@ -63,7 +63,7 @@ impl<'a, 'db> ItemStoreSource<'a> for &'a IndexedViewDb<'db> {
         }
     }
 
-    fn visible_stores(&self) -> Result<Vec<&'a ItemStore>, PackageStoreError> {
+    fn included_stores(&self) -> Result<Vec<&'a ItemStore>, PackageStoreError> {
         self.semantic_ir.included_stores()
     }
 }

--- a/crates/engine/semantic-ir/src/store/txn.rs
+++ b/crates/engine/semantic-ir/src/store/txn.rs
@@ -51,7 +51,7 @@ impl<'a, 'db> ItemStoreSource<'a> for &'a SemanticIrReadTxn<'db> {
         (*self).items(target)
     }
 
-    fn visible_stores(&self) -> Result<Vec<&'a ItemStore>, Self::Error> {
+    fn included_stores(&self) -> Result<Vec<&'a ItemStore>, Self::Error> {
         (*self).included_stores()
     }
 }

--- a/crates/engine/semantic-ir/src/tests/mod.rs
+++ b/crates/engine/semantic-ir/src/tests/mod.rs
@@ -225,6 +225,90 @@ impl ImportedTrait for Local {
 }
 
 #[test]
+fn target_queries_exclude_impls_from_unrelated_workspace_targets() {
+    check_project_semantic_queries(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["crates/shared", "crates/app", "crates/other"]
+resolver = "3"
+
+//- /crates/shared/Cargo.toml
+[package]
+name = "shared"
+version = "0.1.0"
+edition = "2024"
+
+//- /crates/shared/src/lib.rs
+pub struct Maybe;
+
+impl Maybe {
+    pub fn is_some(&self) -> bool {
+        true
+    }
+}
+
+//- /crates/app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+shared = { path = "../shared" }
+
+//- /crates/app/src/lib.rs
+use shared::Maybe;
+
+pub trait AppExt {
+    fn and_then(&self);
+}
+
+impl AppExt for Maybe {
+    fn and_then(&self) {}
+}
+
+//- /crates/other/Cargo.toml
+[package]
+name = "other"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+shared = { path = "../shared" }
+
+//- /crates/other/src/lib.rs
+use shared::Maybe;
+
+pub trait OtherExt {
+    fn and_then(&self);
+}
+
+impl OtherExt for Maybe {
+    fn and_then(&self) {}
+}
+"#,
+        &[SemanticQuery::lib("app", "shared::Maybe")],
+        expect![[r#"
+            query app [lib] crate resolves shared::Maybe -> struct shared[lib]::crate::Maybe
+            impls
+            - impl AppExt for Maybe
+            - impl Maybe
+            trait impls
+            - impl AppExt for Maybe => trait app[lib]::crate::AppExt
+            traits
+            - trait app[lib]::crate::AppExt
+            inherent functions
+            - fn impl Maybe::is_some
+            trait functions
+            - fn trait app[lib]::crate::AppExt::and_then
+            trait impl functions
+            - fn impl AppExt for Maybe::and_then
+        "#]],
+    );
+}
+
+#[test]
 fn resolves_bin_queries_to_sibling_lib_and_dependencies() {
     check_project_semantic_queries(
         r#"

--- a/crates/engine/semantic-ir/src/tests/utils.rs
+++ b/crates/engine/semantic-ir/src/tests/utils.rs
@@ -4,7 +4,7 @@ use expect_test::Expect;
 
 use crate::{SemanticIrReadTxn, testonly::SemanticIrFixture};
 use rg_ir_model::{DefMapRef, ModuleId, ModuleRef, TargetRef, TypeAliasId};
-use rg_ir_storage::{ItemStore, ItemStoreQuery, Path, PathSegment};
+use rg_ir_storage::{ItemStore, ItemStoreQuery, Path, PathSegment, TargetItemQuery};
 use rg_item_tree::{FieldItem, FieldList, ParamKind, VisibilityLevel};
 use rg_package_store::PackageLoader;
 use rg_parse::{Package, ParseDb, Target};
@@ -146,7 +146,7 @@ impl<'a> ProjectSemanticQuerySnapshot<'a> {
             .project
             .semantic_ir_db()
             .read_txn(PackageLoader::resident_only("resident semantic IR fixture"));
-        let item_query = ItemStoreQuery::new(&semantic_ir_txn);
+        let target_items = TargetItemQuery::new(&def_map_txn, &semantic_ir_txn, target_ref);
         let mut type_defs = ItemPathQuery::new(&def_map_txn, &semantic_ir_txn)
             .type_defs_for_path(
                 ModuleRef {
@@ -179,7 +179,7 @@ impl<'a> ProjectSemanticQuerySnapshot<'a> {
                 self.render_query_section(
                     &mut dump,
                     "impls",
-                    item_query
+                    target_items
                         .impls_for_type(ty)
                         .expect("fixture semantic query should find impls for type")
                         .into_iter()
@@ -189,7 +189,7 @@ impl<'a> ProjectSemanticQuerySnapshot<'a> {
                 self.render_query_section(
                     &mut dump,
                     "trait impls",
-                    item_query
+                    target_items
                         .trait_impls_for_type(ty)
                         .expect("fixture semantic query should find trait impls for type")
                         .into_iter()
@@ -205,7 +205,7 @@ impl<'a> ProjectSemanticQuerySnapshot<'a> {
                 self.render_query_section(
                     &mut dump,
                     "traits",
-                    item_query
+                    target_items
                         .traits_for_type(ty)
                         .expect("fixture semantic query should find traits for type")
                         .into_iter()
@@ -215,7 +215,7 @@ impl<'a> ProjectSemanticQuerySnapshot<'a> {
                 self.render_query_section(
                     &mut dump,
                     "inherent functions",
-                    item_query
+                    target_items
                         .inherent_functions_for_type(ty)
                         .expect("fixture semantic query should find inherent functions for type")
                         .into_iter()
@@ -227,7 +227,7 @@ impl<'a> ProjectSemanticQuerySnapshot<'a> {
                 self.render_query_section(
                     &mut dump,
                     "trait functions",
-                    item_query
+                    target_items
                         .trait_functions_for_type(ty)
                         .expect("fixture semantic query should find trait functions for type")
                         .into_iter()
@@ -239,7 +239,7 @@ impl<'a> ProjectSemanticQuerySnapshot<'a> {
                 self.render_query_section(
                     &mut dump,
                     "trait impl functions",
-                    item_query
+                    target_items
                         .trait_impl_functions_for_type(ty)
                         .expect("fixture semantic query should find trait impl functions for type")
                         .into_iter()

--- a/crates/engine/ty/src/autoderef.rs
+++ b/crates/engine/ty/src/autoderef.rs
@@ -6,7 +6,7 @@
 
 use std::{borrow::Cow, collections::VecDeque};
 
-use rg_ir_storage::{DefMapSource, ItemLookupIndex, ItemStoreSource};
+use rg_ir_storage::{DefMapSource, ItemLookupIndex, ItemStoreSource, TargetItemQuery};
 
 use crate::{ItemPathQuery, RefMutability, Ty, deref::DerefResolver};
 
@@ -16,6 +16,7 @@ const AUTODEREF_LIMIT: usize = 8;
 #[derive(Clone)]
 pub struct Autoderef<'query, D, I> {
     item_paths: ItemPathQuery<'query, D, I>,
+    target_items: TargetItemQuery<'query, D, I>,
     lookup_index: Option<&'query ItemLookupIndex>,
 }
 
@@ -25,9 +26,13 @@ where
     I: ItemStoreSource<'query, Error = D::Error> + Clone,
 {
     /// Creates an autoderef engine without a precomputed lookup index.
-    pub fn new(item_paths: ItemPathQuery<'query, D, I>) -> Self {
+    pub fn new(
+        item_paths: ItemPathQuery<'query, D, I>,
+        target_items: TargetItemQuery<'query, D, I>,
+    ) -> Self {
         Self {
             item_paths,
+            target_items,
             lookup_index: None,
         }
     }
@@ -35,10 +40,12 @@ where
     /// Creates an autoderef engine that can reuse a receiver lookup index.
     pub fn with_index(
         item_paths: ItemPathQuery<'query, D, I>,
+        target_items: TargetItemQuery<'query, D, I>,
         lookup_index: &'query ItemLookupIndex,
     ) -> Self {
         Self {
             item_paths,
+            target_items,
             lookup_index: Some(lookup_index),
         }
     }
@@ -74,7 +81,12 @@ where
     }
 
     fn deref_targets(&self, ty: &Ty) -> Result<Vec<Ty>, D::Error> {
-        DerefResolver::new(self.item_paths.clone(), self.lookup_index).targets_for_ty(ty)
+        DerefResolver::new(
+            self.item_paths.clone(),
+            self.target_items.clone(),
+            self.lookup_index,
+        )
+        .targets_for_ty(ty)
     }
 }
 

--- a/crates/engine/ty/src/deref.rs
+++ b/crates/engine/ty/src/deref.rs
@@ -7,7 +7,8 @@ use rg_ir_model::{
     AssocItemId, TraitImplRef, TypeAliasRef, TypePathResolution, hir::items::ImplData,
 };
 use rg_ir_storage::{
-    DefMapSource, ItemLookupIndex, ItemStoreSource, Path, PathSegment, TypePathContext,
+    DefMapSource, ItemLookupIndex, ItemStoreSource, Path, PathSegment, TargetItemQuery,
+    TypePathContext,
 };
 use rg_item_tree::TypeRef;
 use rg_text::Name;
@@ -18,6 +19,7 @@ use crate::{ImplMatcher, ItemPathQuery, NominalTy, Ty, TypeSubst};
 #[derive(Clone)]
 pub(crate) struct DerefResolver<'query, D, I> {
     item_paths: ItemPathQuery<'query, D, I>,
+    target_items: TargetItemQuery<'query, D, I>,
     lookup_index: Option<&'query ItemLookupIndex>,
 }
 
@@ -28,10 +30,12 @@ where
 {
     pub(crate) fn new(
         item_paths: ItemPathQuery<'query, D, I>,
+        target_items: TargetItemQuery<'query, D, I>,
         lookup_index: Option<&'query ItemLookupIndex>,
     ) -> Self {
         Self {
             item_paths,
+            target_items,
             lookup_index,
         }
     }
@@ -54,12 +58,12 @@ where
     /// For `impl<T> core::ops::Deref for Wrapper<T> { type Target = T; }` and receiver
     /// `Wrapper<User>`, this resolves the target as `User`.
     fn targets_for_nominal(&self, receiver_ty: &NominalTy) -> Result<Vec<Ty>, D::Error> {
-        let matcher = ImplMatcher::new(self.item_paths.clone());
+        let matcher = ImplMatcher::new(self.item_paths.clone(), self.target_items.clone());
         let item_query = self.item_paths.items();
         let mut targets = Vec::new();
         let trait_impls = match self.lookup_index {
             Some(index) => index.trait_impls_for_type(receiver_ty.def).to_vec(),
-            None => item_query.trait_impls_for_type(receiver_ty.def)?,
+            None => self.target_items.trait_impls_for_type(receiver_ty.def)?,
         };
 
         for trait_impl in trait_impls {

--- a/crates/engine/ty/src/impl_match.rs
+++ b/crates/engine/ty/src/impl_match.rs
@@ -8,7 +8,9 @@ use crate::{GenericArg, ItemPathQuery, NominalTy, Ty, TypeSubst};
 use rg_ir_model::{
     FunctionRef, ImplRef, ItemOwner, TraitApplicability, TraitImplRef, hir::items::ImplData,
 };
-use rg_ir_storage::{DefMapSource, ItemLookupIndex, ItemStoreSource, TypePathContext};
+use rg_ir_storage::{
+    DefMapSource, ItemLookupIndex, ItemStoreSource, TargetItemQuery, TypePathContext,
+};
 use rg_item_tree::{GenericArg as ItemGenericArg, GenericParams, TypeRef};
 use rg_text::Name;
 
@@ -41,6 +43,7 @@ impl TraitImplMatch {
 /// Matcher for impl headers stored in semantic-shaped item stores.
 pub struct ImplMatcher<'query, D, I> {
     item_paths: ItemPathQuery<'query, D, I>,
+    target_items: TargetItemQuery<'query, D, I>,
 }
 
 impl<'query, D, I> ImplMatcher<'query, D, I>
@@ -49,8 +52,14 @@ where
     I: ItemStoreSource<'query, Error = D::Error>,
 {
     /// Creates a matcher over the same path/item routing used by type conversion.
-    pub fn new(item_paths: ItemPathQuery<'query, D, I>) -> Self {
-        Self { item_paths }
+    pub fn new(
+        item_paths: ItemPathQuery<'query, D, I>,
+        target_items: TargetItemQuery<'query, D, I>,
+    ) -> Self {
+        Self {
+            item_paths,
+            target_items,
+        }
     }
 
     /// Checks whether a function owned by an inherent impl can be called on the receiver type.
@@ -199,7 +208,7 @@ where
         let mut functions = Vec::new();
         let trait_impls = match index {
             Some(index) => index.trait_impls_for_type(receiver_ty.def).to_vec(),
-            None => item_query.trait_impls_for_type(receiver_ty.def)?,
+            None => self.target_items.trait_impls_for_type(receiver_ty.def)?,
         };
 
         for trait_impl in trait_impls {

--- a/crates/engine/ty/src/implementation.rs
+++ b/crates/engine/ty/src/implementation.rs
@@ -5,13 +5,14 @@
 //! declaration shape that UI-facing analysis expects.
 
 use rg_ir_model::{AssocItemId, FunctionRef, ImplRef, ItemOwner, TraitRef, TypeDefRef};
-use rg_ir_storage::{DefMapSource, ItemStoreSource};
+use rg_ir_storage::{DefMapSource, ItemStoreSource, TargetItemQuery};
 
 use crate::{Autoderef, AutoderefMode, ImplMatcher, ItemPathQuery, ReferencePeelingCandidates, Ty};
 
 /// Ref-level implementation lookup shared by view and analysis adapters.
 pub struct ImplementationQuery<'query, D, I> {
     item_paths: ItemPathQuery<'query, D, I>,
+    target_items: TargetItemQuery<'query, D, I>,
 }
 
 impl<'query, D, I> ImplementationQuery<'query, D, I>
@@ -19,8 +20,14 @@ where
     D: DefMapSource + Clone,
     I: ItemStoreSource<'query, Error = D::Error> + Clone,
 {
-    pub fn new(item_paths: ItemPathQuery<'query, D, I>) -> Self {
-        Self { item_paths }
+    pub fn new(
+        item_paths: ItemPathQuery<'query, D, I>,
+        target_items: TargetItemQuery<'query, D, I>,
+    ) -> Self {
+        Self {
+            item_paths,
+            target_items,
+        }
     }
 
     /// Returns impl blocks for all nominal type definitions reachable through reference peeling.
@@ -38,12 +45,12 @@ where
 
     /// Returns impl blocks whose resolved self type mentions this nominal type definition.
     pub fn impls_for_type_def(&self, ty: TypeDefRef) -> Result<Vec<ImplRef>, D::Error> {
-        self.item_paths.items().impls_for_type(ty)
+        self.target_items.impls_for_type(ty)
     }
 
     /// Returns impl blocks that resolve to the requested trait.
     pub fn impls_for_trait(&self, trait_ref: TraitRef) -> Result<Vec<ImplRef>, D::Error> {
-        self.item_paths.items().impls_for_trait(trait_ref)
+        self.target_items.impls_for_trait(trait_ref)
     }
 
     /// Returns concrete functions that implement or correspond to the selected function.
@@ -94,14 +101,14 @@ where
         method_name: &str,
         receiver_ty: &Ty,
     ) -> Result<Vec<FunctionRef>, D::Error> {
-        let autoderef = Autoderef::new(self.item_paths.clone());
-        let matcher = ImplMatcher::new(self.item_paths.clone());
+        let autoderef = Autoderef::new(self.item_paths.clone(), self.target_items.clone());
+        let matcher = ImplMatcher::new(self.item_paths.clone(), self.target_items.clone());
         let mut functions = Vec::new();
 
         for candidate in autoderef.candidates(AutoderefMode::MethodReceiver, receiver_ty) {
             let candidate = candidate?;
             for ty in candidate.ty().as_nominals() {
-                for trait_impl in self.item_paths.items().trait_impls_for_type(ty.def)? {
+                for trait_impl in self.target_items.trait_impls_for_type(ty.def)? {
                     if trait_impl.trait_ref != trait_ref {
                         continue;
                     }

--- a/crates/engine/ty/src/member.rs
+++ b/crates/engine/ty/src/member.rs
@@ -5,7 +5,7 @@
 //! item refs so higher layers can decide how to present them.
 
 use rg_ir_model::{FieldRef, FunctionRef, TraitApplicability, TypeDefRef};
-use rg_ir_storage::{DefMapSource, ItemLookupIndex, ItemStoreSource};
+use rg_ir_storage::{DefMapSource, ItemLookupIndex, ItemStoreSource, TargetItemQuery};
 
 use crate::{Autoderef, AutoderefMode, ImplMatcher, ItemPathQuery, NominalTy, Ty};
 
@@ -50,6 +50,7 @@ pub enum MemberMethodOrigin {
 /// Ref-level member lookup shared by analysis and view adapters.
 pub struct MemberQuery<'query, D, I> {
     item_paths: ItemPathQuery<'query, D, I>,
+    target_items: TargetItemQuery<'query, D, I>,
     lookup_index: Option<&'query ItemLookupIndex>,
 }
 
@@ -59,9 +60,13 @@ where
     I: ItemStoreSource<'query, Error = D::Error> + Clone,
 {
     /// Creates a member query that scans the visible item stores directly.
-    pub fn new(item_paths: ItemPathQuery<'query, D, I>) -> Self {
+    pub fn new(
+        item_paths: ItemPathQuery<'query, D, I>,
+        target_items: TargetItemQuery<'query, D, I>,
+    ) -> Self {
         Self {
             item_paths,
+            target_items,
             lookup_index: None,
         }
     }
@@ -69,10 +74,12 @@ where
     /// Creates a member query that can reuse a precomputed receiver lookup index.
     pub fn with_index(
         item_paths: ItemPathQuery<'query, D, I>,
+        target_items: TargetItemQuery<'query, D, I>,
         lookup_index: &'query ItemLookupIndex,
     ) -> Self {
         Self {
             item_paths,
+            target_items,
             lookup_index: Some(lookup_index),
         }
     }
@@ -117,7 +124,7 @@ where
         receiver_ty: &NominalTy,
     ) -> Result<Vec<MemberMethodCandidateRef>, D::Error> {
         let mut candidates = Vec::new();
-        let matcher = ImplMatcher::new(self.item_paths.clone());
+        let matcher = ImplMatcher::new(self.item_paths.clone(), self.target_items.clone());
 
         for function in self.inherent_functions_for_nominal(receiver_ty)? {
             if !matcher.function_applies_to_receiver(function, receiver_ty)? {
@@ -149,16 +156,17 @@ where
                 index.inherent_functions_for_type(self.item_paths.items(), receiver_ty.def)
             }
             None => self
-                .item_paths
-                .items()
+                .target_items
                 .inherent_functions_for_type(receiver_ty.def),
         }
     }
 
     fn autoderef(&self) -> Autoderef<'query, D, I> {
         match self.lookup_index {
-            Some(index) => Autoderef::with_index(self.item_paths.clone(), index),
-            None => Autoderef::new(self.item_paths.clone()),
+            Some(index) => {
+                Autoderef::with_index(self.item_paths.clone(), self.target_items.clone(), index)
+            }
+            None => Autoderef::new(self.item_paths.clone(), self.target_items.clone()),
         }
     }
 }


### PR DESCRIPTION
Previously we had an issue where some targets invisible to the origin target for query would be attempted to be accessed (while they're offloaded).

This pr fixes the root cause for that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced method and implementation resolution in multi-crate workspaces with improved target-scoped visibility context.

* **Bug Fixes**
  * Fixed method completion to exclude trait implementations from unrelated workspace crates.
  * Improved accuracy of implementation lookup and method resolution across crate boundaries.
  * Corrected hover information and method signature display in multi-crate workspace scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->