### PR TITLE
feat: Better type inference

### DIFF
--- a/crates/engine/analysis/src/tests/completions_at.rs
+++ b/crates/engine/analysis/src/tests/completions_at.rs
@@ -1772,13 +1772,28 @@ core = { package = "fake_core", path = "../core" }
 //- /app/src/lib.rs
 pub struct Package;
 
-pub fn use_it(packages: &[Package]) {
+pub fn use_it(packages: &[Package], array: [Package; 3], array_ref: &[Package; 3]) {
     packages.$slice_methods$;
+    array.$array_methods$;
+    array_ref.$array_ref_methods$;
 }
 "#,
-        &[AnalysisQuery::complete("slice method completions", "slice_methods").in_lib("app")],
+        &[
+            AnalysisQuery::complete("slice method completions", "slice_methods").in_lib("app"),
+            AnalysisQuery::complete("array method completions", "array_methods").in_lib("app"),
+            AnalysisQuery::complete("array ref method completions", "array_ref_methods")
+                .in_lib("app"),
+        ],
         expect![[r#"
             slice method completions
+            - inherent_method first_ref
+            - inherent_method len
+
+            array method completions
+            - inherent_method first_ref
+            - inherent_method len
+
+            array ref method completions
             - inherent_method first_ref
             - inherent_method len
         "#]],

--- a/crates/engine/analysis/src/tests/completions_at.rs
+++ b/crates/engine/analysis/src/tests/completions_at.rs
@@ -1735,6 +1735,57 @@ pub fn use_it(wrapper: Wrapper<User>) {
 }
 
 #[test]
+fn completes_structural_slice_inherent_methods() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["core", "app"]
+resolver = "3"
+
+//- /core/Cargo.toml
+[package]
+name = "fake_core"
+version = "0.1.0"
+edition = "2024"
+
+//- /core/src/lib.rs
+impl<T> [T] {
+    pub fn first_ref(&self) -> &T {
+        missing()
+    }
+
+    pub fn len(&self) -> usize {
+        missing()
+    }
+}
+
+//- /app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+core = { package = "fake_core", path = "../core" }
+
+//- /app/src/lib.rs
+pub struct Package;
+
+pub fn use_it(packages: &[Package]) {
+    packages.$slice_methods$;
+}
+"#,
+        &[AnalysisQuery::complete("slice method completions", "slice_methods").in_lib("app")],
+        expect![[r#"
+            slice method completions
+            - inherent_method first_ref
+            - inherent_method len
+        "#]],
+    );
+}
+
+#[test]
 fn completes_body_local_impl_methods_at_dot() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/goto_definition.rs
+++ b/crates/engine/analysis/src/tests/goto_definition.rs
@@ -199,6 +199,90 @@ pub fn use_it() {
 }
 
 #[test]
+fn resolves_lifetime_parameterized_receiver_method_calls() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_lifetime_receiver_method_goto"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+fn missing<T>() -> T {
+    loop {}
+}
+
+pub struct Module;
+pub struct DebugStruct;
+
+pub struct TargetScopeCollector<'db> {
+    module: &'db Module,
+}
+
+impl<'db> TargetScopeCollector<'db> {
+    fn all$goto_alloc_decl$oc_module(&mut self) -> Module {
+        missing()
+    }
+
+    fn col$goto_collect_decl$lect_items(&mut self) -> Module {
+        self.all$goto_self_alloc$oc_module()
+    }
+
+    fn collect(&mut self) -> Module {
+        self.col$goto_self_collect$lect_items()
+    }
+}
+
+pub mod fmt {
+    pub struct Formatter<'a> {
+        marker: &'a (),
+    }
+}
+
+impl<'a> fmt::Formatter<'a> {
+    fn de$goto_debug_decl$bug_struct(&mut self) -> crate::DebugStruct {
+        crate::missing()
+    }
+}
+
+pub fn use_it<'db>(
+    collector: &mut TargetScopeCollector<'db>,
+    formatter: &mut fmt::Formatter<'_>,
+) {
+    let _items = collector.col$goto_collect$lect_items();
+    let _debug = formatter.de$goto_debug$bug_struct();
+}
+"#,
+        &[
+            AnalysisQuery::goto("goto self method in lifetime impl", "goto_self_alloc"),
+            AnalysisQuery::goto(
+                "goto self sibling method in lifetime impl",
+                "goto_self_collect",
+            ),
+            AnalysisQuery::goto("goto external method on lifetime receiver", "goto_collect"),
+            AnalysisQuery::goto(
+                "goto method on Formatter placeholder lifetime",
+                "goto_debug",
+            ),
+        ],
+        expect![[r#"
+            goto self method in lifetime impl
+            - fn alloc_module @ 13:8-13:20
+
+            goto self sibling method in lifetime impl
+            - fn collect_items @ 17:8-17:21
+
+            goto external method on lifetime receiver
+            - fn collect_items @ 17:8-17:21
+
+            goto method on Formatter placeholder lifetime
+            - fn debug_struct @ 33:8-33:20
+        "#]],
+    );
+}
+
+#[test]
 fn resolves_associated_functions_and_enum_variants_in_body_paths() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/goto_definition.rs
+++ b/crates/engine/analysis/src/tests/goto_definition.rs
@@ -1078,6 +1078,50 @@ pub fn make() {
 }
 
 #[test]
+fn resolves_trait_associated_const_qualified_value_paths() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_trait_assoc_const_goto"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub enum StmtKind {
+    Let,
+}
+
+pub struct Stmt;
+
+pub trait HasAttrs {
+    const SUPPORTS_CUSTOM_INNER_ATTRS: bool;
+}
+
+impl HasAttrs for StmtKind {
+    const SUPPORTS_CUSTOM_INNER_ATTRS: bool = true;
+}
+
+impl HasAttrs for Stmt {
+    const SUPPORTS_CUSTOM_INNER_ATTRS: bool =
+        StmtKind::SUPPORTS$goto_trait_assoc_const$_CUSTOM_INNER_ATTRS$type_trait_assoc_const$;
+}
+"#,
+        &[
+            AnalysisQuery::goto("goto trait associated const", "goto_trait_assoc_const"),
+            AnalysisQuery::ty("type at trait associated const", "type_trait_assoc_const"),
+        ],
+        expect![[r#"
+            goto trait associated const
+            - const SUPPORTS_CUSTOM_INNER_ATTRS @ 12:11-12:38
+
+            type at trait associated const
+            - bool
+        "#]],
+    );
+}
+
+#[test]
 fn resolves_body_local_imported_paths_and_impl_headers() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/hover.rs
+++ b/crates/engine/analysis/src/tests/hover.rs
@@ -84,6 +84,38 @@ fn hovers_over_documented_items_and_usages() {
 }
 
 #[test]
+fn hovers_over_impl_fn_trait_parenthesized_args() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_hover_fn_trait_args"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct AttrVec;
+
+pub fn configure(f$fn_once_hover$: impl FnOnce(&mut AttrVec)) {
+    let _ = f;
+}
+"#,
+        &[AnalysisQuery::hover(
+            "hover impl FnOnce parenthesized args",
+            "fn_once_hover",
+        )],
+        expect![[r#"
+            hover impl FnOnce parenthesized args
+            - range: 3:18-3:19
+            - block:
+              kind: variable
+              signature:
+                let f: impl FnOnce(&mut AttrVec)
+        "#]],
+    );
+}
+
+#[test]
 fn hovers_over_enum_variants_and_body_local_items() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/type_at.rs
+++ b/crates/engine/analysis/src/tests/type_at.rs
@@ -1650,8 +1650,11 @@ pub fn use_it(state: &TargetState) {
 }
 "#,
         &[
-            AnalysisQuery::hover("hover item from project-style slice iter", "hover_iter_import")
-                .in_lib("app"),
+            AnalysisQuery::hover(
+                "hover item from project-style slice iter",
+                "hover_iter_import",
+            )
+            .in_lib("app"),
             AnalysisQuery::ty("use item from project-style slice iter", "type_iter_import")
                 .in_lib("app"),
             AnalysisQuery::hover(

--- a/crates/engine/analysis/src/tests/type_at.rs
+++ b/crates/engine/analysis/src/tests/type_at.rs
@@ -43,7 +43,7 @@ version = "0.1.0"
 edition = "2024"
 
 //- /src/lib.rs
-pub fn use_it(flag: bool, lhs: i32, rhs: i32) {
+pub fn use_it(flag: bool, byte: u8, lhs: i32, rhs: i32) {
     let bool_lit = true$type_bool$;
     let char_lit = 'x'$type_char$;
     let byte_lit = b'x'$type_byte$;
@@ -53,6 +53,7 @@ pub fn use_it(flag: bool, lhs: i32, rhs: i32) {
     let float_suffix = 1.0f32$type_f32$;
     let string_lit = "text"$type_str$;
     let not_flag = (!flag)$type_not$;
+    let not_byte = (!byte)$type_not_byte$;
     let neg_lhs = (-lhs)$type_neg$;
     let sum = (lhs + rhs)$type_sum$;
     let compare = (lhs < rhs)$type_compare$;
@@ -71,6 +72,7 @@ pub fn use_it(flag: bool, lhs: i32, rhs: i32) {
             AnalysisQuery::ty("suffixed float literal", "type_f32"),
             AnalysisQuery::ty("string literal", "type_str"),
             AnalysisQuery::ty("not expression", "type_not"),
+            AnalysisQuery::ty("integer not expression", "type_not_byte"),
             AnalysisQuery::ty("neg expression", "type_neg"),
             AnalysisQuery::ty("sum expression", "type_sum"),
             AnalysisQuery::ty("comparison expression", "type_compare"),
@@ -105,6 +107,9 @@ pub fn use_it(flag: bool, lhs: i32, rhs: i32) {
 
             not expression
             - bool
+
+            integer not expression
+            - u8
 
             neg expression
             - i32
@@ -752,6 +757,8 @@ pub fn use_it(pair: (u8, bool), array: [u8; 3], slice: &[u8], value: u8) {
     let array_expr = [value, value]$type_array_expr$;
     let repeat_expr = [value; 3]$type_repeat_expr$;
     let named_repeat = [value; N]$type_named_repeat$;
+    let spaced_repeat = [value; "a  b".len()
+        + 1]$type_spaced_repeat$;
     let tuple_field = pair.$type_tuple_field$0;
     let indexed = array[0]$type_indexed$;
     let (left, right) = tuple_expr;
@@ -769,6 +776,7 @@ pub fn use_it(pair: (u8, bool), array: [u8; 3], slice: &[u8], value: u8) {
             AnalysisQuery::ty("array expression", "type_array_expr"),
             AnalysisQuery::ty("repeat array expression", "type_repeat_expr"),
             AnalysisQuery::ty("named repeat array expression", "type_named_repeat"),
+            AnalysisQuery::ty("spaced repeat array expression", "type_spaced_repeat"),
             AnalysisQuery::ty("self repeat array expression", "type_self_repeat"),
             AnalysisQuery::ty("tuple field", "type_tuple_field"),
             AnalysisQuery::ty("array index", "type_indexed"),
@@ -797,6 +805,9 @@ pub fn use_it(pair: (u8, bool), array: [u8; 3], slice: &[u8], value: u8) {
 
             named repeat array expression
             - [u8; N]
+
+            spaced repeat array expression
+            - [u8; "a  b".len() + 1]
 
             self repeat array expression
             - [u8; Self::N]

--- a/crates/engine/analysis/src/tests/type_at.rs
+++ b/crates/engine/analysis/src/tests/type_at.rs
@@ -1129,6 +1129,109 @@ pub fn use_it() {
 }
 
 #[test]
+fn applies_explicit_generic_call_arguments_to_return_types() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_explicit_generic_call_args"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+fn missing<T>() -> T {
+    loop {}
+}
+
+pub struct User;
+pub struct Project;
+
+pub fn make<T>() -> T {
+    missing()
+}
+
+pub struct Builder;
+
+impl Builder {
+    pub fn build<T>() -> T {
+        missing()
+    }
+
+    pub fn get<T>(&self) -> T {
+        missing()
+    }
+
+    pub fn pair<T, U>(&self) -> (T, U) {
+        missing()
+    }
+}
+
+pub fn use_it(builder: Builder) {
+    let free = make::<User>()$type_free$;
+    let associated = Builder::build::<Project>()$type_associated$;
+    let method = builder.get::<User>()$type_method$;
+    let pair = builder.pair::<User, Project>()$type_pair$;
+}
+"#,
+        &[
+            AnalysisQuery::ty("explicit free function return", "type_free"),
+            AnalysisQuery::ty("explicit associated function return", "type_associated"),
+            AnalysisQuery::ty("explicit method return", "type_method"),
+            AnalysisQuery::ty("explicit multi-param method return", "type_pair"),
+        ],
+        expect![[r#"
+            explicit free function return
+            - nominal struct analysis_explicit_generic_call_args[lib]::crate::User
+
+            explicit associated function return
+            - nominal struct analysis_explicit_generic_call_args[lib]::crate::Project
+
+            explicit method return
+            - nominal struct analysis_explicit_generic_call_args[lib]::crate::User
+
+            explicit multi-param method return
+            - (nominal struct analysis_explicit_generic_call_args[lib]::crate::User, nominal struct analysis_explicit_generic_call_args[lib]::crate::Project)
+        "#]],
+    );
+}
+
+#[test]
+fn resolves_explicit_generic_call_arguments_from_body_scope() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_explicit_generic_call_body_scope"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+fn missing<T>() -> T {
+    loop {}
+}
+
+pub fn make<T>() -> T {
+    missing()
+}
+
+pub fn use_it() {
+    struct Local;
+
+    let local = make::<Local>()$type_local$;
+}
+"#,
+        &[AnalysisQuery::ty(
+            "explicit call arg from body scope",
+            "type_local",
+        )],
+        expect![[r#"
+            explicit call arg from body scope
+            - nominal struct fn analysis_explicit_generic_call_body_scope[lib]::crate::use_it::Local
+        "#]],
+    );
+}
+
+#[test]
 fn resolves_lifetime_parameterized_receiver_method_types() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/type_at.rs
+++ b/crates/engine/analysis/src/tests/type_at.rs
@@ -857,20 +857,35 @@ core = { package = "fake_core", path = "../core" }
 //- /app/src/lib.rs
 pub struct Package;
 
-pub fn use_it(packages: &[Package]) {
+pub fn use_it(packages: &[Package], array: [Package; 3], array_ref: &[Package; 3]) {
     let first = packages.first$type_first$_ref();
     let count = packages.le$type_len$n();
+    let array_first = array.first$type_array_first$_ref();
+    let array_count = array.le$type_array_len$n();
+    let array_ref_count = array_ref.le$type_array_ref_len$n();
 }
 "#,
         &[
             AnalysisQuery::ty("slice generic method return", "type_first").in_lib("app"),
             AnalysisQuery::ty("slice len method return", "type_len").in_lib("app"),
+            AnalysisQuery::ty("array generic method return", "type_array_first").in_lib("app"),
+            AnalysisQuery::ty("array len method return", "type_array_len").in_lib("app"),
+            AnalysisQuery::ty("array ref len method return", "type_array_ref_len").in_lib("app"),
         ],
         expect![[r#"
             slice generic method return
             - &nominal struct app[lib]::crate::Package
 
             slice len method return
+            - usize
+
+            array generic method return
+            - &nominal struct app[lib]::crate::Package
+
+            array len method return
+            - usize
+
+            array ref len method return
             - usize
         "#]],
     );

--- a/crates/engine/analysis/src/tests/type_at.rs
+++ b/crates/engine/analysis/src/tests/type_at.rs
@@ -722,6 +722,104 @@ pub fn use_it() {
 }
 
 #[test]
+fn returns_structural_tuple_array_and_slice_types() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_structural_type_at"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+const N: usize = 3;
+
+pub struct Holder;
+
+impl Holder {
+    const N: usize = 4;
+
+    pub fn use_self(value: u8) {
+        let self_repeat = [value; Self::N]$type_self_repeat$;
+    }
+}
+
+pub fn use_it(pair: (u8, bool), array: [u8; 3], slice: &[u8], value: u8) {
+    let annotated_tuple$type_annotated_tuple$: (u8, bool) = pair;
+    let annotated_array$type_annotated_array$: [u8; 3] = array;
+    let annotated_slice$type_annotated_slice$: &[u8] = slice;
+    let tuple_expr = (value, true)$type_tuple_expr$;
+    let array_expr = [value, value]$type_array_expr$;
+    let repeat_expr = [value; 3]$type_repeat_expr$;
+    let named_repeat = [value; N]$type_named_repeat$;
+    let tuple_field = pair.$type_tuple_field$0;
+    let indexed = array[0]$type_indexed$;
+    let (left, right) = tuple_expr;
+    let _left = le$type_left$ft;
+    let _right = ri$type_right$ght;
+    let [first, ..] = array_expr;
+    let _first = fir$type_first$st;
+}
+"#,
+        &[
+            AnalysisQuery::ty("annotated tuple binding", "type_annotated_tuple"),
+            AnalysisQuery::ty("annotated array binding", "type_annotated_array"),
+            AnalysisQuery::ty("annotated slice binding", "type_annotated_slice"),
+            AnalysisQuery::ty("tuple expression", "type_tuple_expr"),
+            AnalysisQuery::ty("array expression", "type_array_expr"),
+            AnalysisQuery::ty("repeat array expression", "type_repeat_expr"),
+            AnalysisQuery::ty("named repeat array expression", "type_named_repeat"),
+            AnalysisQuery::ty("self repeat array expression", "type_self_repeat"),
+            AnalysisQuery::ty("tuple field", "type_tuple_field"),
+            AnalysisQuery::ty("array index", "type_indexed"),
+            AnalysisQuery::ty("tuple pattern left", "type_left"),
+            AnalysisQuery::ty("tuple pattern right", "type_right"),
+            AnalysisQuery::ty("slice pattern first", "type_first"),
+        ],
+        expect![[r#"
+            annotated tuple binding
+            - (u8, bool)
+
+            annotated array binding
+            - [u8; 3]
+
+            annotated slice binding
+            - &[u8]
+
+            tuple expression
+            - (u8, bool)
+
+            array expression
+            - [u8; 2]
+
+            repeat array expression
+            - [u8; 3]
+
+            named repeat array expression
+            - [u8; N]
+
+            self repeat array expression
+            - [u8; Self::N]
+
+            tuple field
+            - u8
+
+            array index
+            - u8
+
+            tuple pattern left
+            - u8
+
+            tuple pattern right
+            - bool
+
+            slice pattern first
+            - u8
+        "#]],
+    );
+}
+
+#[test]
 fn primitive_type_paths_respect_type_namespace_shadowing() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/type_at.rs
+++ b/crates/engine/analysis/src/tests/type_at.rs
@@ -892,6 +892,181 @@ pub fn use_it(packages: &[Package], array: [Package; 3], array_ref: &[Package; 3
 }
 
 #[test]
+fn propagates_for_loop_item_types_from_into_iterator() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["core", "app"]
+resolver = "3"
+
+//- /core/Cargo.toml
+[package]
+name = "fake_core"
+version = "0.1.0"
+edition = "2024"
+
+//- /core/src/lib.rs
+pub mod iter {
+    pub trait IntoIterator {
+        type Item;
+    }
+
+    pub trait Iterator {
+        type Item;
+    }
+}
+
+impl<'a, T> iter::IntoIterator for &'a [T] {
+    type Item = &'a T;
+}
+
+impl<T, const N: usize> iter::IntoIterator for [T; N] {
+    type Item = T;
+}
+
+impl<I: iter::Iterator> iter::IntoIterator for I {
+    type Item = I::Item;
+}
+
+//- /app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+core = { package = "fake_core", path = "../core" }
+
+//- /app/src/lib.rs
+pub struct Package;
+pub struct UserId;
+pub struct Event;
+
+pub struct Bag<T> {
+    value: T,
+}
+
+impl<T> core::iter::IntoIterator for Bag<T> {
+    type Item = T;
+}
+
+pub struct Events;
+
+impl core::iter::Iterator for Events {
+    type Item = Event;
+}
+
+pub struct KeyStream<T> {
+    value: T,
+}
+
+impl<T> core::iter::Iterator for KeyStream<T> {
+    type Item = T;
+}
+
+pub struct KeyMap<T> {
+    value: T,
+}
+
+impl<T> KeyMap<T> {
+    pub fn concrete_keys(&self) -> KeyStream<T> {
+        missing()
+    }
+
+    pub fn opaque_keys(&self) -> impl core::iter::Iterator<Item = T> {
+        missing()
+    }
+}
+
+pub fn use_it(
+    packages: &[Package],
+    array: [Package; 3],
+    pairs: [(Package, UserId); 2],
+    bag: Bag<UserId>,
+    events: Events,
+    key_map: KeyMap<UserId>,
+) {
+    for borrowed in packages {
+        let _borrowed = borr$type_borrowed$owed;
+    }
+
+    for owned in array {
+        let _owned = ow$type_owned$ned;
+    }
+
+    for (package, user_id) in pairs {
+        let _package = pack$type_tuple_package$age;
+        let _user_id = user_$type_tuple_user_id$id;
+    }
+
+    for user_id in bag {
+        let _bag_user_id = user_$type_bag_user_id$id;
+    }
+
+    for event in events {
+        let _event = eve$type_event$nt;
+    }
+
+    let _opaque_keys = key_map.opaque_keys()$type_opaque_return$;
+
+    for concrete_key in key_map.concrete_keys() {
+        let _concrete_key = concrete_$type_concrete_key$key;
+    }
+
+    for opaque_key in key_map.opaque_keys() {
+        let _opaque_key = opaque_$type_opaque_key$key;
+    }
+}
+"#,
+        &[
+            AnalysisQuery::ty("for item from borrowed slice", "type_borrowed").in_lib("app"),
+            AnalysisQuery::ty("for item from array", "type_owned").in_lib("app"),
+            AnalysisQuery::ty("for tuple item first field", "type_tuple_package").in_lib("app"),
+            AnalysisQuery::ty("for tuple item second field", "type_tuple_user_id").in_lib("app"),
+            AnalysisQuery::ty("for item from nominal impl", "type_bag_user_id").in_lib("app"),
+            AnalysisQuery::ty("for item from iterator blanket impl", "type_event").in_lib("app"),
+            AnalysisQuery::ty("opaque iterator return", "type_opaque_return").in_lib("app"),
+            AnalysisQuery::ty(
+                "for item from concrete iterator return",
+                "type_concrete_key",
+            )
+            .in_lib("app"),
+            AnalysisQuery::ty("for item from opaque iterator return", "type_opaque_key")
+                .in_lib("app"),
+        ],
+        expect![[r#"
+            for item from borrowed slice
+            - &nominal struct app[lib]::crate::Package
+
+            for item from array
+            - nominal struct app[lib]::crate::Package
+
+            for tuple item first field
+            - nominal struct app[lib]::crate::Package
+
+            for tuple item second field
+            - nominal struct app[lib]::crate::UserId
+
+            for item from nominal impl
+            - nominal struct app[lib]::crate::UserId
+
+            for item from iterator blanket impl
+            - nominal struct app[lib]::crate::Event
+
+            opaque iterator return
+            - impl trait fake_core[lib]::crate::iter::Iterator<Item = nominal struct app[lib]::crate::UserId>
+
+            for item from concrete iterator return
+            - nominal struct app[lib]::crate::UserId
+
+            for item from opaque iterator return
+            - nominal struct app[lib]::crate::UserId
+        "#]],
+    );
+}
+
+#[test]
 fn primitive_type_paths_respect_type_namespace_shadowing() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/type_at.rs
+++ b/crates/engine/analysis/src/tests/type_at.rs
@@ -33,6 +33,101 @@ pub fn use_it() {
 }
 
 #[test]
+fn returns_scalar_literal_and_operator_types() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_scalar_type_at"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub fn use_it(flag: bool, lhs: i32, rhs: i32) {
+    let bool_lit = true$type_bool$;
+    let char_lit = 'x'$type_char$;
+    let byte_lit = b'x'$type_byte$;
+    let int_default = 1$type_int$;
+    let int_suffix = 1usize$type_usize$;
+    let float_default = 1.0$type_float$;
+    let float_suffix = 1.0f32$type_f32$;
+    let string_lit = "text"$type_str$;
+    let not_flag = (!flag)$type_not$;
+    let neg_lhs = (-lhs)$type_neg$;
+    let sum = (lhs + rhs)$type_sum$;
+    let compare = (lhs < rhs)$type_compare$;
+    let logic = (flag && false)$type_logic$;
+    let bit = (lhs & rhs)$type_bit$;
+    let shift = (lhs << 1)$type_shift$;
+}
+"#,
+        &[
+            AnalysisQuery::ty("bool literal", "type_bool"),
+            AnalysisQuery::ty("char literal", "type_char"),
+            AnalysisQuery::ty("byte literal", "type_byte"),
+            AnalysisQuery::ty("default int literal", "type_int"),
+            AnalysisQuery::ty("suffixed int literal", "type_usize"),
+            AnalysisQuery::ty("default float literal", "type_float"),
+            AnalysisQuery::ty("suffixed float literal", "type_f32"),
+            AnalysisQuery::ty("string literal", "type_str"),
+            AnalysisQuery::ty("not expression", "type_not"),
+            AnalysisQuery::ty("neg expression", "type_neg"),
+            AnalysisQuery::ty("sum expression", "type_sum"),
+            AnalysisQuery::ty("comparison expression", "type_compare"),
+            AnalysisQuery::ty("logic expression", "type_logic"),
+            AnalysisQuery::ty("bit expression", "type_bit"),
+            AnalysisQuery::ty("shift expression", "type_shift"),
+        ],
+        expect![[r#"
+            bool literal
+            - bool
+
+            char literal
+            - char
+
+            byte literal
+            - u8
+
+            default int literal
+            - i32
+
+            suffixed int literal
+            - usize
+
+            default float literal
+            - f64
+
+            suffixed float literal
+            - f32
+
+            string literal
+            - &str
+
+            not expression
+            - bool
+
+            neg expression
+            - i32
+
+            sum expression
+            - i32
+
+            comparison expression
+            - bool
+
+            logic expression
+            - bool
+
+            bit expression
+            - i32
+
+            shift expression
+            - i32
+        "#]],
+    );
+}
+
+#[test]
 fn returns_types_for_references_try_and_await_wrappers() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/type_at.rs
+++ b/crates/engine/analysis/src/tests/type_at.rs
@@ -1,6 +1,6 @@
 use expect_test::expect;
 
-use super::utils::{AnalysisQuery, check_analysis_queries};
+use super::utils::{AnalysisQuery, check_analysis_queries, check_analysis_queries_with_sysroot};
 
 #[test]
 fn returns_body_expression_types() {
@@ -1062,6 +1062,210 @@ pub fn use_it(
 
             for item from opaque iterator return
             - nominal struct app[lib]::crate::UserId
+        "#]],
+    );
+}
+
+#[test]
+fn propagates_for_loop_item_types_from_method_returned_slice() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["core", "app"]
+resolver = "3"
+
+//- /core/Cargo.toml
+[package]
+name = "fake_core"
+version = "0.1.0"
+edition = "2024"
+
+//- /core/src/lib.rs
+pub mod iter {
+    pub trait IntoIterator {
+        type Item;
+    }
+}
+
+impl<'a, T> iter::IntoIterator for &'a [T] {
+    type Item = &'a T;
+}
+
+//- /storage/Cargo.toml
+[package]
+name = "storage"
+version = "0.1.0"
+edition = "2024"
+
+//- /storage/src/lib.rs
+pub struct ImportData;
+
+pub struct DefMap;
+
+impl DefMap {
+    pub fn imports(&self) -> &[ImportData] {
+        missing()
+    }
+}
+
+pub struct DefMapBuilder {
+    incomplete: DefMap,
+}
+
+impl DefMapBuilder {
+    pub fn as_incomplete_def_map(&self) -> &DefMap {
+        &self.incomplete
+    }
+}
+
+//- /app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+core = { package = "fake_core", path = "../core" }
+storage = { path = "../storage" }
+
+//- /app/src/lib.rs
+use storage::{DefMap, DefMapBuilder};
+
+pub struct BuildState {
+    builder: DefMapBuilder,
+}
+
+pub fn use_it(def_map: &DefMap, state: &BuildState) {
+    for import in def_map.imports() {
+        let _import = imp$type_import$ort;
+    }
+
+    for chained in state.builder.as_incomplete_def_map().imports() {
+        let _chained = chai$type_chained$ned;
+    }
+}
+"#,
+        &[
+            AnalysisQuery::ty("for item from method returned slice", "type_import").in_lib("app"),
+            AnalysisQuery::ty(
+                "for item from chained method returned slice",
+                "type_chained",
+            )
+            .in_lib("app"),
+        ],
+        expect![[r#"
+            for item from method returned slice
+            - &nominal struct storage[lib]::crate::ImportData
+
+            for item from chained method returned slice
+            - &nominal struct storage[lib]::crate::ImportData
+        "#]],
+    );
+}
+
+#[test]
+fn propagates_for_loop_item_types_from_sysroot_slice_iterator() {
+    check_analysis_queries_with_sysroot(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["storage", "app"]
+resolver = "3"
+
+//- /storage/Cargo.toml
+[package]
+name = "storage"
+version = "0.1.0"
+edition = "2024"
+
+//- /storage/src/lib.rs
+pub struct ImportData;
+
+pub struct DefMap;
+
+impl DefMap {
+    pub fn imports(&self) -> &[ImportData] {
+        missing()
+    }
+}
+
+pub struct DefMapBuilder {
+    incomplete: DefMap,
+}
+
+impl DefMapBuilder {
+    pub fn as_incomplete_def_map(&self) -> &DefMap {
+        &self.incomplete
+    }
+}
+
+//- /app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+storage = { path = "../storage" }
+
+//- /app/src/lib.rs
+use storage::{DefMap, DefMapBuilder};
+
+pub struct BuildState {
+    builder: DefMapBuilder,
+}
+
+pub fn use_it(def_map: &DefMap, state: &BuildState) {
+    for import in def_map.imports() {
+        let _import = imp$type_import$ort;
+    }
+
+    for chained in state.builder.as_incomplete_def_map().imports() {
+        let _chained = chai$type_chained$ned;
+    }
+}
+
+//- /sysroot/library/core/src/lib.rs
+pub mod iter {
+    pub trait IntoIterator {
+        type Item;
+        type IntoIter;
+    }
+}
+
+pub mod slice {
+    pub struct Iter<'a, T>(&'a T);
+}
+
+impl<'a, T> iter::IntoIterator for &'a [T] {
+    type Item = &'a T;
+    type IntoIter = slice::Iter<'a, T>;
+}
+
+//- /sysroot/library/alloc/src/lib.rs
+pub struct Alloc;
+
+//- /sysroot/library/std/src/lib.rs
+pub mod prelude {
+    pub mod rust_2024 {}
+}
+"#,
+        &[
+            AnalysisQuery::ty("for item from sysroot method returned slice", "type_import")
+                .in_lib("app"),
+            AnalysisQuery::ty(
+                "for item from sysroot chained method returned slice",
+                "type_chained",
+            )
+            .in_lib("app"),
+        ],
+        expect![[r#"
+            for item from sysroot method returned slice
+            - &nominal struct storage[lib]::crate::ImportData
+
+            for item from sysroot chained method returned slice
+            - &nominal struct storage[lib]::crate::ImportData
         "#]],
     );
 }

--- a/crates/engine/analysis/src/tests/type_at.rs
+++ b/crates/engine/analysis/src/tests/type_at.rs
@@ -820,6 +820,41 @@ pub fn use_it(pair: (u8, bool), array: [u8; 3], slice: &[u8], value: u8) {
 }
 
 #[test]
+fn returns_index_types_through_references() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_ref_index_type_at"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub fn use_it(slice: &[u8], array_ref: &[bool; 3], nested_slice: &&[u16]) {
+    let slice_item = slice[0]$type_slice_item$;
+    let array_item = array_ref[0]$type_array_item$;
+    let nested_item = nested_slice[0]$type_nested_item$;
+}
+"#,
+        &[
+            AnalysisQuery::ty("slice reference index", "type_slice_item"),
+            AnalysisQuery::ty("array reference index", "type_array_item"),
+            AnalysisQuery::ty("nested slice reference index", "type_nested_item"),
+        ],
+        expect![[r#"
+            slice reference index
+            - u8
+
+            array reference index
+            - bool
+
+            nested slice reference index
+            - u16
+        "#]],
+    );
+}
+
+#[test]
 fn resolves_structural_slice_inherent_method_types() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/type_at.rs
+++ b/crates/engine/analysis/src/tests/type_at.rs
@@ -864,6 +864,84 @@ pub fn use_it() {
 }
 
 #[test]
+fn resolves_lifetime_parameterized_receiver_method_types() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_lifetime_receiver_method_type"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+fn missing<T>() -> T {
+    loop {}
+}
+
+pub struct Module;
+pub struct DebugStruct;
+
+pub struct TargetScopeCollector<'db> {
+    module: &'db Module,
+}
+
+impl<'db> TargetScopeCollector<'db> {
+    fn alloc_module(&mut self) -> Module {
+        missing()
+    }
+
+    fn collect_items(&mut self) -> Module {
+        self.alloc$type_self_alloc$_module()
+    }
+
+    fn collect(&mut self) -> Module {
+        self.collect$type_self_collect$_items()
+    }
+}
+
+pub mod fmt {
+    pub struct Formatter<'a> {
+        marker: &'a (),
+    }
+}
+
+impl<'a> fmt::Formatter<'a> {
+    fn debug_struct(&mut self) -> crate::DebugStruct {
+        crate::missing()
+    }
+}
+
+pub fn use_it<'db>(
+    collector: &mut TargetScopeCollector<'db>,
+    formatter: &mut fmt::Formatter<'_>,
+) {
+    let _items = collector.collect$type_collect$_items();
+    let _debug = formatter.debug$type_debug$_struct();
+}
+"#,
+        &[
+            AnalysisQuery::ty("self method in lifetime impl", "type_self_alloc"),
+            AnalysisQuery::ty("self sibling method in lifetime impl", "type_self_collect"),
+            AnalysisQuery::ty("external method on lifetime receiver", "type_collect"),
+            AnalysisQuery::ty("method on Formatter placeholder lifetime", "type_debug"),
+        ],
+        expect![[r#"
+            self method in lifetime impl
+            - nominal struct analysis_lifetime_receiver_method_type[lib]::crate::Module
+
+            self sibling method in lifetime impl
+            - nominal struct analysis_lifetime_receiver_method_type[lib]::crate::Module
+
+            external method on lifetime receiver
+            - nominal struct analysis_lifetime_receiver_method_type[lib]::crate::Module
+
+            method on Formatter placeholder lifetime
+            - nominal struct analysis_lifetime_receiver_method_type[lib]::crate::DebugStruct
+        "#]],
+    );
+}
+
+#[test]
 fn does_not_treat_concrete_impl_self_args_as_type_params() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/type_at.rs
+++ b/crates/engine/analysis/src/tests/type_at.rs
@@ -820,6 +820,63 @@ pub fn use_it(pair: (u8, bool), array: [u8; 3], slice: &[u8], value: u8) {
 }
 
 #[test]
+fn resolves_structural_slice_inherent_method_types() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["core", "app"]
+resolver = "3"
+
+//- /core/Cargo.toml
+[package]
+name = "fake_core"
+version = "0.1.0"
+edition = "2024"
+
+//- /core/src/lib.rs
+impl<T> [T] {
+    pub fn first_ref(&self) -> &T {
+        missing()
+    }
+
+    pub fn len(&self) -> usize {
+        missing()
+    }
+}
+
+//- /app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+core = { package = "fake_core", path = "../core" }
+
+//- /app/src/lib.rs
+pub struct Package;
+
+pub fn use_it(packages: &[Package]) {
+    let first = packages.first$type_first$_ref();
+    let count = packages.le$type_len$n();
+}
+"#,
+        &[
+            AnalysisQuery::ty("slice generic method return", "type_first").in_lib("app"),
+            AnalysisQuery::ty("slice len method return", "type_len").in_lib("app"),
+        ],
+        expect![[r#"
+            slice generic method return
+            - &nominal struct app[lib]::crate::Package
+
+            slice len method return
+            - usize
+        "#]],
+    );
+}
+
+#[test]
 fn primitive_type_paths_respect_type_namespace_shadowing() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/type_at.rs
+++ b/crates/engine/analysis/src/tests/type_at.rs
@@ -1232,6 +1232,146 @@ pub fn use_it() {
 }
 
 #[test]
+fn infers_basic_generic_call_arguments() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_generic_call_arg_inference"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+fn missing<T>() -> T {
+    loop {}
+}
+
+pub struct User;
+pub struct Project;
+
+pub struct Wrapper<T> {
+    value: T,
+}
+
+pub fn id<T>(value: T) -> T {
+    value
+}
+
+pub fn pair<T, U>(left: T, right: U) -> (T, U) {
+    missing()
+}
+
+pub fn same<T>(left: T, right: T) -> T {
+    missing()
+}
+
+pub struct Builder;
+
+impl Builder {
+    pub fn wrap<T>(value: T) -> Wrapper<T> {
+        missing()
+    }
+
+    pub fn echo<T>(&self, value: T) -> T {
+        value
+    }
+
+    pub fn clone_ref<T>(&self, value: &T) -> T {
+        missing()
+    }
+}
+
+pub fn use_it(builder: Builder, user: User, project: Project) {
+    let id_value = id(user)$type_id$;
+    let pair_value = pair(user, project)$type_pair$;
+    let wrapped = Builder::wrap(user)$type_wrap$;
+    let echoed = builder.echo(project)$type_method$;
+    let cloned = builder.clone_ref(&user)$type_ref$;
+    let conflict = same(user, project)$type_conflict$;
+}
+"#,
+        &[
+            AnalysisQuery::ty("inferred free function return", "type_id"),
+            AnalysisQuery::ty("inferred multi-param return", "type_pair"),
+            AnalysisQuery::ty("inferred associated function return", "type_wrap"),
+            AnalysisQuery::ty("inferred method return", "type_method"),
+            AnalysisQuery::ty("inferred reference param return", "type_ref"),
+            AnalysisQuery::ty("conflicting inferred params", "type_conflict"),
+        ],
+        expect![[r#"
+            inferred free function return
+            - nominal struct analysis_generic_call_arg_inference[lib]::crate::User
+
+            inferred multi-param return
+            - (nominal struct analysis_generic_call_arg_inference[lib]::crate::User, nominal struct analysis_generic_call_arg_inference[lib]::crate::Project)
+
+            inferred associated function return
+            - nominal struct analysis_generic_call_arg_inference[lib]::crate::Wrapper<nominal struct analysis_generic_call_arg_inference[lib]::crate::User>
+
+            inferred method return
+            - nominal struct analysis_generic_call_arg_inference[lib]::crate::Project
+
+            inferred reference param return
+            - nominal struct analysis_generic_call_arg_inference[lib]::crate::User
+
+            conflicting inferred params
+            - <unknown>
+        "#]],
+    );
+}
+
+#[test]
+fn inferred_function_generics_shadow_impl_generics() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_generic_call_arg_shadowing"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+fn missing<T>() -> T {
+    loop {}
+}
+
+pub struct User;
+pub struct Project;
+
+pub struct Container<T> {
+    value: T,
+}
+
+impl<T> Container<T> {
+    pub fn current(&self) -> T {
+        missing()
+    }
+
+    pub fn replace<T>(&self, value: T) -> T {
+        value
+    }
+}
+
+pub fn use_it(container: Container<User>, project: Project) {
+    let current = container.current()$type_current$;
+    let replaced = container.replace(project)$type_replaced$;
+}
+"#,
+        &[
+            AnalysisQuery::ty("impl generic method return", "type_current"),
+            AnalysisQuery::ty("shadowed method generic return", "type_replaced"),
+        ],
+        expect![[r#"
+            impl generic method return
+            - nominal struct analysis_generic_call_arg_shadowing[lib]::crate::User
+
+            shadowed method generic return
+            - nominal struct analysis_generic_call_arg_shadowing[lib]::crate::Project
+        "#]],
+    );
+}
+
+#[test]
 fn resolves_lifetime_parameterized_receiver_method_types() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/type_at.rs
+++ b/crates/engine/analysis/src/tests/type_at.rs
@@ -1227,6 +1227,8 @@ pub fn use_it(def_map: &DefMap, state: &BuildState) {
 }
 
 //- /sysroot/library/core/src/lib.rs
+extern crate self as core;
+
 pub mod iter {
     pub trait IntoIterator {
         type Item;
@@ -1234,11 +1236,17 @@ pub mod iter {
     }
 }
 
+pub mod prelude {
+    pub mod rust_2024 {
+        pub use crate::iter::IntoIterator;
+    }
+}
+
 pub mod slice {
     pub struct Iter<'a, T>(&'a T);
 }
 
-impl<'a, T> iter::IntoIterator for &'a [T] {
+impl<'a, T> IntoIterator for &'a [T] {
     type Item = &'a T;
     type IntoIter = slice::Iter<'a, T>;
 }
@@ -1265,6 +1273,402 @@ pub mod prelude {
             - &nominal struct storage[lib]::crate::ImportData
 
             for item from sysroot chained method returned slice
+            - &nominal struct storage[lib]::crate::ImportData
+        "#]],
+    );
+}
+
+#[test]
+fn propagates_for_loop_item_types_from_slice_iter_method() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["core", "storage", "app"]
+resolver = "3"
+
+//- /core/Cargo.toml
+[package]
+name = "fake_core"
+version = "0.1.0"
+edition = "2024"
+
+//- /core/src/lib.rs
+pub mod iter {
+    pub trait IntoIterator {
+        type Item;
+    }
+
+    pub trait Iterator {
+        type Item;
+    }
+}
+
+pub mod slice {
+    pub struct Iter<'a, T>(&'a T);
+}
+
+impl<T> [T] {
+    pub fn iter(&self) -> slice::Iter<'_, T> {
+        missing()
+    }
+}
+
+impl<'a, T> iter::Iterator for slice::Iter<'a, T> {
+    type Item = &'a T;
+}
+
+impl<I: iter::Iterator> iter::IntoIterator for I {
+    type Item = I::Item;
+}
+
+//- /storage/Cargo.toml
+[package]
+name = "storage"
+version = "0.1.0"
+edition = "2024"
+
+//- /storage/src/lib.rs
+pub struct ImportData;
+
+pub struct DefMap;
+
+impl DefMap {
+    pub fn imports(&self) -> &[ImportData] {
+        missing()
+    }
+}
+
+//- /app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+core = { package = "fake_core", path = "../core" }
+storage = { path = "../storage" }
+
+//- /app/src/lib.rs
+use storage::DefMap;
+
+pub fn use_it(def_map: &DefMap) {
+    let iter = def_map.imports().it$type_iter$er();
+
+    for imp$hover_import$ort in def_map.imports().iter() {
+        let _import = imp$type_import$ort;
+    }
+}
+"#,
+        &[
+            AnalysisQuery::ty("slice iter method return", "type_iter").in_lib("app"),
+            AnalysisQuery::ty("for item from slice iter method", "type_import").in_lib("app"),
+            AnalysisQuery::hover("hover for item from slice iter method", "hover_import")
+                .in_lib("app"),
+        ],
+        expect![[r#"
+            slice iter method return
+            - nominal struct fake_core[lib]::crate::slice::Iter<'_, nominal struct storage[lib]::crate::ImportData>
+
+            for item from slice iter method
+            - &nominal struct storage[lib]::crate::ImportData
+
+            hover for item from slice iter method
+            - range: 6:9-6:15
+            - block:
+              kind: variable
+              signature:
+                let import: &ImportData
+        "#]],
+    );
+}
+
+#[test]
+fn propagates_for_loop_item_types_from_sysroot_slice_iter_method() {
+    check_analysis_queries_with_sysroot(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["storage", "app"]
+resolver = "3"
+
+//- /storage/Cargo.toml
+[package]
+name = "storage"
+version = "0.1.0"
+edition = "2024"
+
+//- /storage/src/lib.rs
+pub struct ImportData;
+
+pub struct DefMap;
+
+impl DefMap {
+    pub fn imports(&self) -> &[ImportData] {
+        missing()
+    }
+}
+
+//- /app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+storage = { path = "../storage" }
+
+//- /app/src/lib.rs
+use storage::DefMap;
+
+pub fn use_it(def_map: &DefMap) {
+    let iter = def_map.imports().it$type_iter$er();
+
+    for imp$hover_import$ort in def_map.imports().iter() {
+        let _import = imp$type_import$ort;
+    }
+}
+
+//- /sysroot/library/core/src/lib.rs
+extern crate self as core;
+
+pub mod iter {
+    pub trait IntoIterator {
+        type Item;
+    }
+
+    pub trait Iterator {
+        type Item;
+    }
+}
+
+pub mod prelude {
+    pub mod rust_2024 {
+        pub use crate::iter::{IntoIterator, Iterator};
+    }
+}
+
+pub mod slice {
+    pub struct Iter<'a, T: 'a>(&'a T);
+}
+
+impl<T> [T] {
+    pub fn iter(&self) -> slice::Iter<'_, T> {
+        missing()
+    }
+}
+
+impl<'a, T> Iterator for slice::Iter<'a, T> {
+    type Item = &'a T;
+}
+
+impl<I: Iterator> IntoIterator for I {
+    type Item = I::Item;
+}
+
+//- /sysroot/library/alloc/src/lib.rs
+pub struct Alloc;
+
+//- /sysroot/library/std/src/lib.rs
+pub mod prelude {
+    pub mod rust_2024 {}
+}
+"#,
+        &[
+            AnalysisQuery::ty("sysroot slice iter method return", "type_iter").in_lib("app"),
+            AnalysisQuery::ty("for item from sysroot slice iter method", "type_import")
+                .in_lib("app"),
+            AnalysisQuery::hover(
+                "hover for item from sysroot slice iter method",
+                "hover_import",
+            )
+            .in_lib("app"),
+        ],
+        expect![[r#"
+            sysroot slice iter method return
+            - nominal struct core[lib]::crate::slice::Iter<'_, nominal struct storage[lib]::crate::ImportData>
+
+            for item from sysroot slice iter method
+            - &nominal struct storage[lib]::crate::ImportData
+
+            hover for item from sysroot slice iter method
+            - range: 6:9-6:15
+            - block:
+              kind: variable
+              signature:
+                let import: &ImportData
+        "#]],
+    );
+}
+
+#[test]
+fn propagates_for_loop_items_from_project_style_import_helpers() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["core", "storage", "app"]
+resolver = "3"
+
+//- /core/Cargo.toml
+[package]
+name = "fake_core"
+version = "0.1.0"
+edition = "2024"
+
+//- /core/src/lib.rs
+pub mod iter {
+    pub trait IntoIterator {
+        type Item;
+    }
+
+    pub trait Iterator {
+        type Item;
+    }
+}
+
+pub mod slice {
+    pub struct Iter<'a, T>(&'a T);
+}
+
+impl<T> [T] {
+    pub fn iter(&self) -> slice::Iter<'_, T> {
+        missing()
+    }
+}
+
+impl<'a, T> iter::Iterator for slice::Iter<'a, T> {
+    type Item = &'a T;
+}
+
+impl<I: iter::Iterator> iter::IntoIterator for I {
+    type Item = I::Item;
+}
+
+//- /storage/Cargo.toml
+[package]
+name = "storage"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+core = { package = "fake_core", path = "../core" }
+
+//- /storage/src/lib.rs
+use core::iter;
+
+pub struct ImportId;
+pub struct ImportData;
+
+pub struct DefMap;
+
+impl DefMap {
+    pub fn imports(&self) -> &[ImportData] {
+        missing()
+    }
+
+    pub fn imports_with_ids(&self) -> impl iter::Iterator<Item = (ImportId, &ImportData)> {
+        missing()
+    }
+}
+
+pub struct DefMapBuilder {
+    pub incomplete: DefMap,
+}
+
+impl DefMapBuilder {
+    pub fn as_incomplete_def_map(&self) -> &DefMap {
+        &self.incomplete
+    }
+}
+
+pub struct TargetState {
+    pub def_map_builder: DefMapBuilder,
+}
+
+//- /app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+core = { package = "fake_core", path = "../core" }
+storage = { path = "../storage" }
+
+//- /app/src/lib.rs
+use storage::TargetState;
+
+pub fn use_it(state: &TargetState) {
+    for imp$hover_iter_import$ort in state.def_map_builder.as_incomplete_def_map().imports().iter() {
+        let _import = imp$type_iter_import$ort;
+    }
+
+    for (import_$hover_import_id$id, imp$hover_ids_import$ort) in state
+        .def_map_builder
+        .as_incomplete_def_map()
+        .imports_with_ids()
+    {
+        let _import_id = import$type_import_id$_id;
+        let _import = imp$type_ids_import$ort;
+    }
+}
+"#,
+        &[
+            AnalysisQuery::hover("hover item from project-style slice iter", "hover_iter_import")
+                .in_lib("app"),
+            AnalysisQuery::ty("use item from project-style slice iter", "type_iter_import")
+                .in_lib("app"),
+            AnalysisQuery::hover(
+                "hover import id from project-style opaque iterator",
+                "hover_import_id",
+            )
+            .in_lib("app"),
+            AnalysisQuery::ty(
+                "use import id from project-style opaque iterator",
+                "type_import_id",
+            )
+            .in_lib("app"),
+            AnalysisQuery::hover(
+                "hover item from project-style opaque iterator",
+                "hover_ids_import",
+            )
+            .in_lib("app"),
+            AnalysisQuery::ty(
+                "use item from project-style opaque iterator",
+                "type_ids_import",
+            )
+            .in_lib("app"),
+        ],
+        expect![[r#"
+            hover item from project-style slice iter
+            - range: 4:9-4:15
+            - block:
+              kind: variable
+              signature:
+                let import: &ImportData
+
+            use item from project-style slice iter
+            - &nominal struct storage[lib]::crate::ImportData
+
+            hover import id from project-style opaque iterator
+            - range: 8:10-8:19
+            - block:
+              kind: variable
+              signature:
+                let import_id: ImportId
+
+            use import id from project-style opaque iterator
+            - nominal struct storage[lib]::crate::ImportId
+
+            hover item from project-style opaque iterator
+            - range: 8:21-8:27
+            - block:
+              kind: variable
+              signature:
+                let import: &ImportData
+
+            use item from project-style opaque iterator
             - &nominal struct storage[lib]::crate::ImportData
         "#]],
     );

--- a/crates/engine/analysis/src/tests/utils.rs
+++ b/crates/engine/analysis/src/tests/utils.rs
@@ -1152,6 +1152,19 @@ impl<'a> AnalysisQuerySnapshot<'a> {
             GenericArg::Type(ty) => self.render_ty(ty),
             GenericArg::Lifetime(lifetime) => lifetime.clone(),
             GenericArg::Const(value) => value.clone(),
+            GenericArg::FnTraitArgs { params, ret } => {
+                let params = params
+                    .iter()
+                    .map(|ty| self.render_ty(ty))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let mut text = format!("({params})");
+                if !matches!(ret.as_ref(), Ty::Unit) {
+                    text.push_str(" -> ");
+                    text.push_str(&self.render_ty(ret));
+                }
+                text
+            }
             GenericArg::AssocType { name, ty } => match ty {
                 Some(ty) => format!("{name} = {}", self.render_ty(ty)),
                 None => name.to_string(),

--- a/crates/engine/analysis/src/tests/utils.rs
+++ b/crates/engine/analysis/src/tests/utils.rs
@@ -19,7 +19,7 @@ use rg_ir_view::IndexedViewDb;
 use rg_package_store::PackageLoader;
 use rg_parse::{FileId, ParseDb, Span};
 use rg_semantic_ir::{SemanticIrReadTxn, testonly::SemanticIrFixture};
-use rg_ty::{GenericArg, NominalTy, Ty};
+use rg_ty::{GenericArg, NominalTy, OpaqueTraitBound, Ty};
 use rg_workspace::{SysrootSources, TargetKind, WorkspaceMetadata};
 use test_fixture::{CrateFixture, FixtureMarkers, fixture_crate, fixture_crate_with_markers};
 
@@ -1119,6 +1119,14 @@ impl<'a> AnalysisQuerySnapshot<'a> {
             Ty::Reference { mutability, inner } => {
                 format!("{}{}", mutability.render_prefix(), self.render_ty(inner))
             }
+            Ty::Opaque { bounds } => {
+                let mut bounds = bounds
+                    .iter()
+                    .map(|bound| self.render_opaque_bound(bound))
+                    .collect::<Vec<_>>();
+                bounds.sort();
+                format!("impl {}", bounds.join(" + "))
+            }
             Ty::Nominal(types) => {
                 let mut types = types
                     .iter()
@@ -1137,6 +1145,14 @@ impl<'a> AnalysisQuerySnapshot<'a> {
             }
             Ty::Unknown => "<unknown>".to_string(),
         }
+    }
+
+    fn render_opaque_bound(&self, bound: &OpaqueTraitBound) -> String {
+        format!(
+            "{}{}",
+            self.render_trait_ref(bound.trait_ref),
+            self.render_generic_args(&bound.args)
+        )
     }
 
     fn render_body_nominal_ty(&self, ty: &NominalTy) -> String {
@@ -1227,6 +1243,28 @@ impl<'a> AnalysisQuerySnapshot<'a> {
                 )
             }
         }
+    }
+
+    fn render_trait_ref(&self, trait_ref: TraitRef) -> String {
+        let items = match trait_ref.origin {
+            DefMapRef::Target(target) => self
+                .db
+                .resident_target_ir(target)
+                .expect("target semantic IR should exist while rendering analysis trait"),
+            DefMapRef::Body(body) => self
+                .db
+                .resident_body_item_store(body)
+                .expect("body item store should exist while rendering analysis trait"),
+        };
+
+        let data = items
+            .trait_data(trait_ref.id)
+            .expect("trait id should exist while rendering analysis type");
+        format!(
+            "trait {}::{}",
+            self.render_module_ref(data.owner),
+            data.name
+        )
     }
 
     fn render_function_ref(&self, function_ref: FunctionRef) -> String {

--- a/crates/engine/analysis/src/tests/utils.rs
+++ b/crates/engine/analysis/src/tests/utils.rs
@@ -1101,6 +1101,20 @@ impl<'a> AnalysisQuerySnapshot<'a> {
             Ty::Unit => "()".to_string(),
             Ty::Never => "!".to_string(),
             Ty::Primitive(primitive) => primitive.label().to_string(),
+            Ty::Tuple(fields) => {
+                let fields = fields
+                    .iter()
+                    .map(|ty| self.render_ty(ty))
+                    .collect::<Vec<_>>();
+                let suffix = if fields.len() == 1 { "," } else { "" };
+                format!("({}{suffix})", fields.join(", "))
+            }
+            Ty::Array { inner, len } => format!(
+                "[{}; {}]",
+                self.render_ty(inner),
+                len.as_deref().unwrap_or("<unknown>")
+            ),
+            Ty::Slice(inner) => format!("[{}]", self.render_ty(inner)),
             Ty::Syntax(ty) => format!("syntax {ty}"),
             Ty::Reference { mutability, inner } => {
                 format!("{}{}", mutability.render_prefix(), self.render_ty(inner))

--- a/crates/engine/body-ir/src/build/lower/expr.rs
+++ b/crates/engine/body-ir/src/build/lower/expr.rs
@@ -6,6 +6,7 @@ use rg_syntax::{
         self, ArrayExprKind, BinaryOp, ElseBranch, HasArgList as _, HasGenericArgs as _,
         HasLoopBody as _, LogicOp, RangeItem as _,
     },
+    utils::normalized_syntax_text,
 };
 
 use rg_ir_model::{ExprId, ScopeId};
@@ -146,15 +147,7 @@ impl BodyLowering<'_> {
                     initializer.map(|initializer| self.lower_expr(initializer, scope));
                 // Preserve the written const expression for display and shallow type equality. This
                 // deliberately does not evaluate the expression; it only mirrors array type syntax.
-                let len_text = repeat.as_ref().map(|repeat| {
-                    repeat
-                        .syntax()
-                        .text()
-                        .to_string()
-                        .split_whitespace()
-                        .collect::<Vec<_>>()
-                        .join(" ")
-                });
+                let len_text = repeat.as_ref().map(normalized_syntax_text);
                 let repeat = repeat.map(|repeat| self.lower_expr(repeat, scope));
                 self.alloc_expr(
                     array.syntax(),

--- a/crates/engine/body-ir/src/build/lower/expr.rs
+++ b/crates/engine/body-ir/src/build/lower/expr.rs
@@ -3,13 +3,13 @@
 use rg_syntax::{
     AstNode as _,
     ast::{
-        self, ArrayExprKind, BinaryOp, ElseBranch, HasArgList as _, HasLoopBody as _, LogicOp,
-        RangeItem as _,
+        self, ArrayExprKind, BinaryOp, ElseBranch, HasArgList as _, HasGenericArgs as _,
+        HasLoopBody as _, LogicOp, RangeItem as _,
     },
 };
 
 use rg_ir_model::{ExprId, ScopeId};
-use rg_item_tree::{FieldKey, FromAst as _, TypeRef};
+use rg_item_tree::{FieldKey, FromAst as _, GenericArg, TypeRef};
 use rg_parse::{Span, TextSpan};
 use rg_ty::Ty;
 
@@ -553,6 +553,12 @@ impl BodyLowering<'_> {
         let method_name_span = name_ref
             .as_ref()
             .map(|name| self.source(name.syntax()).span);
+        let generic_args = method_call
+            .generic_arg_list()
+            .into_iter()
+            .flat_map(|args| args.generic_args())
+            .map(|arg| GenericArg::from_ast(&arg, (self.line_index, &mut *self.interner)))
+            .collect();
         let args = method_call
             .arg_list()
             .into_iter()
@@ -568,6 +574,7 @@ impl BodyLowering<'_> {
                 dot_span,
                 method_name,
                 method_name_span,
+                generic_args,
                 args,
             },
         )

--- a/crates/engine/body-ir/src/build/lower/expr.rs
+++ b/crates/engine/body-ir/src/build/lower/expr.rs
@@ -144,6 +144,17 @@ impl BodyLowering<'_> {
             } => {
                 let initializer =
                     initializer.map(|initializer| self.lower_expr(initializer, scope));
+                // Preserve the written const expression for display and shallow type equality. This
+                // deliberately does not evaluate the expression; it only mirrors array type syntax.
+                let len_text = repeat.as_ref().map(|repeat| {
+                    repeat
+                        .syntax()
+                        .text()
+                        .to_string()
+                        .split_whitespace()
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                });
                 let repeat = repeat.map(|repeat| self.lower_expr(repeat, scope));
                 self.alloc_expr(
                     array.syntax(),
@@ -151,6 +162,7 @@ impl BodyLowering<'_> {
                     ExprKind::RepeatArray {
                         initializer,
                         repeat,
+                        len_text,
                     },
                 )
             }

--- a/crates/engine/body-ir/src/build/lower/syntax.rs
+++ b/crates/engine/body-ir/src/build/lower/syntax.rs
@@ -8,6 +8,7 @@ use rg_syntax::{
 use rg_item_tree::{FromAst as _, GenericArg, TypePath, TypeRef};
 use rg_parse::{FileId, Span};
 use rg_text::Name;
+use rg_ty::{PrimitiveTy, UnsignedIntTy};
 
 use crate::ir::{
     BodyPath, BodySource, ExprAssignOp, ExprBinaryOp, ExprRangeKind, ExprUnaryOp, LabelData,
@@ -22,9 +23,15 @@ impl LiteralKind {
         match literal.kind() {
             ast::LiteralKind::Bool(_) => Self::Bool,
             ast::LiteralKind::Char(_) => Self::Char,
-            ast::LiteralKind::Byte(_) => Self::Int,
-            ast::LiteralKind::FloatNumber(_) => Self::Float,
-            ast::LiteralKind::IntNumber(_) => Self::Int,
+            ast::LiteralKind::Byte(_) => Self::Int {
+                primitive_ty: Some(PrimitiveTy::UnsignedInt(UnsignedIntTy::U8)),
+            },
+            ast::LiteralKind::FloatNumber(number) => Self::Float {
+                primitive_ty: PrimitiveTy::from_float_suffix(number.suffix()),
+            },
+            ast::LiteralKind::IntNumber(number) => Self::Int {
+                primitive_ty: PrimitiveTy::from_integer_suffix(number.suffix()),
+            },
             ast::LiteralKind::String(_)
             | ast::LiteralKind::ByteString(_)
             | ast::LiteralKind::CString(_) => Self::String,
@@ -286,6 +293,7 @@ pub(super) fn source_for(file_id: FileId, syntax: &rg_syntax::SyntaxNode) -> Bod
 #[cfg(test)]
 mod tests {
     use rg_syntax::{AstNode as _, Edition, SourceFile, ast};
+    use rg_ty::{FloatTy, PrimitiveTy, SignedIntTy, UnsignedIntTy};
 
     use crate::ir::LiteralKind;
 
@@ -294,14 +302,54 @@ mod tests {
         let cases = [
             ("true", LiteralKind::Bool, "bool literal"),
             ("'x'", LiteralKind::Char, "char literal"),
-            ("b'x'", LiteralKind::Int, "byte literal"),
-            ("42", LiteralKind::Int, "integer literal"),
-            ("1.5", LiteralKind::Float, "decimal float literal"),
-            ("1e10", LiteralKind::Float, "exponent float literal"),
+            (
+                "b'x'",
+                LiteralKind::Int {
+                    primitive_ty: Some(PrimitiveTy::UnsignedInt(UnsignedIntTy::U8)),
+                },
+                "byte literal",
+            ),
+            (
+                "42",
+                LiteralKind::Int {
+                    primitive_ty: Some(PrimitiveTy::SignedInt(SignedIntTy::I32)),
+                },
+                "integer literal",
+            ),
+            (
+                "42usize",
+                LiteralKind::Int {
+                    primitive_ty: Some(PrimitiveTy::UnsignedInt(UnsignedIntTy::Usize)),
+                },
+                "suffixed integer literal",
+            ),
+            (
+                "1.5",
+                LiteralKind::Float {
+                    primitive_ty: Some(PrimitiveTy::Float(FloatTy::F64)),
+                },
+                "decimal float literal",
+            ),
+            (
+                "1e10",
+                LiteralKind::Float {
+                    primitive_ty: Some(PrimitiveTy::Float(FloatTy::F64)),
+                },
+                "exponent float literal",
+            ),
             (
                 "1E-10",
-                LiteralKind::Float,
+                LiteralKind::Float {
+                    primitive_ty: Some(PrimitiveTy::Float(FloatTy::F64)),
+                },
                 "negative exponent float literal",
+            ),
+            (
+                "1E-10f32",
+                LiteralKind::Float {
+                    primitive_ty: Some(PrimitiveTy::Float(FloatTy::F32)),
+                },
+                "suffixed float literal",
             ),
             (r#""text""#, LiteralKind::String, "string literal"),
             (r##"r#"text"#"##, LiteralKind::String, "raw string literal"),

--- a/crates/engine/body-ir/src/cursor/scan/sites.rs
+++ b/crates/engine/body-ir/src/cursor/scan/sites.rs
@@ -15,8 +15,8 @@ use rg_parse::{FileId, Span};
 use crate::{
     BodyData, BodyPath, ExprKind, StmtKind,
     walk::{
-        PatWalkSite, walk_body_path_type_refs as walk_embedded_body_path_type_refs, walk_pat,
-        walk_type_ref_paths,
+        PatWalkSite, walk_body_path_type_refs as walk_embedded_body_path_type_refs,
+        walk_generic_args_type_refs, walk_pat, walk_type_ref_paths,
     },
 };
 
@@ -280,6 +280,16 @@ where
                         expr.visible_bindings,
                         expr.source.file_id,
                     );
+                }
+                ExprKind::MethodCall { generic_args, .. } => {
+                    let context = TypeRefContext {
+                        scope: expr.scope,
+                        visible_bindings: expr.visible_bindings,
+                        file_id: expr.source.file_id,
+                    };
+                    walk_generic_args_type_refs(generic_args, &mut |ty| {
+                        self.emit_type_ref(context, ty);
+                    });
                 }
                 _ => {}
             }

--- a/crates/engine/body-ir/src/ir/expr.rs
+++ b/crates/engine/body-ir/src/ir/expr.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use wincode::{SchemaRead, SchemaWrite};
 
 use rg_ir_model::{BindingId, ExprId, PatId, ScopeId, StmtId};
-use rg_item_tree::{FieldKey, TypeRef};
+use rg_item_tree::{FieldKey, GenericArg, TypeRef};
 use rg_memsize::MemorySize;
 use rg_parse::Span;
 use rg_text::Name;
@@ -254,6 +254,10 @@ pub enum ExprKind {
         dot_span: Option<Span>,
         method_name: Name,
         method_name_span: Option<Span>,
+        /// Explicit method generic arguments written after the method name, such as
+        /// `receiver.get::<User>()`.
+        #[wincode(with = "rg_wincode_utils::WincodeDynamic<Vec<GenericArg>>")]
+        generic_args: Vec<GenericArg>,
         args: Vec<ExprId>,
     },
     /// `<base>.field` or `<base>.0`.
@@ -588,11 +592,16 @@ impl ExprKind {
             Self::MethodCall {
                 receiver,
                 method_name,
+                generic_args,
                 args,
                 ..
             } => {
                 let _ = receiver;
                 method_name.shrink_to_fit();
+                generic_args.shrink_to_fit();
+                for arg in generic_args {
+                    arg.shrink_to_fit();
+                }
                 args.shrink_to_fit();
             }
             Self::Field { field, .. } => {

--- a/crates/engine/body-ir/src/ir/expr.rs
+++ b/crates/engine/body-ir/src/ir/expr.rs
@@ -7,7 +7,7 @@ use rg_item_tree::{FieldKey, TypeRef};
 use rg_memsize::MemorySize;
 use rg_parse::Span;
 use rg_text::Name;
-use rg_ty::Ty;
+use rg_ty::{PrimitiveTy, RefMutability, Ty};
 
 use super::{RecordFieldSyntax, body::BodySource, path::BodyPath, resolved::BodyResolution};
 
@@ -370,6 +370,19 @@ pub enum ExprBinaryOp {
     BitAnd,
 }
 
+impl ExprBinaryOp {
+    pub fn is_logical(self) -> bool {
+        matches!(self, Self::LogicOr | Self::LogicAnd)
+    }
+
+    pub fn is_comparison(self) -> bool {
+        matches!(
+            self,
+            Self::Eq | Self::NotEq | Self::Less | Self::LessEq | Self::Greater | Self::GreaterEq
+        )
+    }
+}
+
 /// Assignment operator written between a target expression and a value expression.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, derive_more::Display, SchemaRead, SchemaWrite, MemorySize,
@@ -425,7 +438,7 @@ pub enum ExprWrapperKind {
     Paren,
     /// `&<expr>` or `&mut <expr>`.
     #[display("ref")]
-    Ref { mutability: rg_ty::RefMutability },
+    Ref { mutability: RefMutability },
     /// `<expr>.await`.
     #[display("await")]
     Await,
@@ -462,24 +475,43 @@ pub struct LabelData {
     pub span: Span,
 }
 
-/// Literal category used for display and future cheap inference.
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, derive_more::Display, SchemaRead, SchemaWrite, MemorySize,
-)]
+/// Literal category plus the primitive type implied by suffix/default heuristics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, SchemaRead, SchemaWrite, MemorySize)]
 #[memsize(leaf)]
 pub enum LiteralKind {
-    #[display("bool")]
     Bool,
-    #[display("char")]
     Char,
-    #[display("float")]
-    Float,
-    #[display("int")]
-    Int,
-    #[display("string")]
+    Float { primitive_ty: Option<PrimitiveTy> },
+    Int { primitive_ty: Option<PrimitiveTy> },
     String,
-    #[display("unknown")]
     Unknown,
+}
+
+impl LiteralKind {
+    pub fn ty(self) -> Ty {
+        match self {
+            Self::Bool => Ty::Primitive(PrimitiveTy::Bool),
+            Self::Char => Ty::Primitive(PrimitiveTy::Char),
+            Self::Float { primitive_ty } | Self::Int { primitive_ty } => {
+                primitive_ty.map(Ty::Primitive).unwrap_or(Ty::Unknown)
+            }
+            Self::String => Ty::reference(RefMutability::Shared, Ty::Primitive(PrimitiveTy::Str)),
+            Self::Unknown => Ty::Unknown,
+        }
+    }
+}
+
+impl fmt::Display for LiteralKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Bool => write!(f, "bool"),
+            Self::Char => write!(f, "char"),
+            Self::Float { .. } => write!(f, "float"),
+            Self::Int { .. } => write!(f, "int"),
+            Self::String => write!(f, "string"),
+            Self::Unknown => write!(f, "unknown"),
+        }
+    }
 }
 
 impl ExprKind {

--- a/crates/engine/body-ir/src/ir/expr.rs
+++ b/crates/engine/body-ir/src/ir/expr.rs
@@ -159,6 +159,7 @@ pub enum ExprKind {
     RepeatArray {
         initializer: Option<ExprId>,
         repeat: Option<ExprId>,
+        len_text: Option<String>,
     },
     /// `<base>[<index>]`.
     Index {
@@ -608,8 +609,12 @@ impl ExprKind {
                     field.shrink_to_fit();
                 }
             }
-            Self::RepeatArray { .. }
-            | Self::Index { .. }
+            Self::RepeatArray { len_text, .. } => {
+                if let Some(len_text) = len_text {
+                    len_text.shrink_to_fit();
+                }
+            }
+            Self::Index { .. }
             | Self::Range { .. }
             | Self::Unary { .. }
             | Self::Binary { .. }

--- a/crates/engine/body-ir/src/ir/path.rs
+++ b/crates/engine/body-ir/src/ir/path.rs
@@ -110,6 +110,17 @@ impl BodyPath {
         self.segments.len()
     }
 
+    /// Returns angle arguments written on the final path segment, such as `T` in `make::<T>`.
+    ///
+    /// For paths, turbofish arguments belong to the segment they follow; callers that resolve a
+    /// function path care about the final segment because that is the called item.
+    pub(crate) fn last_segment_angle_args(&self) -> Option<&[GenericArg]> {
+        self.segments
+            .last()
+            .and_then(|segment| segment.args.as_ref())
+            .and_then(BodyPathSegmentArgs::angle_args)
+    }
+
     pub(crate) fn shrink_to_fit(&mut self) {
         self.segments.shrink_to_fit();
         for segment in &mut self.segments {
@@ -164,6 +175,13 @@ impl BodyPathSegmentKind {
 }
 
 impl BodyPathSegmentArgs {
+    pub(crate) fn angle_args(&self) -> Option<&[GenericArg]> {
+        match self {
+            Self::Angle { args, .. } => Some(args),
+            Self::Parenthesized(_) => None,
+        }
+    }
+
     fn shrink_to_fit(&mut self) {
         match self {
             Self::Angle { args, .. } => {

--- a/crates/engine/body-ir/src/resolution/body.rs
+++ b/crates/engine/body-ir/src/resolution/body.rs
@@ -613,6 +613,33 @@ where
                     );
                 }
             }
+
+            // Structural receivers such as `[T]` do not have a named type definition, so they
+            // cannot use the nominal `TypeDefRef` impl index above. They still may have visible
+            // inherent impls, for example `impl<T> [T]`, and those impls carry substitutions that
+            // are needed to render returns like `&T` in the receiver context.
+            for structural in self
+                .receiver_functions()
+                .structural_function_candidates_for_receiver(candidate.ty(), Some(method_name))?
+            {
+                let function_ref = structural.function();
+                let Some(function_data) = item_query.function_data(function_ref)? else {
+                    continue;
+                };
+                if function_data.name != method_name || !function_data.has_self_receiver() {
+                    continue;
+                }
+
+                push_unique(&mut functions, function_ref);
+                push_unique(
+                    &mut return_tys,
+                    self.semantic_function_return_ty_with_subst(
+                        function_ref,
+                        Some(structural.receiver_ty().clone()),
+                        structural.subst().clone(),
+                    )?,
+                );
+            }
         }
 
         if !functions.is_empty() {
@@ -778,21 +805,9 @@ where
         function_ref: FunctionRef,
         receiver_ty: Option<&NominalTy>,
     ) -> Result<Ty, PackageStoreError> {
-        let item_query = self.item_query();
-        let Some(function_data) = item_query.function_data(function_ref)? else {
+        let Some(function_data) = self.item_query().function_data(function_ref)? else {
             return Ok(Ty::Unknown);
         };
-        let Some(ret_ty) = function_data.signature.ret_ty() else {
-            return Ok(Ty::Unit);
-        };
-
-        if receiver_ty.is_some() && ret_ty.is_self_type() {
-            return Ok(receiver_ty
-                .cloned()
-                .map(|ty| Ty::nominal(vec![ty]))
-                .unwrap_or(Ty::Unknown));
-        }
-
         let subst = receiver_ty
             .map(|ty| {
                 // Receiver type args and impl self args both contribute substitutions. For
@@ -807,6 +822,37 @@ where
             })
             .transpose()?
             .unwrap_or_default();
+        self.semantic_function_return_ty_with_subst(
+            function_ref,
+            receiver_ty.cloned().map(|ty| Ty::nominal(vec![ty])),
+            subst,
+        )
+    }
+
+    fn semantic_function_return_ty_with_subst(
+        &self,
+        function_ref: FunctionRef,
+        self_ty: Option<Ty>,
+        subst: TypeSubst,
+    ) -> Result<Ty, PackageStoreError> {
+        let item_query = self.item_query();
+        let Some(function_data) = item_query.function_data(function_ref)? else {
+            return Ok(Ty::Unknown);
+        };
+        let Some(ret_ty) = function_data.signature.ret_ty() else {
+            return Ok(Ty::Unit);
+        };
+
+        if ret_ty.is_self_type() {
+            return Ok(match self_ty {
+                Some(self_ty) => self_ty,
+                None => Ty::self_ty(
+                    self.type_path_resolver()
+                        .self_nominal_tys_for_function(function_ref)?,
+                ),
+            });
+        }
+
         self.type_path_resolver()
             .type_ref(TypeRefUseSite::Function(function_ref))
             .with_subst(&subst)

--- a/crates/engine/body-ir/src/resolution/body.rs
+++ b/crates/engine/body-ir/src/resolution/body.rs
@@ -110,7 +110,8 @@ where
             for expr_idx in 0..self.body.exprs.len() {
                 changed |= self.resolve_expr(ExprId(expr_idx))?;
             }
-            let binding_updates = PatternTypePropagator::new(self.query_source()).propagate()?;
+            let binding_updates =
+                PatternTypePropagator::new(self.query_source(), self.semantic_index).propagate()?;
             changed |= self.apply_binding_type_updates(binding_updates);
 
             if !changed {

--- a/crates/engine/body-ir/src/resolution/body.rs
+++ b/crates/engine/body-ir/src/resolution/body.rs
@@ -16,7 +16,8 @@ use rg_item_tree::{FieldKey, GenericArg as ItemGenericArg};
 use rg_package_store::PackageStoreError;
 use rg_ty::{
     Autoderef, AutoderefMode, CallArgInference, CallArgMapping, ImplMatcher, ItemPathQuery,
-    NominalTy, PrimitiveTy, Ty, TypeSubst, function_generic_shadow_subst,
+    NominalTy, PrimitiveTy, ReferencePeelingCandidates, Ty, TypeSubst,
+    function_generic_shadow_subst,
 };
 
 use crate::{
@@ -426,10 +427,17 @@ where
             return Ty::Unknown;
         };
 
-        match &self.body.exprs[base].ty {
-            Ty::Array { inner, .. } | Ty::Slice(inner) => inner.as_ref().clone(),
-            _ => Ty::Unknown,
+        // Indexing is reference-transparent for the structural array/slice cases we model here:
+        // `&[T]` and `&[T; N]` should behave like their inner container. Keep this deliberately
+        // narrower than method lookup: no trait deref, no `Index` trait, and no container coercions.
+        for candidate in ReferencePeelingCandidates::new(&self.body.exprs[base].ty) {
+            match candidate.ty() {
+                Ty::Array { inner, .. } | Ty::Slice(inner) => return inner.as_ref().clone(),
+                _ => {}
+            }
         }
+
+        Ty::Unknown
     }
 
     pub(super) fn resolve_nonlocal_path_expr(

--- a/crates/engine/body-ir/src/resolution/body.rs
+++ b/crates/engine/body-ir/src/resolution/body.rs
@@ -14,11 +14,13 @@ use rg_ir_storage::{
 };
 use rg_item_tree::FieldKey;
 use rg_package_store::PackageStoreError;
-use rg_ty::{Autoderef, AutoderefMode, ImplMatcher, ItemPathQuery, NominalTy, Ty, TypeSubst};
+use rg_ty::{
+    Autoderef, AutoderefMode, ImplMatcher, ItemPathQuery, NominalTy, PrimitiveTy, Ty, TypeSubst,
+};
 
 use crate::{
     ir::body::BodyData,
-    ir::expr::{ExprKind, ExprUnaryOp, ExprWrapperKind},
+    ir::expr::{ExprBinaryOp, ExprKind, ExprUnaryOp, ExprWrapperKind},
     ir::resolved::BodyResolution,
     ir::stmt::{BindingKind, BodySelfParamKind},
 };
@@ -292,6 +294,22 @@ where
             } => {
                 self.body.exprs[expr].ty = self.explicit_deref_ty(inner)?;
             }
+            ExprKind::Unary {
+                op: Some(op),
+                expr: Some(inner),
+            } => {
+                self.body.exprs[expr].ty = self.unary_ty(op, inner);
+            }
+            ExprKind::Binary {
+                lhs: Some(lhs),
+                rhs: Some(rhs),
+                op: Some(op),
+            } => {
+                self.body.exprs[expr].ty = self.binary_ty(op, lhs, rhs);
+            }
+            ExprKind::Literal { kind } => {
+                self.body.exprs[expr].ty = kind.ty();
+            }
             ExprKind::While { .. } | ExprKind::For { .. } => {
                 self.body.exprs[expr].ty = Ty::Unit;
             }
@@ -315,7 +333,6 @@ where
             | ExprKind::Cast { ty: None, .. }
             | ExprKind::Unary { .. }
             | ExprKind::Binary { .. }
-            | ExprKind::Literal { .. }
             | ExprKind::Underscore
             | ExprKind::Yield { .. }
             | ExprKind::Unknown { .. } => {}
@@ -568,6 +585,79 @@ where
         } else {
             Ty::Unknown
         })
+    }
+
+    fn unary_ty(&self, op: ExprUnaryOp, inner: ExprId) -> Ty {
+        let ty = &self.body.exprs[inner].ty;
+        match op {
+            ExprUnaryOp::Not => match ty {
+                Ty::Primitive(primitive) if primitive.is_bool() => Ty::Primitive(*primitive),
+                _ => Ty::Unknown,
+            },
+            ExprUnaryOp::Neg => match ty {
+                Ty::Primitive(primitive) if primitive.is_signed_numeric() => {
+                    Ty::Primitive(*primitive)
+                }
+                _ => Ty::Unknown,
+            },
+            ExprUnaryOp::Deref => Ty::Unknown,
+        }
+    }
+
+    fn binary_ty(&self, op: ExprBinaryOp, lhs: ExprId, rhs: ExprId) -> Ty {
+        let lhs_ty = &self.body.exprs[lhs].ty;
+        let rhs_ty = &self.body.exprs[rhs].ty;
+
+        if op.is_logical() || op.is_comparison() {
+            return Ty::Primitive(PrimitiveTy::Bool);
+        }
+
+        match op {
+            ExprBinaryOp::Add
+            | ExprBinaryOp::Sub
+            | ExprBinaryOp::Mul
+            | ExprBinaryOp::Div
+            | ExprBinaryOp::Rem => {
+                self.symmetric_primitive_op_ty(lhs_ty, rhs_ty, |ty| ty.is_numeric())
+            }
+            ExprBinaryOp::BitAnd | ExprBinaryOp::BitOr | ExprBinaryOp::BitXor => self
+                .symmetric_primitive_op_ty(lhs_ty, rhs_ty, |ty| ty.is_integral() || ty.is_bool()),
+            ExprBinaryOp::Shl | ExprBinaryOp::Shr => self.shift_op_ty(lhs_ty, rhs_ty),
+            ExprBinaryOp::LogicOr
+            | ExprBinaryOp::LogicAnd
+            | ExprBinaryOp::Eq
+            | ExprBinaryOp::NotEq
+            | ExprBinaryOp::Less
+            | ExprBinaryOp::LessEq
+            | ExprBinaryOp::Greater
+            | ExprBinaryOp::GreaterEq => Ty::Primitive(PrimitiveTy::Bool),
+        }
+    }
+
+    fn symmetric_primitive_op_ty(
+        &self,
+        lhs_ty: &Ty,
+        rhs_ty: &Ty,
+        accepts: impl Fn(PrimitiveTy) -> bool,
+    ) -> Ty {
+        match (lhs_ty, rhs_ty) {
+            (Ty::Primitive(lhs), Ty::Primitive(rhs)) if lhs == rhs && accepts(*lhs) => {
+                Ty::Primitive(*lhs)
+            }
+            (Ty::Primitive(lhs), Ty::Unknown) if accepts(*lhs) => Ty::Primitive(*lhs),
+            (Ty::Unknown, Ty::Primitive(rhs)) if accepts(*rhs) => Ty::Primitive(*rhs),
+            _ => Ty::Unknown,
+        }
+    }
+
+    fn shift_op_ty(&self, lhs_ty: &Ty, rhs_ty: &Ty) -> Ty {
+        match (lhs_ty, rhs_ty) {
+            (Ty::Primitive(lhs), Ty::Primitive(rhs)) if lhs.is_integral() && rhs.is_integral() => {
+                Ty::Primitive(*lhs)
+            }
+            (Ty::Primitive(lhs), Ty::Unknown) if lhs.is_integral() => Ty::Primitive(*lhs),
+            _ => Ty::Unknown,
+        }
     }
 
     fn impl_self_subst_for_function(

--- a/crates/engine/body-ir/src/resolution/body.rs
+++ b/crates/engine/body-ir/src/resolution/body.rs
@@ -206,8 +206,22 @@ where
             ExprKind::Call { callee, .. } => {
                 self.body.exprs[expr].ty = self.call_ty(callee)?;
             }
-            ExprKind::Tuple { fields } if fields.is_empty() => {
-                self.body.exprs[expr].ty = Ty::Unit;
+            ExprKind::Tuple { fields } => {
+                self.body.exprs[expr].ty = self.tuple_expr_ty(&fields);
+            }
+            ExprKind::Array { elements } => {
+                self.body.exprs[expr].ty = self.array_expr_ty(&elements);
+            }
+            ExprKind::RepeatArray {
+                initializer,
+                len_text,
+                ..
+            } => {
+                self.body.exprs[expr].ty =
+                    self.repeat_array_expr_ty(initializer, len_text.as_deref());
+            }
+            ExprKind::Index { base, .. } => {
+                self.body.exprs[expr].ty = self.index_expr_ty(base);
             }
             ExprKind::Cast { ty: Some(ty), .. } => {
                 self.body.exprs[expr].ty = self
@@ -325,10 +339,6 @@ where
             ExprKind::Let { .. }
             | ExprKind::Closure { .. }
             | ExprKind::Loop { .. }
-            | ExprKind::Tuple { .. }
-            | ExprKind::Array { .. }
-            | ExprKind::RepeatArray { .. }
-            | ExprKind::Index { .. }
             | ExprKind::Range { .. }
             | ExprKind::Cast { ty: None, .. }
             | ExprKind::Unary { .. }
@@ -353,6 +363,63 @@ where
         let visible_bindings = self.body.exprs[expr].visible_bindings;
         BodyValuePathResolver::new(self.query_source(), Some(self.semantic_index))
             .resolve_path_expr(scope, path, Some(visible_bindings))
+    }
+
+    fn tuple_expr_ty(&self, fields: &[ExprId]) -> Ty {
+        Ty::tuple(
+            fields
+                .iter()
+                .map(|field| self.body.exprs[*field].ty.clone())
+                .collect(),
+        )
+    }
+
+    fn array_expr_ty(&self, elements: &[ExprId]) -> Ty {
+        if elements.is_empty() {
+            return Ty::Unknown;
+        }
+
+        let mut element_tys = Vec::new();
+        for element in elements {
+            let element_ty = self.body.exprs[*element].ty.clone();
+            if matches!(element_ty, Ty::Unknown) {
+                return Ty::Unknown;
+            }
+            push_unique(&mut element_tys, element_ty);
+        }
+
+        if element_tys.len() == 1 {
+            Ty::array(
+                element_tys
+                    .pop()
+                    .expect("one array element type should exist"),
+                Some(elements.len().to_string()),
+            )
+        } else {
+            Ty::Unknown
+        }
+    }
+
+    fn repeat_array_expr_ty(&self, initializer: Option<ExprId>, len_text: Option<&str>) -> Ty {
+        let Some(initializer) = initializer else {
+            return Ty::Unknown;
+        };
+
+        Ty::array(
+            self.body.exprs[initializer].ty.clone(),
+            len_text.map(str::to_owned),
+        )
+    }
+
+    fn index_expr_ty(&self, base: Option<ExprId>) -> Ty {
+        let Some(base) = base else {
+            return Ty::Unknown;
+        };
+
+        match &self.body.exprs[base].ty {
+            Ty::Array { inner, .. } | Ty::Slice(inner) => inner.as_ref().clone(),
+            _ => Ty::Unknown,
+        }
     }
 
     pub(super) fn resolve_nonlocal_path_expr(
@@ -419,20 +486,28 @@ where
             let candidate = candidate?;
             // Autoderef yields candidates by depth. Resolve only after the whole matching depth is
             // collected, so same-depth alternatives produce ambiguity instead of order dependence.
-            if current_depth.is_some_and(|depth| depth != candidate.depth()) && !fields.is_empty() {
+            if current_depth.is_some_and(|depth| depth != candidate.depth())
+                && (!fields.is_empty() || !field_tys.is_empty())
+            {
                 let ty = if field_tys.len() == 1 {
                     field_tys.pop().expect("one field type should exist")
                 } else {
                     Ty::Unknown
                 };
-                return Ok((
+                let resolution = if fields.is_empty() {
+                    BodyResolution::Unknown
+                } else {
                     BodyResolution::Declarations(
                         fields.into_iter().map(DeclarationRef::from).collect(),
-                    ),
-                    ty,
-                ));
+                    )
+                };
+                return Ok((resolution, ty));
             }
             current_depth = Some(candidate.depth());
+
+            if let Some(field_ty) = Self::structural_field_ty(candidate.ty(), field) {
+                push_unique(&mut field_tys, field_ty);
+            }
 
             for nominal_ty in candidate.ty().as_nominals() {
                 let Some(field_ref) = item_query.field_for_type(nominal_ty.def, field)? else {
@@ -453,21 +528,28 @@ where
             }
         }
 
-        if !fields.is_empty() {
+        if !fields.is_empty() || !field_tys.is_empty() {
             let ty = if field_tys.len() == 1 {
                 field_tys.pop().expect("one field type should exist")
             } else {
                 Ty::Unknown
             };
-            return Ok((
-                BodyResolution::Declarations(
-                    fields.into_iter().map(DeclarationRef::from).collect(),
-                ),
-                ty,
-            ));
+            let resolution = if fields.is_empty() {
+                BodyResolution::Unknown
+            } else {
+                BodyResolution::Declarations(fields.into_iter().map(DeclarationRef::from).collect())
+            };
+            return Ok((resolution, ty));
         }
 
         Ok((BodyResolution::Unknown, Ty::Unknown))
+    }
+
+    fn structural_field_ty(ty: &Ty, field: &FieldKey) -> Option<Ty> {
+        match (ty, field) {
+            (Ty::Tuple(fields), FieldKey::Tuple(index)) => fields.get(*index).cloned(),
+            _ => None,
+        }
     }
 
     fn resolve_method_call_expr(

--- a/crates/engine/body-ir/src/resolution/body.rs
+++ b/crates/engine/body-ir/src/resolution/body.rs
@@ -15,7 +15,8 @@ use rg_ir_storage::{
 use rg_item_tree::{FieldKey, GenericArg as ItemGenericArg};
 use rg_package_store::PackageStoreError;
 use rg_ty::{
-    Autoderef, AutoderefMode, ImplMatcher, ItemPathQuery, NominalTy, PrimitiveTy, Ty, TypeSubst,
+    Autoderef, AutoderefMode, CallArgInference, CallArgMapping, ImplMatcher, ItemPathQuery,
+    NominalTy, PrimitiveTy, Ty, TypeSubst, function_generic_shadow_subst,
 };
 
 use crate::{
@@ -203,8 +204,8 @@ where
                 data.resolution = resolution;
                 data.ty = ty;
             }
-            ExprKind::Call { callee, .. } => {
-                self.body.exprs[expr].ty = self.call_ty(callee)?;
+            ExprKind::Call { callee, args } => {
+                self.body.exprs[expr].ty = self.call_ty(callee, &args)?;
             }
             ExprKind::Tuple { fields } => {
                 self.body.exprs[expr].ty = self.tuple_expr_ty(&fields);
@@ -290,12 +291,14 @@ where
                 receiver,
                 method_name,
                 generic_args,
+                args,
                 ..
             } => {
                 let (resolution, ty) = self.resolve_method_call_expr(
                     receiver,
                     &method_name,
                     &generic_args,
+                    &args,
                     self.body.exprs[expr].scope,
                 )?;
                 let data = &mut self.body.exprs[expr];
@@ -563,6 +566,7 @@ where
         receiver: Option<ExprId>,
         method_name: &str,
         explicit_args: &[ItemGenericArg],
+        args: &[ExprId],
         call_scope: ScopeId,
     ) -> Result<(BodyResolution, Ty), PackageStoreError> {
         let Some(receiver) = receiver else {
@@ -621,6 +625,8 @@ where
                             function_ref,
                             Some(nominal_ty),
                             explicit_args,
+                            args,
+                            CallArgMapping::MethodCall,
                             Some(call_scope),
                         )?,
                     );
@@ -651,6 +657,8 @@ where
                         Some(structural.receiver_ty().clone()),
                         structural.subst().clone(),
                         explicit_args,
+                        args,
+                        CallArgMapping::MethodCall,
                         Some(call_scope),
                     )?,
                 );
@@ -820,12 +828,14 @@ where
         function_ref: FunctionRef,
         receiver_ty: Option<&NominalTy>,
         explicit_args: &[ItemGenericArg],
+        args: &[ExprId],
+        arg_mapping: CallArgMapping,
         call_scope: Option<ScopeId>,
     ) -> Result<Ty, PackageStoreError> {
         let Some(function_data) = self.item_query().function_data(function_ref)? else {
             return Ok(Ty::Unknown);
         };
-        let mut subst = receiver_ty
+        let subst = receiver_ty
             .map(|ty| {
                 // Receiver type args and impl self args both contribute substitutions. For
                 // `impl<U> Wrapper<U>`, this maps `U` to the known receiver argument.
@@ -839,32 +849,14 @@ where
             })
             .transpose()?
             .unwrap_or_default();
-        if let Some(call_scope) = call_scope {
-            subst.extend(self.explicit_function_subst(
-                function_data.signature.generics(),
-                explicit_args,
-                call_scope,
-            )?);
-        }
-        self.semantic_function_return_ty_with_subst(
+        self.semantic_function_return_ty_with_subst_and_call_args(
             function_ref,
             receiver_ty.cloned().map(|ty| Ty::nominal(vec![ty])),
             subst,
-        )
-    }
-
-    fn semantic_function_return_ty_with_subst(
-        &self,
-        function_ref: FunctionRef,
-        self_ty: Option<Ty>,
-        subst: TypeSubst,
-    ) -> Result<Ty, PackageStoreError> {
-        self.semantic_function_return_ty_with_subst_and_call_args(
-            function_ref,
-            self_ty,
-            subst,
-            &[],
-            None,
+            explicit_args,
+            args,
+            arg_mapping,
+            call_scope,
         )
     }
 
@@ -874,12 +866,17 @@ where
         self_ty: Option<Ty>,
         mut subst: TypeSubst,
         explicit_args: &[ItemGenericArg],
+        args: &[ExprId],
+        arg_mapping: CallArgMapping,
         call_scope: Option<ScopeId>,
     ) -> Result<Ty, PackageStoreError> {
         let item_query = self.item_query();
         let Some(function_data) = item_query.function_data(function_ref)? else {
             return Ok(Ty::Unknown);
         };
+        subst.extend(function_generic_shadow_subst(
+            function_data.signature.generics(),
+        ));
         if let Some(call_scope) = call_scope {
             subst.extend(self.explicit_function_subst(
                 function_data.signature.generics(),
@@ -887,6 +884,32 @@ where
                 call_scope,
             )?);
         }
+        let arg_tys = args
+            .iter()
+            .map(|arg| self.body.exprs[*arg].ty.clone())
+            .collect::<Vec<_>>();
+        let inferred_subst = CallArgInference::new(
+            function_data.signature.generics(),
+            function_data.signature.params(),
+            &arg_tys,
+            arg_mapping,
+            &subst,
+        )
+        .infer();
+        subst.extend(inferred_subst);
+        self.semantic_function_return_ty_with_resolved_subst(function_ref, self_ty, subst)
+    }
+
+    fn semantic_function_return_ty_with_resolved_subst(
+        &self,
+        function_ref: FunctionRef,
+        self_ty: Option<Ty>,
+        subst: TypeSubst,
+    ) -> Result<Ty, PackageStoreError> {
+        let item_query = self.item_query();
+        let Some(function_data) = item_query.function_data(function_ref)? else {
+            return Ok(Ty::Unknown);
+        };
         let Some(ret_ty) = function_data.signature.ret_ty() else {
             return Ok(Ty::Unit);
         };
@@ -907,7 +930,7 @@ where
             .resolve(ret_ty)
     }
 
-    fn call_ty(&self, callee: Option<ExprId>) -> Result<Ty, PackageStoreError> {
+    fn call_ty(&self, callee: Option<ExprId>, args: &[ExprId]) -> Result<Ty, PackageStoreError> {
         let Some(callee) = callee else {
             return Ok(Ty::Unknown);
         };
@@ -917,8 +940,8 @@ where
             return Ok(callee_data.ty.clone());
         }
 
-        // Ordinary calls use explicit return types only. Generic function inference remains
-        // outside the current intentionally-small Body IR model.
+        // Ordinary calls use declared return types plus a deliberately-small substitution model:
+        // explicit turbofish args and direct argument-to-parameter type inference.
         let mut return_tys = Vec::new();
         match &callee_data.resolution {
             BodyResolution::Declarations(declarations) => {
@@ -928,6 +951,7 @@ where
                         &mut return_tys,
                         self.explicit_callee_generic_args(callee_data),
                         callee_data.scope,
+                        args,
                     )?;
                 }
             }
@@ -947,6 +971,7 @@ where
         return_tys: &mut Vec<Ty>,
         explicit_args: &[ItemGenericArg],
         call_scope: ScopeId,
+        args: &[ExprId],
     ) -> Result<(), PackageStoreError> {
         match declaration {
             DeclarationRef::LocalDef(local_def) => {
@@ -959,6 +984,8 @@ where
                         function_ref,
                         None,
                         explicit_args,
+                        args,
+                        CallArgMapping::FunctionCall,
                         Some(call_scope),
                     )?,
                 );
@@ -970,6 +997,8 @@ where
                         function_ref,
                         None,
                         explicit_args,
+                        args,
+                        CallArgMapping::FunctionCall,
                         Some(call_scope),
                     )?,
                 );

--- a/crates/engine/body-ir/src/resolution/body.rs
+++ b/crates/engine/body-ir/src/resolution/body.rs
@@ -5,7 +5,7 @@
 
 use rg_ir_model::{
     AssocItemId, BindingId, BodyRef, ConstRef, DefId, DefMapRef, ExprId, FunctionRef, ImplRef,
-    ItemOwner, ModuleId, ModuleRef, ScopeId, SemanticItemRef, StaticRef, TypeDefId,
+    ItemOwner, ModuleId, ModuleRef, ScopeId, SemanticItemRef, StaticRef, TraitImplRef, TypeDefId,
     TypePathResolution, identity::DeclarationRef, items::GenericParams,
 };
 use rg_ir_storage::{
@@ -1477,6 +1477,30 @@ where
             }
         }
 
+        // Trait associated const lookup is still receiver-driven: `Type::CONST` first proves that
+        // `Type` has a visible trait impl, then reads the matching const item from that impl or
+        // falls back to the trait declaration. This mirrors trait method lookup without pretending
+        // to be a full trait solver.
+        let mut trait_consts = Vec::new();
+        let mut trait_const_tys = Vec::new();
+        for nominal_ty in prefix_ty.as_nominals() {
+            for (const_ref, ty) in
+                self.semantic_associated_trait_value_items_for_type(nominal_ty, last_segment)?
+            {
+                push_unique(&mut trait_consts, const_ref);
+                push_unique(&mut trait_const_tys, ty);
+            }
+        }
+
+        if !trait_consts.is_empty() {
+            return Ok(Some((
+                BodyResolution::Declarations(
+                    trait_consts.into_iter().map(DeclarationRef::from).collect(),
+                ),
+                unique_ty_or_unknown(trait_const_tys),
+            )));
+        }
+
         // Inherent associated functions are exact candidates. Trait-associated functions are kept
         // deliberately optimistic, following the same "prefer useful candidates over false
         // negatives" policy as dot completion.
@@ -1528,6 +1552,92 @@ where
         )
     }
 
+    fn semantic_associated_trait_value_items_for_type(
+        &self,
+        ty: &NominalTy,
+        name: &str,
+    ) -> Result<Vec<(ConstRef, Ty)>, PackageStoreError> {
+        let mut items = Vec::new();
+
+        self.push_associated_trait_value_items_for_impls(
+            &mut items,
+            self.body_local_items().trait_impls_for_type(ty.def)?,
+            ty,
+            name,
+        )?;
+
+        if ty.def.origin == DefMapRef::Body(self.source.body_ref()) {
+            return Ok(items);
+        }
+
+        let source = self.source;
+        let target_items = TargetItemQuery::new(source, source, self.source.body_ref().target);
+        let semantic_trait_impls = match self.semantic_index {
+            Some(index) => index.trait_impls_for_type(ty.def).to_vec(),
+            None => target_items.trait_impls_for_type(ty.def)?,
+        };
+        self.push_associated_trait_value_items_for_impls(
+            &mut items,
+            semantic_trait_impls,
+            ty,
+            name,
+        )?;
+
+        Ok(items)
+    }
+
+    fn push_associated_trait_value_items_for_impls(
+        &self,
+        items: &mut Vec<(ConstRef, Ty)>,
+        trait_impls: Vec<TraitImplRef>,
+        ty: &NominalTy,
+        name: &str,
+    ) -> Result<(), PackageStoreError> {
+        let item_query = self.item_query();
+        let matcher = self.impl_matcher();
+        for trait_impl in trait_impls {
+            if !matcher
+                .trait_impl_applicability(trait_impl, ty)?
+                .is_applicable()
+            {
+                continue;
+            }
+
+            let Some(impl_data) = item_query.impl_data(trait_impl.impl_ref)? else {
+                continue;
+            };
+
+            // Impl consts are the concrete declaration for `Type::CONST`. When the impl omits the
+            // item, use the trait declaration as a best-effort source for defaulted or incomplete
+            // code; const signatures do not preserve whether a default body was written.
+            let mut candidate = self.associated_const_from_items(
+                trait_impl.impl_ref.origin,
+                &impl_data.items,
+                ty,
+                name,
+            )?;
+            if candidate.is_none()
+                && let Some(trait_data) = item_query.trait_data(trait_impl.trait_ref)?
+            {
+                candidate = self.associated_const_from_items(
+                    trait_impl.trait_ref.origin,
+                    &trait_data.items,
+                    ty,
+                    name,
+                )?;
+            }
+
+            let Some(candidate) = candidate else {
+                continue;
+            };
+            if !items.iter().any(|(existing, _)| *existing == candidate.0) {
+                items.push(candidate);
+            }
+        }
+
+        Ok(())
+    }
+
     fn associated_value_item_for_impls(
         &self,
         impls: Vec<ImplRef>,
@@ -1546,23 +1656,37 @@ where
                 continue;
             }
 
-            for item in &impl_data.items {
-                let AssocItemId::Const(id) = item else {
-                    continue;
-                };
-                let const_ref = ConstRef {
-                    origin: impl_ref.origin,
-                    id: *id,
-                };
-                let Some(const_data) = item_query.const_data(const_ref)? else {
-                    continue;
-                };
-                if const_data.name == name {
-                    return Ok(Some((
-                        const_ref,
-                        self.semantic_const_ty_for_receiver(const_ref, const_data.owner, ty)?,
-                    )));
-                }
+            if let Some(item) =
+                self.associated_const_from_items(impl_ref.origin, &impl_data.items, ty, name)?
+            {
+                return Ok(Some(item));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn associated_const_from_items(
+        &self,
+        origin: DefMapRef,
+        assoc_items: &[AssocItemId],
+        receiver_ty: &NominalTy,
+        name: &str,
+    ) -> Result<Option<(ConstRef, Ty)>, PackageStoreError> {
+        let item_query = self.item_query();
+        for item in assoc_items {
+            let AssocItemId::Const(id) = item else {
+                continue;
+            };
+            let const_ref = ConstRef { origin, id: *id };
+            let Some(const_data) = item_query.const_data(const_ref)? else {
+                continue;
+            };
+            if const_data.name == name {
+                return Ok(Some((
+                    const_ref,
+                    self.semantic_const_ty_for_receiver(const_ref, const_data.owner, receiver_ty)?,
+                )));
             }
         }
 

--- a/crates/engine/body-ir/src/resolution/body.rs
+++ b/crates/engine/body-ir/src/resolution/body.rs
@@ -172,15 +172,15 @@ where
             && binding_data.name.as_deref() == Some("self")
             && let Some(function) = self.body.function_owner()
         {
-            let self_tys = self.type_path_resolver().self_tys_for_function(function)?;
-            if !self_tys.is_empty() {
-                let ty = Ty::self_ty(self_tys.into_iter().map(NominalTy::bare).collect());
-                return Ok(match kind {
-                    BodySelfParamKind::Value => ty,
-                    BodySelfParamKind::Reference { mutability } => Ty::reference(mutability, ty),
-                    BodySelfParamKind::Explicit => Ty::Unknown,
-                });
-            }
+            let self_tys = self
+                .type_path_resolver()
+                .self_nominal_tys_for_function(function)?;
+            let ty = Ty::self_ty(self_tys);
+            return Ok(match kind {
+                BodySelfParamKind::Value => ty,
+                BodySelfParamKind::Reference { mutability } => Ty::reference(mutability, ty),
+                BodySelfParamKind::Explicit => Ty::Unknown,
+            });
         }
 
         Ok(Ty::Unknown)

--- a/crates/engine/body-ir/src/resolution/body.rs
+++ b/crates/engine/body-ir/src/resolution/body.rs
@@ -732,7 +732,9 @@ where
         let ty = &self.body.exprs[inner].ty;
         match op {
             ExprUnaryOp::Not => match ty {
-                Ty::Primitive(primitive) if primitive.is_bool() => Ty::Primitive(*primitive),
+                Ty::Primitive(primitive) if primitive.is_bool() || primitive.is_integral() => {
+                    Ty::Primitive(*primitive)
+                }
                 _ => Ty::Unknown,
             },
             ExprUnaryOp::Neg => match ty {

--- a/crates/engine/body-ir/src/resolution/body.rs
+++ b/crates/engine/body-ir/src/resolution/body.rs
@@ -869,6 +869,7 @@ where
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn semantic_function_return_ty_with_subst_and_call_args(
         &self,
         function_ref: FunctionRef,

--- a/crates/engine/body-ir/src/resolution/body.rs
+++ b/crates/engine/body-ir/src/resolution/body.rs
@@ -6,13 +6,13 @@
 use rg_ir_model::{
     AssocItemId, BindingId, BodyRef, ConstRef, DefId, DefMapRef, ExprId, FunctionRef, ImplRef,
     ItemOwner, ModuleId, ModuleRef, ScopeId, SemanticItemRef, StaticRef, TypeDefId,
-    TypePathResolution, identity::DeclarationRef,
+    TypePathResolution, identity::DeclarationRef, items::GenericParams,
 };
 use rg_ir_storage::{
     DefMapQuery, DefMapSource, ItemLookupIndex, ItemStoreQuery, ItemStoreSource,
     NameResolutionFilter, Path, PathSegment, ResolvePathResult, TargetItemQuery, TypePathContext,
 };
-use rg_item_tree::FieldKey;
+use rg_item_tree::{FieldKey, GenericArg as ItemGenericArg};
 use rg_package_store::PackageStoreError;
 use rg_ty::{
     Autoderef, AutoderefMode, ImplMatcher, ItemPathQuery, NominalTy, PrimitiveTy, Ty, TypeSubst,
@@ -289,9 +289,15 @@ where
             ExprKind::MethodCall {
                 receiver,
                 method_name,
+                generic_args,
                 ..
             } => {
-                let (resolution, ty) = self.resolve_method_call_expr(receiver, &method_name)?;
+                let (resolution, ty) = self.resolve_method_call_expr(
+                    receiver,
+                    &method_name,
+                    &generic_args,
+                    self.body.exprs[expr].scope,
+                )?;
                 let data = &mut self.body.exprs[expr];
                 data.resolution = resolution;
                 data.ty = ty;
@@ -556,6 +562,8 @@ where
         &self,
         receiver: Option<ExprId>,
         method_name: &str,
+        explicit_args: &[ItemGenericArg],
+        call_scope: ScopeId,
     ) -> Result<(BodyResolution, Ty), PackageStoreError> {
         let Some(receiver) = receiver else {
             return Ok((BodyResolution::Unknown, Ty::Unknown));
@@ -609,7 +617,12 @@ where
                     push_unique(&mut functions, function_ref);
                     push_unique(
                         &mut return_tys,
-                        self.semantic_function_return_ty(function_ref, Some(nominal_ty))?,
+                        self.semantic_function_return_ty_with_call_args(
+                            function_ref,
+                            Some(nominal_ty),
+                            explicit_args,
+                            Some(call_scope),
+                        )?,
                     );
                 }
             }
@@ -633,10 +646,12 @@ where
                 push_unique(&mut functions, function_ref);
                 push_unique(
                     &mut return_tys,
-                    self.semantic_function_return_ty_with_subst(
+                    self.semantic_function_return_ty_with_subst_and_call_args(
                         function_ref,
                         Some(structural.receiver_ty().clone()),
                         structural.subst().clone(),
+                        explicit_args,
+                        Some(call_scope),
                     )?,
                 );
             }
@@ -800,15 +815,17 @@ where
             .unwrap_or_else(TypeSubst::new))
     }
 
-    fn semantic_function_return_ty(
+    fn semantic_function_return_ty_with_call_args(
         &self,
         function_ref: FunctionRef,
         receiver_ty: Option<&NominalTy>,
+        explicit_args: &[ItemGenericArg],
+        call_scope: Option<ScopeId>,
     ) -> Result<Ty, PackageStoreError> {
         let Some(function_data) = self.item_query().function_data(function_ref)? else {
             return Ok(Ty::Unknown);
         };
-        let subst = receiver_ty
+        let mut subst = receiver_ty
             .map(|ty| {
                 // Receiver type args and impl self args both contribute substitutions. For
                 // `impl<U> Wrapper<U>`, this maps `U` to the known receiver argument.
@@ -822,6 +839,13 @@ where
             })
             .transpose()?
             .unwrap_or_default();
+        if let Some(call_scope) = call_scope {
+            subst.extend(self.explicit_function_subst(
+                function_data.signature.generics(),
+                explicit_args,
+                call_scope,
+            )?);
+        }
         self.semantic_function_return_ty_with_subst(
             function_ref,
             receiver_ty.cloned().map(|ty| Ty::nominal(vec![ty])),
@@ -835,10 +859,34 @@ where
         self_ty: Option<Ty>,
         subst: TypeSubst,
     ) -> Result<Ty, PackageStoreError> {
+        self.semantic_function_return_ty_with_subst_and_call_args(
+            function_ref,
+            self_ty,
+            subst,
+            &[],
+            None,
+        )
+    }
+
+    fn semantic_function_return_ty_with_subst_and_call_args(
+        &self,
+        function_ref: FunctionRef,
+        self_ty: Option<Ty>,
+        mut subst: TypeSubst,
+        explicit_args: &[ItemGenericArg],
+        call_scope: Option<ScopeId>,
+    ) -> Result<Ty, PackageStoreError> {
         let item_query = self.item_query();
         let Some(function_data) = item_query.function_data(function_ref)? else {
             return Ok(Ty::Unknown);
         };
+        if let Some(call_scope) = call_scope {
+            subst.extend(self.explicit_function_subst(
+                function_data.signature.generics(),
+                explicit_args,
+                call_scope,
+            )?);
+        }
         let Some(ret_ty) = function_data.signature.ret_ty() else {
             return Ok(Ty::Unit);
         };
@@ -875,7 +923,12 @@ where
         match &callee_data.resolution {
             BodyResolution::Declarations(declarations) => {
                 for declaration in declarations {
-                    self.push_return_ty_for_declaration(*declaration, &mut return_tys)?;
+                    self.push_return_ty_for_declaration(
+                        *declaration,
+                        &mut return_tys,
+                        self.explicit_callee_generic_args(callee_data),
+                        callee_data.scope,
+                    )?;
                 }
             }
             BodyResolution::Binding(_) | BodyResolution::Unknown => {}
@@ -892,6 +945,8 @@ where
         &self,
         declaration: DeclarationRef,
         return_tys: &mut Vec<Ty>,
+        explicit_args: &[ItemGenericArg],
+        call_scope: ScopeId,
     ) -> Result<(), PackageStoreError> {
         match declaration {
             DeclarationRef::LocalDef(local_def) => {
@@ -900,13 +955,23 @@ where
                 };
                 push_unique(
                     return_tys,
-                    self.semantic_function_return_ty(function_ref, None)?,
+                    self.semantic_function_return_ty_with_call_args(
+                        function_ref,
+                        None,
+                        explicit_args,
+                        Some(call_scope),
+                    )?,
                 );
             }
             DeclarationRef::Item(SemanticItemRef::Function(function_ref)) => {
                 push_unique(
                     return_tys,
-                    self.semantic_function_return_ty(function_ref, None)?,
+                    self.semantic_function_return_ty_with_call_args(
+                        function_ref,
+                        None,
+                        explicit_args,
+                        Some(call_scope),
+                    )?,
                 );
             }
             DeclarationRef::Module(_)
@@ -924,6 +989,43 @@ where
         }
 
         Ok(())
+    }
+
+    fn explicit_callee_generic_args<'expr>(
+        &self,
+        callee_data: &'expr crate::ir::expr::ExprData,
+    ) -> &'expr [ItemGenericArg] {
+        // A normal call expression has a callee expression, so `make::<T>()` and
+        // `Type::build::<T>()` carry call generics on the final callee path segment. Method calls
+        // are a different ExprKind and store their method-name generics directly.
+        match &callee_data.kind {
+            ExprKind::Path { path } => path.last_segment_angle_args().unwrap_or(&[]),
+            _ => &[],
+        }
+    }
+
+    fn explicit_function_subst(
+        &self,
+        generics: Option<&GenericParams>,
+        explicit_args: &[ItemGenericArg],
+        scope: ScopeId,
+    ) -> Result<TypeSubst, PackageStoreError> {
+        let Some(generics) = generics else {
+            return Ok(TypeSubst::new());
+        };
+        if explicit_args.is_empty() {
+            return Ok(TypeSubst::new());
+        }
+
+        // Function turbofish arguments are supplied at the call site, so names inside them must
+        // resolve from the body scope where the call was written.
+        let type_resolver = self.type_path_resolver();
+        let arg_resolver = type_resolver.type_ref(TypeRefUseSite::Scope(scope));
+        let generic_args = explicit_args
+            .iter()
+            .map(|arg| arg_resolver.generic_arg(arg))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(TypeSubst::from_generics(generics, &generic_args))
     }
 
     fn function_ref_for_def(&self, def: DefId) -> Result<Option<FunctionRef>, PackageStoreError> {

--- a/crates/engine/body-ir/src/resolution/pat.rs
+++ b/crates/engine/body-ir/src/resolution/pat.rs
@@ -6,7 +6,8 @@
 
 use rg_ir_model::{BindingId, ExprId, PatId, ScopeId, StmtId, TypeDefId};
 use rg_ir_storage::{
-    DefMapSource, ItemStoreQuery, ItemStoreSource, Path, PathSegment, TargetItemQuery,
+    DefMapSource, ItemLookupIndex, ItemStoreQuery, ItemStoreSource, Path, PathSegment,
+    TargetItemQuery,
 };
 use rg_item_tree::{FieldItem, FieldKey, FieldList};
 use rg_package_store::PackageStoreError;
@@ -25,6 +26,7 @@ use super::{BodyQuerySource, TypeRefUseSite, push_unique, type_path::BodyTypePat
 
 pub(super) struct PatternTypePropagator<'query, D, I> {
     source: BodyQuerySource<'query, D, I>,
+    semantic_index: &'query ItemLookupIndex,
 }
 
 impl<'query, D, I> PatternTypePropagator<'query, D, I>
@@ -32,8 +34,14 @@ where
     D: DefMapSource<Error = PackageStoreError> + Copy,
     I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
 {
-    pub(super) fn new(source: BodyQuerySource<'query, D, I>) -> Self {
-        Self { source }
+    pub(super) fn new(
+        source: BodyQuerySource<'query, D, I>,
+        semantic_index: &'query ItemLookupIndex,
+    ) -> Self {
+        Self {
+            source,
+            semantic_index,
+        }
     }
 
     pub(super) fn propagate(&self) -> Result<Vec<(BindingId, Ty)>, PackageStoreError> {
@@ -56,6 +64,7 @@ where
             self.propagate_pat(pat, &expected_ty, &mut updates)?;
         }
 
+        let iteration_items = self.iteration_items();
         for expr_idx in 0..self.source.body().exprs.len() {
             let expr = ExprId(expr_idx);
             match self.source.body().exprs[expr].kind.clone() {
@@ -85,9 +94,7 @@ where
                     ..
                 } => {
                     let iterable_ty = &self.source.body().exprs[iterable].ty;
-                    let item_ty = self
-                        .iteration_items()
-                        .into_iterator_item_for_ty(iterable_ty)?;
+                    let item_ty = iteration_items.into_iterator_item_for_ty(iterable_ty)?;
                     self.propagate_pat(pat, &item_ty, &mut updates)?;
                 }
                 ExprKind::Path { .. }
@@ -141,7 +148,7 @@ where
         let source = self.source;
         let item_paths = ItemPathQuery::new(source, source);
         let target_items = TargetItemQuery::new(source, source, self.source.body_ref().target);
-        IterationItemResolver::new(item_paths, target_items)
+        IterationItemResolver::with_index(item_paths, target_items, self.semantic_index)
     }
 
     fn expected_ty_for_let(

--- a/crates/engine/body-ir/src/resolution/pat.rs
+++ b/crates/engine/body-ir/src/resolution/pat.rs
@@ -172,6 +172,8 @@ where
             PatKind::Record { path, fields, .. } => {
                 self.propagate_record_variant(path.as_ref(), &fields, expected_ty, updates)
             }
+            PatKind::Tuple { fields } => self.propagate_tuple_pat(&fields, expected_ty, updates),
+            PatKind::Slice { fields } => self.propagate_slice_pat(&fields, expected_ty, updates),
             PatKind::Or { pats } => {
                 for pat in pats {
                     self.propagate_pat(pat, expected_ty, updates)?;
@@ -181,9 +183,7 @@ where
             PatKind::Ref { pat, .. } | PatKind::Box { pat } => {
                 self.propagate_pat(pat, expected_ty, updates)
             }
-            PatKind::Tuple { .. }
-            | PatKind::Slice { .. }
-            | PatKind::Path { .. }
+            PatKind::Path { .. }
             | PatKind::Rest
             | PatKind::Literal { .. }
             | PatKind::Range { .. }
@@ -191,6 +191,50 @@ where
             | PatKind::Wildcard
             | PatKind::Unsupported => Ok(()),
         }
+    }
+
+    fn propagate_tuple_pat(
+        &self,
+        fields: &[PatId],
+        expected_ty: &Ty,
+        updates: &mut Vec<(BindingId, Ty)>,
+    ) -> Result<(), PackageStoreError> {
+        let Ty::Tuple(field_tys) = expected_ty else {
+            return Ok(());
+        };
+        if fields.len() != field_tys.len() {
+            return Ok(());
+        }
+
+        for (field_pat, field_ty) in fields.iter().zip(field_tys) {
+            self.propagate_pat(*field_pat, field_ty, updates)?;
+        }
+        Ok(())
+    }
+
+    fn propagate_slice_pat(
+        &self,
+        fields: &[PatId],
+        expected_ty: &Ty,
+        updates: &mut Vec<(BindingId, Ty)>,
+    ) -> Result<(), PackageStoreError> {
+        let element_ty = match expected_ty {
+            Ty::Array { inner, .. } | Ty::Slice(inner) => inner.as_ref(),
+            _ => return Ok(()),
+        };
+
+        for field in fields {
+            if self
+                .source
+                .body()
+                .pat(*field)
+                .is_some_and(|pat| matches!(&pat.kind, PatKind::Rest))
+            {
+                continue;
+            }
+            self.propagate_pat(*field, element_ty, updates)?;
+        }
+        Ok(())
     }
 
     fn propagate_tuple_variant(

--- a/crates/engine/body-ir/src/resolution/pat.rs
+++ b/crates/engine/body-ir/src/resolution/pat.rs
@@ -5,10 +5,14 @@
 //! not infer the scrutinee type by themselves.
 
 use rg_ir_model::{BindingId, ExprId, PatId, ScopeId, StmtId, TypeDefId};
-use rg_ir_storage::{DefMapSource, ItemStoreQuery, ItemStoreSource, Path, PathSegment};
+use rg_ir_storage::{
+    DefMapSource, ItemStoreQuery, ItemStoreSource, Path, PathSegment, TargetItemQuery,
+};
 use rg_item_tree::{FieldItem, FieldKey, FieldList};
 use rg_package_store::PackageStoreError;
-use rg_ty::{NominalTy, ReferencePeelingCandidates, Ty, TypeSubst};
+use rg_ty::{
+    ItemPathQuery, IterationItemResolver, NominalTy, ReferencePeelingCandidates, Ty, TypeSubst,
+};
 
 use crate::{
     ir::expr::ExprKind,
@@ -75,6 +79,17 @@ where
                     let expected_ty = self.expected_ty_for_let(scope, None, initializer)?;
                     self.propagate_pat(pat, &expected_ty, &mut updates)?;
                 }
+                ExprKind::For {
+                    pat: Some(pat),
+                    iterable: Some(iterable),
+                    ..
+                } => {
+                    let iterable_ty = &self.source.body().exprs[iterable].ty;
+                    let item_ty = self
+                        .iteration_items()
+                        .into_iterator_item_for_ty(iterable_ty)?;
+                    self.propagate_pat(pat, &item_ty, &mut updates)?;
+                }
                 ExprKind::Path { .. }
                 | ExprKind::Call { .. }
                 | ExprKind::Tuple { .. }
@@ -117,6 +132,16 @@ where
 
     fn type_path_resolver(&self) -> BodyTypePathResolver<'query, D, I> {
         BodyTypePathResolver::new(self.source)
+    }
+
+    fn iteration_items(
+        &self,
+    ) -> IterationItemResolver<'query, BodyQuerySource<'query, D, I>, BodyQuerySource<'query, D, I>>
+    {
+        let source = self.source;
+        let item_paths = ItemPathQuery::new(source, source);
+        let target_items = TargetItemQuery::new(source, source, self.source.body_ref().target);
+        IterationItemResolver::new(item_paths, target_items)
     }
 
     fn expected_ty_for_let(

--- a/crates/engine/body-ir/src/resolution/pat_binding.rs
+++ b/crates/engine/body-ir/src/resolution/pat_binding.rs
@@ -754,15 +754,15 @@ where
             && binding_data.name.as_deref() == Some("self")
             && let Some(function) = self.body.function_owner()
         {
-            let self_tys = self.type_path_resolver().self_tys_for_function(function)?;
-            if !self_tys.is_empty() {
-                let ty = Ty::self_ty(self_tys.into_iter().map(NominalTy::bare).collect());
-                return Ok(match kind {
-                    BodySelfParamKind::Value => ty,
-                    BodySelfParamKind::Reference { mutability } => Ty::reference(mutability, ty),
-                    BodySelfParamKind::Explicit => Ty::Unknown,
-                });
-            }
+            let self_tys = self
+                .type_path_resolver()
+                .self_nominal_tys_for_function(function)?;
+            let ty = Ty::self_ty(self_tys);
+            return Ok(match kind {
+                BodySelfParamKind::Value => ty,
+                BodySelfParamKind::Reference { mutability } => Ty::reference(mutability, ty),
+                BodySelfParamKind::Explicit => Ty::Unknown,
+            });
         }
 
         Ok(Ty::Unknown)

--- a/crates/engine/body-ir/src/resolution/receiver_items.rs
+++ b/crates/engine/body-ir/src/resolution/receiver_items.rs
@@ -186,7 +186,11 @@ where
         // Structural inherent impls model language/core-provided builtins such as `impl<T> [T]`.
         // Body-local impl lookup remains nominal-only because block-local impls are useful for
         // local structs, not for defining new inherent methods on builtin shaped types.
-        for impl_ref in target_items.inherent_impls()? {
+        let impl_refs = match self.semantic_index {
+            Some(index) => index.structural_inherent_impls().to_vec(),
+            None => target_items.inherent_impls()?,
+        };
+        for impl_ref in impl_refs {
             self.push_structural_inherent_functions_for_impl(
                 &item_query,
                 &matcher,
@@ -249,10 +253,7 @@ where
     }
 
     fn receiver_ty_uses_structural_impl_lookup(ty: &Ty) -> bool {
-        matches!(
-            ty,
-            Ty::Tuple(_) | Ty::Array { .. } | Ty::Slice(_) | Ty::Reference { .. }
-        )
+        matches!(ty, Ty::Tuple(_) | Ty::Array { .. } | Ty::Slice(_))
     }
 
     fn body_inherent_functions(

--- a/crates/engine/body-ir/src/resolution/receiver_items.rs
+++ b/crates/engine/body-ir/src/resolution/receiver_items.rs
@@ -4,14 +4,14 @@
 //! overlay. Method lookup should not care which layer produced an impl candidate after visibility
 //! has been decided, so this query merges both layers before returning ref-level candidates.
 
-use rg_ir_model::FunctionRef;
+use rg_ir_model::{AssocItemId, FunctionRef, ImplRef};
 use rg_ir_storage::{
     DefMapSource, ItemLookupIndex, ItemStoreQuery, ItemStoreSource, TargetItemQuery,
 };
 use rg_package_store::PackageStoreError;
 use rg_ty::{
     Autoderef, AutoderefMode, ImplMatcher, ItemPathQuery, MemberMethodCandidateRef,
-    MemberMethodOrigin, NominalTy, Ty,
+    MemberMethodOrigin, NominalTy, Ty, TypeSubst,
 };
 
 use super::{BodyLocalItemQuery, BodyQuerySource, push_unique};
@@ -19,6 +19,31 @@ use super::{BodyLocalItemQuery, BodyQuerySource, push_unique};
 pub(crate) struct BodyReceiverFunctionQuery<'query, D, I> {
     source: BodyQuerySource<'query, D, I>,
     semantic_index: Option<&'query ItemLookupIndex>,
+}
+
+/// Inherent function found by matching an impl whose `Self` type is structural.
+///
+/// The candidate carries the adjusted receiver type and substitutions because structural impls
+/// cannot recover that context from a nominal type definition later.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct BodyStructuralReceiverFunctionCandidate {
+    function: FunctionRef,
+    receiver_ty: Ty,
+    subst: TypeSubst,
+}
+
+impl BodyStructuralReceiverFunctionCandidate {
+    pub(super) fn function(&self) -> FunctionRef {
+        self.function
+    }
+
+    pub(super) fn receiver_ty(&self) -> &Ty {
+        &self.receiver_ty
+    }
+
+    pub(super) fn subst(&self) -> &TypeSubst {
+        &self.subst
+    }
 }
 
 impl<'query, D, I> BodyReceiverFunctionQuery<'query, D, I>
@@ -55,6 +80,12 @@ where
                 for method in self.function_candidates_for_receiver(receiver_ty, None)? {
                     Self::push_candidate(&mut candidates, method);
                 }
+            }
+            for method in self.structural_function_candidates_for_receiver(candidate.ty(), None)? {
+                Self::push_candidate(
+                    &mut candidates,
+                    MemberMethodCandidateRef::inherent(method.function()),
+                );
             }
         }
 
@@ -134,6 +165,96 @@ where
         Ok(candidates)
     }
 
+    pub(super) fn structural_function_candidates_for_receiver(
+        &self,
+        receiver_ty: &Ty,
+        method_name: Option<&str>,
+    ) -> Result<Vec<BodyStructuralReceiverFunctionCandidate>, PackageStoreError> {
+        // Nominal receivers are handled by the indexed path. Scanning visible impls is reserved
+        // for shaped builtin types such as `[T]`, where there is no `TypeDefRef` key to query.
+        if !Self::receiver_ty_uses_structural_impl_lookup(receiver_ty) {
+            return Ok(Vec::new());
+        }
+
+        let source = self.source;
+        let item_paths = ItemPathQuery::new(source, source);
+        let target_items = TargetItemQuery::new(source, source, self.source.body_ref().target);
+        let matcher = ImplMatcher::new(item_paths, target_items.clone());
+        let item_query = ItemStoreQuery::new(source);
+        let mut candidates = Vec::new();
+
+        // Structural inherent impls model language/core-provided builtins such as `impl<T> [T]`.
+        // Body-local impl lookup remains nominal-only because block-local impls are useful for
+        // local structs, not for defining new inherent methods on builtin shaped types.
+        for impl_ref in target_items.inherent_impls()? {
+            self.push_structural_inherent_functions_for_impl(
+                &item_query,
+                &matcher,
+                impl_ref,
+                receiver_ty,
+                method_name,
+                &mut candidates,
+            )?;
+        }
+
+        Ok(candidates)
+    }
+
+    fn push_structural_inherent_functions_for_impl(
+        &self,
+        item_query: &ItemStoreQuery<'query, BodyQuerySource<'query, D, I>>,
+        matcher: &ImplMatcher<'query, BodyQuerySource<'query, D, I>, BodyQuerySource<'query, D, I>>,
+        impl_ref: ImplRef,
+        receiver_ty: &Ty,
+        method_name: Option<&str>,
+        candidates: &mut Vec<BodyStructuralReceiverFunctionCandidate>,
+    ) -> Result<(), PackageStoreError> {
+        let Some(impl_data) = item_query.impl_data(impl_ref)? else {
+            return Ok(());
+        };
+        let Some(subst) =
+            matcher.structural_inherent_impl_subst(impl_ref, impl_data, receiver_ty)?
+        else {
+            return Ok(());
+        };
+
+        for item in &impl_data.items {
+            let AssocItemId::Function(id) = item else {
+                continue;
+            };
+            let function = FunctionRef {
+                origin: impl_ref.origin,
+                id: *id,
+            };
+            let Some(function_data) = item_query.function_data(function)? else {
+                continue;
+            };
+            if !function_data.has_self_receiver() {
+                continue;
+            }
+            if method_name.is_some_and(|name| function_data.name != name) {
+                continue;
+            }
+            Self::push_structural_candidate(
+                candidates,
+                BodyStructuralReceiverFunctionCandidate {
+                    function,
+                    receiver_ty: receiver_ty.clone(),
+                    subst: subst.clone(),
+                },
+            );
+        }
+
+        Ok(())
+    }
+
+    fn receiver_ty_uses_structural_impl_lookup(ty: &Ty) -> bool {
+        matches!(
+            ty,
+            Ty::Tuple(_) | Ty::Array { .. } | Ty::Slice(_) | Ty::Reference { .. }
+        )
+    }
+
     fn body_inherent_functions(
         &self,
         body_items: &BodyLocalItemQuery<'query, D, I>,
@@ -204,6 +325,17 @@ where
         };
 
         *existing = Self::merge_candidates(*existing, candidate);
+    }
+
+    fn push_structural_candidate(
+        candidates: &mut Vec<BodyStructuralReceiverFunctionCandidate>,
+        candidate: BodyStructuralReceiverFunctionCandidate,
+    ) {
+        if !candidates.iter().any(|existing| {
+            existing.function == candidate.function && existing.subst == candidate.subst
+        }) {
+            candidates.push(candidate);
+        }
     }
 
     fn merge_candidates(

--- a/crates/engine/body-ir/src/resolution/type_path.rs
+++ b/crates/engine/body-ir/src/resolution/type_path.rs
@@ -5,7 +5,7 @@
 
 use rg_ir_model::{
     AssocItemId, DefId, DefMapRef, FunctionRef, ImplRef, ItemOwner, ModuleId, ModuleRef, ScopeId,
-    SemanticItemRef, TypeAliasRef, TypeDefRef, TypePathResolution,
+    SemanticItemRef, TypeAliasRef, TypePathResolution,
 };
 use rg_ir_storage::{
     DefMapQuery, DefMapSource, ItemStoreQuery, ItemStoreSource, NameResolutionFilter, Path,
@@ -110,24 +110,53 @@ where
         )
     }
 
-    pub(super) fn self_tys_for_function(
+    pub(super) fn self_nominal_tys_for_function(
         &self,
         function: FunctionRef,
-    ) -> Result<Vec<TypeDefRef>, PackageStoreError> {
-        // `self` parameters and explicit `Self` annotations need the enclosing impl owner, not
-        // just the owner module. Semantic IR owns that function-to-owner mapping.
-        let Some(impl_ref) = self
-            .context_for_function(function, self.source.body().owner_module)?
-            .impl_ref
-        else {
+    ) -> Result<Vec<NominalTy>, PackageStoreError> {
+        let context = self.context_for_function(function, self.source.body().owner_module)?;
+        self.self_nominal_tys_for_context(context)
+    }
+
+    pub(super) fn self_nominal_tys_for_context(
+        &self,
+        context: TypePathContext,
+    ) -> Result<Vec<NominalTy>, PackageStoreError> {
+        let Some(impl_ref) = context.impl_ref else {
+            return Ok(Vec::new());
+        };
+        let item_query = self.item_query();
+        let Some(impl_data) = item_query.impl_data(impl_ref)? else {
             return Ok(Vec::new());
         };
 
-        Ok(self
-            .item_query()
-            .impl_data(impl_ref)?
-            .map(|impl_data| impl_data.resolved_self_tys.clone())
-            .unwrap_or_default())
+        let source = self.source;
+        let item_paths = ItemPathQuery::new(source, source);
+        let resolved = item_paths.resolve_type_ref(
+            &impl_data.self_ty,
+            context,
+            Ty::Unknown,
+            &TypeSubst::new(),
+        )?;
+
+        let mut self_tys = Vec::new();
+        for ty in resolved.as_nominals() {
+            if impl_data.resolved_self_tys.contains(&ty.def) {
+                push_unique(&mut self_tys, ty.clone());
+            }
+        }
+
+        if self_tys.is_empty() {
+            self_tys.extend(
+                impl_data
+                    .resolved_self_tys
+                    .iter()
+                    .copied()
+                    .map(NominalTy::bare),
+            );
+        }
+
+        Ok(self_tys)
     }
 
     pub(super) fn context_for_function(

--- a/crates/engine/body-ir/src/resolution/type_ref.rs
+++ b/crates/engine/body-ir/src/resolution/type_ref.rs
@@ -195,6 +195,14 @@ where
             )),
             TypeRef::Unknown(_) | TypeRef::Infer => Ok(Ty::Unknown),
             TypeRef::Tuple(types) if types.is_empty() => Ok(Ty::Unit),
+            TypeRef::Tuple(types) => Ok(Ty::tuple(
+                types
+                    .iter()
+                    .map(|ty| self.resolve(ty))
+                    .collect::<Result<_, _>>()?,
+            )),
+            TypeRef::Slice(inner) => Ok(Ty::slice(self.resolve(inner)?)),
+            TypeRef::Array { inner, len } => Ok(Ty::array(self.resolve(inner)?, len.clone())),
             _ => Ok(Ty::syntax(ty.clone())),
         }
     }

--- a/crates/engine/body-ir/src/resolution/type_ref.rs
+++ b/crates/engine/body-ir/src/resolution/type_ref.rs
@@ -132,6 +132,11 @@ where
         if let Some(ty) = self.subst_for_single_segment(&path) {
             return Ok(ty);
         }
+        if path.is_self_type() {
+            let context = self.resolver.context_for_body_owner()?;
+            let self_tys = self.resolver.self_nominal_tys_for_context(context)?;
+            return Ok(Ty::self_ty(self_tys));
+        }
 
         let args = self.generic_args_from_type_path(type_path)?;
         if let Some(ty) = self.ty_from_local_associated_type_path(type_path, &path, scope, &args)? {
@@ -154,6 +159,10 @@ where
         let path = Path::from_type_path(type_path);
         if let Some(ty) = self.subst_for_single_segment(&path) {
             return Ok(ty);
+        }
+        if path.is_self_type() {
+            let self_tys = self.resolver.self_nominal_tys_for_context(context)?;
+            return Ok(Ty::self_ty(self_tys));
         }
 
         let args = self.generic_args_from_type_path(type_path)?;

--- a/crates/engine/body-ir/src/resolution/type_ref.rs
+++ b/crates/engine/body-ir/src/resolution/type_ref.rs
@@ -322,7 +322,10 @@ where
         Ok(generic_args)
     }
 
-    fn generic_arg(&self, arg: &ItemGenericArg) -> Result<GenericArg, PackageStoreError> {
+    pub(crate) fn generic_arg(
+        &self,
+        arg: &ItemGenericArg,
+    ) -> Result<GenericArg, PackageStoreError> {
         match arg {
             ItemGenericArg::Type(ty) => Ok(GenericArg::Type(Box::new(self.resolve(ty)?))),
             ItemGenericArg::Lifetime(lifetime) => Ok(GenericArg::Lifetime(lifetime.clone())),

--- a/crates/engine/body-ir/src/resolution/type_ref.rs
+++ b/crates/engine/body-ir/src/resolution/type_ref.rs
@@ -319,6 +319,13 @@ where
             ItemGenericArg::Type(ty) => Ok(GenericArg::Type(Box::new(self.resolve(ty)?))),
             ItemGenericArg::Lifetime(lifetime) => Ok(GenericArg::Lifetime(lifetime.clone())),
             ItemGenericArg::Const(value) => Ok(GenericArg::Const(value.clone())),
+            ItemGenericArg::FnTraitArgs { params, ret } => Ok(GenericArg::FnTraitArgs {
+                params: params
+                    .iter()
+                    .map(|ty| self.resolve(ty))
+                    .collect::<Result<_, _>>()?,
+                ret: Box::new(self.resolve(ret)?),
+            }),
             ItemGenericArg::AssocType { name, ty } => Ok(GenericArg::AssocType {
                 name: name.clone(),
                 ty: ty

--- a/crates/engine/body-ir/src/tests/body_local_items.rs
+++ b/crates/engine/body-ir/src/tests/body_local_items.rs
@@ -1137,6 +1137,69 @@ pub fn use_it() {
 }
 
 #[test]
+fn resolves_body_local_trait_associated_consts() {
+    check_project_body_ir(
+        r#"
+//- /Cargo.toml
+[package]
+name = "body_local_trait_assoc_const_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct GlobalId;
+
+pub fn use_it() {
+    struct Local;
+
+    trait Tagged {
+        const DEFAULT: GlobalId;
+    }
+
+    impl Tagged for Local {
+        const DEFAULT: GlobalId = GlobalId;
+    }
+
+    let default = Local::DEFAULT;
+}
+"#,
+        expect![[r#"
+            package body_local_trait_assoc_const_fixture
+
+            body_local_trait_assoc_const_fixture [lib]
+            body b0 fn body_local_trait_assoc_const_fixture[lib]::crate::use_it @ 3:1-15:2
+            scopes
+            - s0 parent <none>: <none>
+            - s1 parent s0: v0; source_items i0, i2, i4
+            source_items
+            - i0 struct Local @ 4:5-4:18
+            - i1 const DEFAULT @ 7:9-7:33
+            - i2 trait Tagged @ 6:5-8:6
+            - i3 const DEFAULT @ 11:9-11:44
+            - i4 impl <unnamed> @ 10:5-12:6
+            bindings
+            - v0 let default `default` => nominal struct body_local_trait_assoc_const_fixture[lib]::crate::GlobalId @ 14:9-14:16
+            body
+            expr e1 block s1 => () @ 3:17-15:2
+              stmt s0 source_item i0 @ 4:5-4:18
+              stmt s1 source_item i2 @ 6:5-8:6
+              stmt s2 source_item i4 @ 10:5-12:6
+              stmt s3 let v0 @ 14:5-14:34
+                initializer
+                  expr e0 path Local::DEFAULT -> const impl Tagged for Local::DEFAULT => nominal struct body_local_trait_assoc_const_fixture[lib]::crate::GlobalId @ 14:19-14:33
+
+
+            body b1 const impl Tagged for Local::DEFAULT @ 11:9-11:44
+            scopes
+            - s0 parent <none>: <none>
+            bindings
+            body
+            expr e0 path GlobalId -> item struct body_local_trait_assoc_const_fixture[lib]::crate::GlobalId => nominal struct body_local_trait_assoc_const_fixture[lib]::crate::GlobalId @ 11:35-11:43
+        "#]],
+    );
+}
+
+#[test]
 fn lowers_body_local_associated_function_and_const_bodies() {
     check_project_body_ir(
         r#"

--- a/crates/engine/body-ir/src/tests/control_flow.rs
+++ b/crates/engine/body-ir/src/tests/control_flow.rs
@@ -265,6 +265,123 @@ pub fn walk(input: Maybe, items: Items) {
 }
 
 #[test]
+fn propagates_for_loop_items_from_into_iterator() {
+    check_project_body_ir(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["core", "app"]
+resolver = "3"
+
+//- /core/Cargo.toml
+[package]
+name = "fake_core"
+version = "0.1.0"
+edition = "2024"
+
+//- /core/src/lib.rs
+pub mod iter {
+    pub trait IntoIterator {
+        type Item;
+    }
+}
+
+impl<'a, T> iter::IntoIterator for &'a [T] {
+    type Item = &'a T;
+}
+
+impl<T, const N: usize> iter::IntoIterator for [T; N] {
+    type Item = T;
+}
+
+//- /app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+core = { package = "fake_core", path = "../core" }
+
+//- /app/src/lib.rs
+pub struct Package;
+pub struct UserId;
+
+pub fn use_it(packages: &[Package], array: [Package; 3], pairs: [(Package, UserId); 2]) {
+    for borrowed in packages {
+        borrowed;
+    }
+
+    for owned in array {
+        owned;
+    }
+
+    for (package, user_id) in pairs {
+        package;
+        user_id;
+    }
+}
+"#,
+        expect![[r#"
+            package app
+
+            app [lib]
+            body b0 fn app[lib]::crate::use_it @ 4:1-17:2
+            scopes
+            - s0 parent <none>: v0, v1, v2
+            - s1 parent s0: <none>
+            - s2 parent s1: v3
+            - s3 parent s2: <none>
+            - s4 parent s1: v4
+            - s5 parent s4: <none>
+            - s6 parent s1: v5, v6
+            - s7 parent s6: <none>
+            bindings
+            - v0 param packages `packages`: &[Package] => &[nominal struct app[lib]::crate::Package] @ 4:15-4:23
+            - v1 param array `array`: [Package; 3] => [nominal struct app[lib]::crate::Package; 3] @ 4:37-4:42
+            - v2 param pairs `pairs`: [(Package, UserId); 2] => [(nominal struct app[lib]::crate::Package, nominal struct app[lib]::crate::UserId); 2] @ 4:58-4:63
+            - v3 let borrowed `borrowed` => &nominal struct app[lib]::crate::Package @ 5:9-5:17
+            - v4 let owned `owned` => nominal struct app[lib]::crate::Package @ 9:9-9:14
+            - v5 let package `package` => nominal struct app[lib]::crate::Package @ 13:10-13:17
+            - v6 let user_id `user_id` => nominal struct app[lib]::crate::UserId @ 13:19-13:26
+            body
+            expr e13 block s1 => () @ 4:89-17:2
+              stmt s1 expr @ 5:5-7:6
+                expr e3 for s2 v3 => () @ 5:5-7:6
+                  iterable
+                    expr e0 path packages -> local v0 => &[nominal struct app[lib]::crate::Package] @ 5:21-5:29
+                  body
+                    expr e2 block s3 => () @ 5:30-7:6
+                      stmt s0 expr; @ 6:9-6:18
+                        expr e1 path borrowed -> local v3 => &nominal struct app[lib]::crate::Package @ 6:9-6:17
+              stmt s3 expr @ 9:5-11:6
+                expr e7 for s4 v4 => () @ 9:5-11:6
+                  iterable
+                    expr e4 path array -> local v1 => [nominal struct app[lib]::crate::Package; 3] @ 9:18-9:23
+                  body
+                    expr e6 block s5 => () @ 9:24-11:6
+                      stmt s2 expr; @ 10:9-10:15
+                        expr e5 path owned -> local v4 => nominal struct app[lib]::crate::Package @ 10:9-10:14
+              tail
+                expr e12 for s6 v5, v6 => () @ 13:5-16:6
+                  iterable
+                    expr e8 path pairs -> local v2 => [(nominal struct app[lib]::crate::Package, nominal struct app[lib]::crate::UserId); 2] @ 13:31-13:36
+                  body
+                    expr e11 block s7 => () @ 13:37-16:6
+                      stmt s4 expr; @ 14:9-14:17
+                        expr e9 path package -> local v5 => nominal struct app[lib]::crate::Package @ 14:9-14:16
+                      stmt s5 expr; @ 15:9-15:17
+                        expr e10 path user_id -> local v6 => nominal struct app[lib]::crate::UserId @ 15:9-15:16
+
+
+            package fake_core
+
+            fake_core [lib]
+        "#]],
+    );
+}
+
+#[test]
 fn lowers_labeled_block_control_flow() {
     check_project_body_ir(
         r#"

--- a/crates/engine/body-ir/src/tests/control_flow.rs
+++ b/crates/engine/body-ir/src/tests/control_flow.rs
@@ -54,7 +54,7 @@ pub fn choose(input: Maybe, fallback: UserId) -> UserId {
               tail
                 expr e9 if => nominal struct body_if_let_fixture[lib]::crate::UserId @ 15:5-19:6
                   condition
-                    expr e4 binary && => <unknown> @ 15:8-15:52
+                    expr e4 binary && => bool @ 15:8-15:52
                       lhs
                         expr e1 let s2 v2 => <unknown> @ 15:8-15:35
                           initializer
@@ -80,9 +80,9 @@ pub fn choose(input: Maybe, fallback: UserId) -> UserId {
             bindings
             - v0 self_param self `&self` => &Self struct body_if_let_fixture[lib]::crate::UserId @ 4:21-4:26
             body
-            expr e1 block s1 => <unknown> @ 4:36-6:6
+            expr e1 block s1 => bool @ 4:36-6:6
               tail
-                expr e0 literal bool `true` => <unknown> @ 5:9-5:13
+                expr e0 literal bool `true` => bool @ 5:9-5:13
         "#]],
     );
 }
@@ -170,9 +170,9 @@ pub fn choose(input: Maybe, fallback: UserId) -> UserId {
             bindings
             - v0 self_param self `&self` => &Self struct body_let_else_guard_fixture[lib]::crate::UserId @ 4:21-4:26
             body
-            expr e1 block s1 => <unknown> @ 4:36-6:6
+            expr e1 block s1 => bool @ 4:36-6:6
               tail
-                expr e0 literal bool `true` => <unknown> @ 5:9-5:13
+                expr e0 literal bool `true` => bool @ 5:9-5:13
         "#]],
     );
 }

--- a/crates/engine/body-ir/src/tests/control_flow.rs
+++ b/crates/engine/body-ir/src/tests/control_flow.rs
@@ -494,6 +494,151 @@ pub fn use_it(def_map: &DefMap) {
 }
 
 #[test]
+fn propagates_for_loop_items_from_slice_iter_method() {
+    check_project_body_ir(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["core", "storage", "app"]
+resolver = "3"
+
+//- /core/Cargo.toml
+[package]
+name = "fake_core"
+version = "0.1.0"
+edition = "2024"
+
+//- /core/src/lib.rs
+pub mod iter {
+    pub trait IntoIterator {
+        type Item;
+    }
+
+    pub trait Iterator {
+        type Item;
+    }
+}
+
+pub mod slice {
+    pub struct Iter<'a, T>(&'a T);
+}
+
+impl<T> [T] {
+    pub fn iter(&self) -> slice::Iter<'_, T> {
+        missing()
+    }
+}
+
+impl<'a, T> iter::Iterator for slice::Iter<'a, T> {
+    type Item = &'a T;
+}
+
+impl<I: iter::Iterator> iter::IntoIterator for I {
+    type Item = I::Item;
+}
+
+//- /storage/Cargo.toml
+[package]
+name = "storage"
+version = "0.1.0"
+edition = "2024"
+
+//- /storage/src/lib.rs
+pub struct ImportData;
+
+pub struct DefMap;
+
+impl DefMap {
+    pub fn imports(&self) -> &[ImportData] {
+        missing()
+    }
+}
+
+//- /app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+core = { package = "fake_core", path = "../core" }
+storage = { path = "../storage" }
+
+//- /app/src/lib.rs
+use storage::DefMap;
+
+pub fn use_it(def_map: &DefMap) {
+    for import in def_map.imports().iter() {
+        import;
+    }
+}
+"#,
+        expect![[r#"
+            package app
+
+            app [lib]
+            body b0 fn app[lib]::crate::use_it @ 3:1-7:2
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: <none>
+            - s2 parent s1: v1
+            - s3 parent s2: <none>
+            bindings
+            - v0 param def_map `def_map`: &DefMap => &nominal struct storage[lib]::crate::DefMap @ 3:15-3:22
+            - v1 let import `import` => &nominal struct storage[lib]::crate::ImportData @ 4:9-4:15
+            body
+            expr e6 block s1 => () @ 3:33-7:2
+              tail
+                expr e5 for s2 v1 => () @ 4:5-6:6
+                  iterable
+                    expr e2 method_call iter -> fn impl [T]::iter => nominal struct fake_core[lib]::crate::slice::Iter<'_, nominal struct storage[lib]::crate::ImportData> @ 4:19-4:43
+                      receiver
+                        expr e1 method_call imports -> fn impl DefMap::imports => &[nominal struct storage[lib]::crate::ImportData] @ 4:19-4:36
+                          receiver
+                            expr e0 path def_map -> local v0 => &nominal struct storage[lib]::crate::DefMap @ 4:19-4:26
+                  body
+                    expr e4 block s3 => () @ 4:44-6:6
+                      stmt s0 expr; @ 5:9-5:16
+                        expr e3 path import -> local v1 => &nominal struct storage[lib]::crate::ImportData @ 5:9-5:15
+
+
+            package fake_core
+
+            fake_core [lib]
+            body b0 fn impl [T]::iter @ 16:5-18:6
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: <none>
+            bindings
+            - v0 self_param self `&self` => <unknown> @ 16:17-16:22
+            body
+            expr e2 block s1 => <unknown> @ 16:46-18:6
+              tail
+                expr e1 call => <unknown> @ 17:9-17:18
+                  callee
+                    expr e0 path missing => <unknown> @ 17:9-17:16
+
+
+            package storage
+
+            storage [lib]
+            body b0 fn impl DefMap::imports @ 6:5-8:6
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: <none>
+            bindings
+            - v0 self_param self `&self` => &Self struct storage[lib]::crate::DefMap @ 6:20-6:25
+            body
+            expr e2 block s1 => <unknown> @ 6:44-8:6
+              tail
+                expr e1 call => <unknown> @ 7:9-7:18
+                  callee
+                    expr e0 path missing => <unknown> @ 7:9-7:16
+        "#]],
+    );
+}
+
+#[test]
 fn lowers_labeled_block_control_flow() {
     check_project_body_ir(
         r#"

--- a/crates/engine/body-ir/src/tests/control_flow.rs
+++ b/crates/engine/body-ir/src/tests/control_flow.rs
@@ -382,6 +382,118 @@ pub fn use_it(packages: &[Package], array: [Package; 3], pairs: [(Package, UserI
 }
 
 #[test]
+fn propagates_for_loop_items_from_method_returned_slice() {
+    check_project_body_ir(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["core", "storage", "app"]
+resolver = "3"
+
+//- /core/Cargo.toml
+[package]
+name = "fake_core"
+version = "0.1.0"
+edition = "2024"
+
+//- /core/src/lib.rs
+pub mod iter {
+    pub trait IntoIterator {
+        type Item;
+    }
+}
+
+impl<'a, T> iter::IntoIterator for &'a [T] {
+    type Item = &'a T;
+}
+
+//- /storage/Cargo.toml
+[package]
+name = "storage"
+version = "0.1.0"
+edition = "2024"
+
+//- /storage/src/lib.rs
+pub struct ImportData;
+
+pub struct DefMap;
+
+impl DefMap {
+    pub fn imports(&self) -> &[ImportData] {
+        missing()
+    }
+}
+
+//- /app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+core = { package = "fake_core", path = "../core" }
+storage = { path = "../storage" }
+
+//- /app/src/lib.rs
+use storage::DefMap;
+
+pub fn use_it(def_map: &DefMap) {
+    for import in def_map.imports() {
+        import;
+    }
+}
+"#,
+        expect![[r#"
+            package app
+
+            app [lib]
+            body b0 fn app[lib]::crate::use_it @ 3:1-7:2
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: <none>
+            - s2 parent s1: v1
+            - s3 parent s2: <none>
+            bindings
+            - v0 param def_map `def_map`: &DefMap => &nominal struct storage[lib]::crate::DefMap @ 3:15-3:22
+            - v1 let import `import` => &nominal struct storage[lib]::crate::ImportData @ 4:9-4:15
+            body
+            expr e5 block s1 => () @ 3:33-7:2
+              tail
+                expr e4 for s2 v1 => () @ 4:5-6:6
+                  iterable
+                    expr e1 method_call imports -> fn impl DefMap::imports => &[nominal struct storage[lib]::crate::ImportData] @ 4:19-4:36
+                      receiver
+                        expr e0 path def_map -> local v0 => &nominal struct storage[lib]::crate::DefMap @ 4:19-4:26
+                  body
+                    expr e3 block s3 => () @ 4:37-6:6
+                      stmt s0 expr; @ 5:9-5:16
+                        expr e2 path import -> local v1 => &nominal struct storage[lib]::crate::ImportData @ 5:9-5:15
+
+
+            package fake_core
+
+            fake_core [lib]
+
+            package storage
+
+            storage [lib]
+            body b0 fn impl DefMap::imports @ 6:5-8:6
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: <none>
+            bindings
+            - v0 self_param self `&self` => &Self struct storage[lib]::crate::DefMap @ 6:20-6:25
+            body
+            expr e2 block s1 => <unknown> @ 6:44-8:6
+              tail
+                expr e1 call => <unknown> @ 7:9-7:18
+                  callee
+                    expr e0 path missing => <unknown> @ 7:9-7:16
+        "#]],
+    );
+}
+
+#[test]
 fn lowers_labeled_block_control_flow() {
     check_project_body_ir(
         r#"

--- a/crates/engine/body-ir/src/tests/expressions.rs
+++ b/crates/engine/body-ir/src/tests/expressions.rs
@@ -304,6 +304,65 @@ pub fn use_it(pair: (u8, bool), array: [u8; 3], slice: &[u8], value: u8) {
 }
 
 #[test]
+fn infers_indexing_through_references() {
+    check_project_body_ir(
+        r#"
+//- /Cargo.toml
+[package]
+name = "body_ref_index_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub fn use_it(slice: &[u8], array_ref: &[bool; 3], nested_slice: &&[u16]) {
+    let slice_item = slice[0];
+    let array_item = array_ref[0];
+    let nested_item = nested_slice[0];
+}
+"#,
+        expect![[r#"
+            package body_ref_index_fixture
+
+            body_ref_index_fixture [lib]
+            body b0 fn body_ref_index_fixture[lib]::crate::use_it @ 1:1-5:2
+            scopes
+            - s0 parent <none>: v0, v1, v2
+            - s1 parent s0: v3, v4, v5
+            bindings
+            - v0 param slice `slice`: &[u8] => &[u8] @ 1:15-1:20
+            - v1 param array_ref `array_ref`: &[bool; 3] => &[bool; 3] @ 1:29-1:38
+            - v2 param nested_slice `nested_slice`: &&[u16] => &&[u16] @ 1:52-1:64
+            - v3 let slice_item `slice_item` => u8 @ 2:9-2:19
+            - v4 let array_item `array_item` => bool @ 3:9-3:19
+            - v5 let nested_item `nested_item` => u16 @ 4:9-4:20
+            body
+            expr e9 block s1 => () @ 1:75-5:2
+              stmt s0 let v3 @ 2:5-2:31
+                initializer
+                  expr e2 index => u8 @ 2:22-2:30
+                    base
+                      expr e0 path slice -> local v0 => &[u8] @ 2:22-2:27
+                    index
+                      expr e1 literal int `0` => i32 @ 2:28-2:29
+              stmt s1 let v4 @ 3:5-3:35
+                initializer
+                  expr e5 index => bool @ 3:22-3:34
+                    base
+                      expr e3 path array_ref -> local v1 => &[bool; 3] @ 3:22-3:31
+                    index
+                      expr e4 literal int `0` => i32 @ 3:32-3:33
+              stmt s2 let v5 @ 4:5-4:39
+                initializer
+                  expr e8 index => u16 @ 4:23-4:38
+                    base
+                      expr e6 path nested_slice -> local v2 => &&[u16] @ 4:23-4:35
+                    index
+                      expr e7 literal int `0` => i32 @ 4:36-4:37
+        "#]],
+    );
+}
+
+#[test]
 fn infers_scalar_literals_and_builtin_operator_results() {
     check_project_body_ir(
         r#"

--- a/crates/engine/body-ir/src/tests/expressions.rs
+++ b/crates/engine/body-ir/src/tests/expressions.rs
@@ -112,6 +112,60 @@ impl User {
 }
 
 #[test]
+fn preserves_method_call_generic_args() {
+    check_project_body_ir(
+        r#"
+//- /Cargo.toml
+[package]
+name = "body_method_call_generic_args_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct User;
+pub struct Builder;
+
+impl Builder {
+    pub fn get<T>(&self) -> T {}
+}
+
+pub fn use_it(builder: Builder) {
+    let user = builder.get::<User>();
+}
+"#,
+        expect![[r#"
+            package body_method_call_generic_args_fixture
+
+            body_method_call_generic_args_fixture [lib]
+            body b0 fn body_method_call_generic_args_fixture[lib]::crate::use_it @ 8:1-10:2
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: v1
+            bindings
+            - v0 param builder `builder`: Builder => nominal struct body_method_call_generic_args_fixture[lib]::crate::Builder @ 8:15-8:22
+            - v1 let user `user` => nominal struct body_method_call_generic_args_fixture[lib]::crate::User @ 9:9-9:13
+            body
+            expr e2 block s1 => () @ 8:33-10:2
+              stmt s0 let v1 @ 9:5-9:38
+                initializer
+                  expr e1 method_call get<User> -> fn impl Builder::get => nominal struct body_method_call_generic_args_fixture[lib]::crate::User @ 9:16-9:37
+                    receiver
+                      expr e0 path builder -> local v0 => nominal struct body_method_call_generic_args_fixture[lib]::crate::Builder @ 9:16-9:23
+
+
+            body b1 fn impl Builder::get @ 5:5-5:33
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: <none>
+            bindings
+            - v0 self_param self `&self` => &Self struct body_method_call_generic_args_fixture[lib]::crate::Builder @ 5:19-5:24
+            body
+            expr e0 block s1 => () @ 5:31-5:33
+        "#]],
+    );
+}
+
+#[test]
 fn renders_fn_trait_parenthesized_args_in_binding_annotations() {
     check_project_body_ir(
         r#"

--- a/crates/engine/body-ir/src/tests/expressions.rs
+++ b/crates/engine/body-ir/src/tests/expressions.rs
@@ -75,7 +75,7 @@ impl User {
                     callee
                       expr e1 path UserId -> item struct body_expr_fixture[lib]::crate::UserId => nominal struct body_expr_fixture[lib]::crate::UserId @ 14:29-14:35
                     arg
-                      expr e2 literal int `1` => <unknown> @ 14:36-14:37
+                      expr e2 literal int `1` => i32 @ 14:36-14:37
               stmt s2 let v4: UserId @ 15:9-15:43
                 initializer
                   expr e6 call => nominal struct body_expr_fixture[lib]::crate::UserId @ 15:30-15:42
@@ -107,6 +107,173 @@ impl User {
             expr e1 block s1 => nominal struct body_expr_fixture[lib]::crate::UserId @ 20:43-22:6
               tail
                 expr e0 path id -> local v1 => nominal struct body_expr_fixture[lib]::crate::UserId @ 21:9-21:11
+        "#]],
+    );
+}
+
+#[test]
+fn renders_fn_trait_parenthesized_args_in_binding_annotations() {
+    check_project_body_ir(
+        r#"
+//- /Cargo.toml
+[package]
+name = "body_fn_trait_args_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct AttrVec;
+
+pub fn configure(f: impl FnOnce(&mut AttrVec)) {
+    let _ = f;
+}
+"#,
+        expect![[r#"
+            package body_fn_trait_args_fixture
+
+            body_fn_trait_args_fixture [lib]
+            body b0 fn body_fn_trait_args_fixture[lib]::crate::configure @ 3:1-5:2
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: <none>
+            bindings
+            - v0 param f `f`: impl FnOnce(&mut AttrVec) => syntax impl FnOnce(&mut AttrVec) @ 3:18-3:19
+            body
+            expr e1 block s1 => () @ 3:48-5:2
+              stmt s0 let  @ 4:5-4:15
+                initializer
+                  expr e0 path f -> local v0 => syntax impl FnOnce(&mut AttrVec) @ 4:13-4:14
+        "#]],
+    );
+}
+
+#[test]
+fn infers_scalar_literals_and_builtin_operator_results() {
+    check_project_body_ir(
+        r#"
+//- /Cargo.toml
+[package]
+name = "body_scalar_operator_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub fn use_it(flag: bool, lhs: i32, rhs: i32) {
+    let bool_lit = true;
+    let char_lit = 'x';
+    let byte_lit = b'x';
+    let int_default = 1;
+    let int_suffix = 1usize;
+    let float_default = 1.0;
+    let float_suffix = 1.0f32;
+    let not_flag = !flag;
+    let neg_lhs = -lhs;
+    let sum = lhs + rhs;
+    let compare = lhs < rhs;
+    let logic = flag && false;
+    let bit = lhs & rhs;
+    let shift = lhs << 1;
+    let string_lit = "text";
+}
+"#,
+        expect![[r#"
+            package body_scalar_operator_fixture
+
+            body_scalar_operator_fixture [lib]
+            body b0 fn body_scalar_operator_fixture[lib]::crate::use_it @ 1:1-17:2
+            scopes
+            - s0 parent <none>: v0, v1, v2
+            - s1 parent s0: v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17
+            bindings
+            - v0 param flag `flag`: bool => bool @ 1:15-1:19
+            - v1 param lhs `lhs`: i32 => i32 @ 1:27-1:30
+            - v2 param rhs `rhs`: i32 => i32 @ 1:37-1:40
+            - v3 let bool_lit `bool_lit` => bool @ 2:9-2:17
+            - v4 let char_lit `char_lit` => char @ 3:9-3:17
+            - v5 let byte_lit `byte_lit` => u8 @ 4:9-4:17
+            - v6 let int_default `int_default` => i32 @ 5:9-5:20
+            - v7 let int_suffix `int_suffix` => usize @ 6:9-6:19
+            - v8 let float_default `float_default` => f64 @ 7:9-7:22
+            - v9 let float_suffix `float_suffix` => f32 @ 8:9-8:21
+            - v10 let not_flag `not_flag` => bool @ 9:9-9:17
+            - v11 let neg_lhs `neg_lhs` => i32 @ 10:9-10:16
+            - v12 let sum `sum` => i32 @ 11:9-11:12
+            - v13 let compare `compare` => bool @ 12:9-12:16
+            - v14 let logic `logic` => bool @ 13:9-13:14
+            - v15 let bit `bit` => i32 @ 14:9-14:12
+            - v16 let shift `shift` => i32 @ 15:9-15:14
+            - v17 let string_lit `string_lit` => &str @ 16:9-16:19
+            body
+            expr e27 block s1 => () @ 1:47-17:2
+              stmt s0 let v3 @ 2:5-2:25
+                initializer
+                  expr e0 literal bool `true` => bool @ 2:20-2:24
+              stmt s1 let v4 @ 3:5-3:24
+                initializer
+                  expr e1 literal char `'x'` => char @ 3:20-3:23
+              stmt s2 let v5 @ 4:5-4:25
+                initializer
+                  expr e2 literal int `b'x'` => u8 @ 4:20-4:24
+              stmt s3 let v6 @ 5:5-5:25
+                initializer
+                  expr e3 literal int `1` => i32 @ 5:23-5:24
+              stmt s4 let v7 @ 6:5-6:29
+                initializer
+                  expr e4 literal int `1usize` => usize @ 6:22-6:28
+              stmt s5 let v8 @ 7:5-7:29
+                initializer
+                  expr e5 literal float `1.0` => f64 @ 7:25-7:28
+              stmt s6 let v9 @ 8:5-8:31
+                initializer
+                  expr e6 literal float `1.0f32` => f32 @ 8:24-8:30
+              stmt s7 let v10 @ 9:5-9:26
+                initializer
+                  expr e8 unary ! => bool @ 9:20-9:25
+                    inner
+                      expr e7 path flag -> local v0 => bool @ 9:21-9:25
+              stmt s8 let v11 @ 10:5-10:24
+                initializer
+                  expr e10 unary - => i32 @ 10:19-10:23
+                    inner
+                      expr e9 path lhs -> local v1 => i32 @ 10:20-10:23
+              stmt s9 let v12 @ 11:5-11:25
+                initializer
+                  expr e13 binary + => i32 @ 11:15-11:24
+                    lhs
+                      expr e11 path lhs -> local v1 => i32 @ 11:15-11:18
+                    rhs
+                      expr e12 path rhs -> local v2 => i32 @ 11:21-11:24
+              stmt s10 let v13 @ 12:5-12:29
+                initializer
+                  expr e16 binary < => bool @ 12:19-12:28
+                    lhs
+                      expr e14 path lhs -> local v1 => i32 @ 12:19-12:22
+                    rhs
+                      expr e15 path rhs -> local v2 => i32 @ 12:25-12:28
+              stmt s11 let v14 @ 13:5-13:31
+                initializer
+                  expr e19 binary && => bool @ 13:17-13:30
+                    lhs
+                      expr e17 path flag -> local v0 => bool @ 13:17-13:21
+                    rhs
+                      expr e18 literal bool `false` => bool @ 13:25-13:30
+              stmt s12 let v15 @ 14:5-14:25
+                initializer
+                  expr e22 binary & => i32 @ 14:15-14:24
+                    lhs
+                      expr e20 path lhs -> local v1 => i32 @ 14:15-14:18
+                    rhs
+                      expr e21 path rhs -> local v2 => i32 @ 14:21-14:24
+              stmt s13 let v16 @ 15:5-15:26
+                initializer
+                  expr e25 binary << => i32 @ 15:17-15:25
+                    lhs
+                      expr e23 path lhs -> local v1 => i32 @ 15:17-15:20
+                    rhs
+                      expr e24 literal int `1` => i32 @ 15:24-15:25
+              stmt s14 let v17 @ 16:5-16:29
+                initializer
+                  expr e26 literal string `"text"` => &str @ 16:22-16:28
         "#]],
     );
 }
@@ -159,12 +326,12 @@ pub fn use_it(id: u8, name: u8) -> User {
                 initializer
                   expr e4 record User -> item struct body_record_expr_fixture[lib]::crate::User => nominal struct body_record_expr_fixture[lib]::crate::User @ 8:20-8:38
                     field id
-                      expr e3 literal int `2` => <unknown> @ 8:31-8:32
+                      expr e3 literal int `2` => i32 @ 8:31-8:32
                     spread @ 8:34-8:36
               tail
                 expr e7 record User -> item struct body_record_expr_fixture[lib]::crate::User => nominal struct body_record_expr_fixture[lib]::crate::User @ 9:5-9:27
                   field id
-                    expr e5 literal int `1` => <unknown> @ 9:16-9:17
+                    expr e5 literal int `1` => i32 @ 9:16-9:17
                   spread @ 9:19-9:25
                     expr e6 path base -> local v2 => nominal struct body_record_expr_fixture[lib]::crate::User @ 9:21-9:25
         "#]],
@@ -365,7 +532,7 @@ pub fn use_it(mut pair: (u8, u8), mut slots: [u8; 3], value: u8, user: User) {
             - v11 let casted `casted` => nominal struct body_common_expr_fixture[lib]::crate::User @ 17:9-17:15
             - v12 let field_after_cast `field_after_cast` => u8 @ 18:9-18:25
             - v13 let unary `unary` => <unknown> @ 19:9-19:14
-            - v14 let binary `binary` => <unknown> @ 20:9-20:15
+            - v14 let binary `binary` => bool @ 20:9-20:15
             - v15 let hole `hole` => <unknown> @ 23:9-23:13
             body
             expr e66 block s1 => () @ 9:78-27:2
@@ -384,28 +551,28 @@ pub fn use_it(mut pair: (u8, u8), mut slots: [u8; 3], value: u8, user: User) {
                     element
                       expr e4 path value -> local v2 => u8 @ 11:18-11:23
                     element
-                      expr e5 literal int `1` => <unknown> @ 11:25-11:26
+                      expr e5 literal int `1` => i32 @ 11:25-11:26
                     element
-                      expr e6 literal int `2` => <unknown> @ 11:28-11:29
+                      expr e6 literal int `2` => i32 @ 11:28-11:29
               stmt s2 let v6 @ 12:5-12:29
                 initializer
                   expr e10 repeat_array => <unknown> @ 12:18-12:28
                     initializer
                       expr e8 path value -> local v2 => u8 @ 12:19-12:24
                     repeat
-                      expr e9 literal int `3` => <unknown> @ 12:26-12:27
+                      expr e9 literal int `3` => i32 @ 12:26-12:27
               stmt s3 let v7 @ 13:5-13:28
                 initializer
                   expr e13 index => <unknown> @ 13:19-13:27
                     base
                       expr e11 path slots -> local v1 => syntax [u8; 3] @ 13:19-13:24
                     index
-                      expr e12 literal int `0` => <unknown> @ 13:25-13:26
+                      expr e12 literal int `0` => i32 @ 13:25-13:26
               stmt s4 let v8 @ 14:5-14:30
                 initializer
                   expr e16 range .. => <unknown> @ 14:21-14:29
                     start
-                      expr e14 literal int `1` => <unknown> @ 14:21-14:22
+                      expr e14 literal int `1` => i32 @ 14:21-14:22
                     end
                       expr e15 path value -> local v2 => u8 @ 14:24-14:29
               stmt s5 let v9 @ 15:5-15:35
@@ -436,13 +603,13 @@ pub fn use_it(mut pair: (u8, u8), mut slots: [u8; 3], value: u8, user: User) {
                 initializer
                   expr e34 tuple => <unknown> @ 19:17-19:38
                     field
-                      expr e28 unary ! => <unknown> @ 19:18-19:24
+                      expr e28 unary ! => bool @ 19:18-19:24
                         inner
-                          expr e27 literal bool `false` => <unknown> @ 19:19-19:24
+                          expr e27 literal bool `false` => bool @ 19:19-19:24
                     field
-                      expr e30 unary - => <unknown> @ 19:26-19:28
+                      expr e30 unary - => i32 @ 19:26-19:28
                         inner
-                          expr e29 literal int `1` => <unknown> @ 19:27-19:28
+                          expr e29 literal int `1` => i32 @ 19:27-19:28
                     field
                       expr e33 unary * => u8 @ 19:30-19:37
                         inner
@@ -451,23 +618,23 @@ pub fn use_it(mut pair: (u8, u8), mut slots: [u8; 3], value: u8, user: User) {
                               expr e31 path value -> local v2 => u8 @ 19:32-19:37
               stmt s10 let v14 @ 20:5-20:50
                 initializer
-                  expr e43 binary || => <unknown> @ 20:18-20:49
+                  expr e43 binary || => bool @ 20:18-20:49
                     lhs
-                      expr e41 binary && => <unknown> @ 20:18-20:41
+                      expr e41 binary && => bool @ 20:18-20:41
                         lhs
-                          expr e39 binary == => <unknown> @ 20:18-20:32
+                          expr e39 binary == => bool @ 20:18-20:32
                             lhs
                               expr e37 binary + => <unknown> @ 20:18-20:27
                                 lhs
                                   expr e35 path value -> local v2 => u8 @ 20:18-20:23
                                 rhs
-                                  expr e36 literal int `1` => <unknown> @ 20:26-20:27
+                                  expr e36 literal int `1` => i32 @ 20:26-20:27
                             rhs
-                              expr e38 literal int `2` => <unknown> @ 20:31-20:32
+                              expr e38 literal int `2` => i32 @ 20:31-20:32
                         rhs
-                          expr e40 literal bool `false` => <unknown> @ 20:36-20:41
+                          expr e40 literal bool `false` => bool @ 20:36-20:41
                     rhs
-                      expr e42 literal bool `true` => <unknown> @ 20:45-20:49
+                      expr e42 literal bool `true` => bool @ 20:45-20:49
               stmt s11 expr; @ 21:5-21:31
                 expr e52 assign = => () @ 21:5-21:30
                   target
@@ -483,9 +650,9 @@ pub fn use_it(mut pair: (u8, u8), mut slots: [u8; 3], value: u8, user: User) {
                   value
                     expr e51 tuple => <unknown> @ 21:24-21:30
                       field
-                        expr e49 literal int `1` => <unknown> @ 21:25-21:26
+                        expr e49 literal int `1` => i32 @ 21:25-21:26
                       field
-                        expr e50 literal int `2` => <unknown> @ 21:28-21:29
+                        expr e50 literal int `2` => i32 @ 21:28-21:29
               stmt s12 expr; @ 22:5-22:23
                 expr e57 assign += => () @ 22:5-22:22
                   target
@@ -493,7 +660,7 @@ pub fn use_it(mut pair: (u8, u8), mut slots: [u8; 3], value: u8, user: User) {
                       base
                         expr e53 path slots -> local v1 => syntax [u8; 3] @ 22:5-22:10
                       index
-                        expr e54 literal int `0` => <unknown> @ 22:11-22:12
+                        expr e54 literal int `0` => i32 @ 22:11-22:12
                   value
                     expr e56 path value -> local v2 => u8 @ 22:17-22:22
               stmt s13 let v15 @ 23:5-23:18
@@ -746,7 +913,7 @@ pub static CURRENT: u32 = LIMIT;
             - s0 parent <none>: <none>
             bindings
             body
-            expr e0 literal int `3` => <unknown> @ 1:24-1:25
+            expr e0 literal int `3` => i32 @ 1:24-1:25
 
 
             body b1 static body_item_initializer_fixture[lib]::crate::CURRENT @ 2:1-2:33

--- a/crates/engine/body-ir/src/tests/expressions.rs
+++ b/crates/engine/body-ir/src/tests/expressions.rs
@@ -148,6 +148,108 @@ pub fn configure(f: impl FnOnce(&mut AttrVec)) {
 }
 
 #[test]
+fn infers_structural_tuple_array_and_slice_types() {
+    check_project_body_ir(
+        r#"
+//- /Cargo.toml
+[package]
+name = "body_structural_type_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub fn use_it(pair: (u8, bool), array: [u8; 3], slice: &[u8], value: u8) {
+    let annotated_tuple: (u8, bool) = pair;
+    let annotated_array: [u8; 3] = array;
+    let annotated_slice: &[u8] = slice;
+    let tuple_expr = (value, true);
+    let array_expr = [value, value];
+    let repeat_expr = [value; 3];
+    let tuple_field = pair.0;
+    let indexed = array[0];
+    let (left, right) = tuple_expr;
+    let [first, ..] = array_expr;
+}
+"#,
+        expect![[r#"
+            package body_structural_type_fixture
+
+            body_structural_type_fixture [lib]
+            body b0 fn body_structural_type_fixture[lib]::crate::use_it @ 1:1-12:2
+            scopes
+            - s0 parent <none>: v0, v1, v2, v3
+            - s1 parent s0: v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14
+            bindings
+            - v0 param pair `pair`: (u8, bool) => (u8, bool) @ 1:15-1:19
+            - v1 param array `array`: [u8; 3] => [u8; 3] @ 1:33-1:38
+            - v2 param slice `slice`: &[u8] => &[u8] @ 1:49-1:54
+            - v3 param value `value`: u8 => u8 @ 1:63-1:68
+            - v4 let annotated_tuple `annotated_tuple`: (u8, bool) => (u8, bool) @ 2:9-2:24
+            - v5 let annotated_array `annotated_array`: [u8; 3] => [u8; 3] @ 3:9-3:24
+            - v6 let annotated_slice `annotated_slice`: &[u8] => &[u8] @ 4:9-4:24
+            - v7 let tuple_expr `tuple_expr` => (u8, bool) @ 5:9-5:19
+            - v8 let array_expr `array_expr` => [u8; 2] @ 6:9-6:19
+            - v9 let repeat_expr `repeat_expr` => [u8; 3] @ 7:9-7:20
+            - v10 let tuple_field `tuple_field` => u8 @ 8:9-8:20
+            - v11 let indexed `indexed` => u8 @ 9:9-9:16
+            - v12 let left `left` => u8 @ 10:10-10:14
+            - v13 let right `right` => bool @ 10:16-10:21
+            - v14 let first `first` => u8 @ 11:10-11:15
+            body
+            expr e19 block s1 => () @ 1:74-12:2
+              stmt s0 let v4: (u8, bool) @ 2:5-2:44
+                initializer
+                  expr e0 path pair -> local v0 => (u8, bool) @ 2:39-2:43
+              stmt s1 let v5: [u8; 3] @ 3:5-3:42
+                initializer
+                  expr e1 path array -> local v1 => [u8; 3] @ 3:36-3:41
+              stmt s2 let v6: &[u8] @ 4:5-4:40
+                initializer
+                  expr e2 path slice -> local v2 => &[u8] @ 4:34-4:39
+              stmt s3 let v7 @ 5:5-5:36
+                initializer
+                  expr e5 tuple => (u8, bool) @ 5:22-5:35
+                    field
+                      expr e3 path value -> local v3 => u8 @ 5:23-5:28
+                    field
+                      expr e4 literal bool `true` => bool @ 5:30-5:34
+              stmt s4 let v8 @ 6:5-6:37
+                initializer
+                  expr e8 array => [u8; 2] @ 6:22-6:36
+                    element
+                      expr e6 path value -> local v3 => u8 @ 6:23-6:28
+                    element
+                      expr e7 path value -> local v3 => u8 @ 6:30-6:35
+              stmt s5 let v9 @ 7:5-7:34
+                initializer
+                  expr e11 repeat_array => [u8; 3] @ 7:23-7:33
+                    initializer
+                      expr e9 path value -> local v3 => u8 @ 7:24-7:29
+                    repeat
+                      expr e10 literal int `3` => i32 @ 7:31-7:32
+              stmt s6 let v10 @ 8:5-8:30
+                initializer
+                  expr e13 field 0 => u8 @ 8:23-8:29
+                    base
+                      expr e12 path pair -> local v0 => (u8, bool) @ 8:23-8:27
+              stmt s7 let v11 @ 9:5-9:28
+                initializer
+                  expr e16 index => u8 @ 9:19-9:27
+                    base
+                      expr e14 path array -> local v1 => [u8; 3] @ 9:19-9:24
+                    index
+                      expr e15 literal int `0` => i32 @ 9:25-9:26
+              stmt s8 let v12, v13 @ 10:5-10:36
+                initializer
+                  expr e17 path tuple_expr -> local v7 => (u8, bool) @ 10:25-10:35
+              stmt s9 let v14 @ 11:5-11:34
+                initializer
+                  expr e18 path array_expr -> local v8 => [u8; 2] @ 11:23-11:33
+        "#]],
+    );
+}
+
+#[test]
 fn infers_scalar_literals_and_builtin_operator_results() {
     check_project_body_ir(
         r#"
@@ -518,27 +620,27 @@ pub fn use_it(mut pair: (u8, u8), mut slots: [u8; 3], value: u8, user: User) {
             - s0 parent <none>: v0, v1, v2, v3
             - s1 parent s0: v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15
             bindings
-            - v0 param pair `mut pair`: (u8, u8) => syntax (u8, u8) @ 9:15-9:23
-            - v1 param slots `mut slots`: [u8; 3] => syntax [u8; 3] @ 9:35-9:44
+            - v0 param pair `mut pair`: (u8, u8) => (u8, u8) @ 9:15-9:23
+            - v1 param slots `mut slots`: [u8; 3] => [u8; 3] @ 9:35-9:44
             - v2 param value `value`: u8 => u8 @ 9:55-9:60
             - v3 param user `user`: User => nominal struct body_common_expr_fixture[lib]::crate::User @ 9:66-9:70
-            - v4 let tuple `tuple` => <unknown> @ 10:9-10:14
+            - v4 let tuple `tuple` => (u8, u8) @ 10:9-10:14
             - v5 let array `array` => <unknown> @ 11:9-11:14
-            - v6 let repeat `repeat` => <unknown> @ 12:9-12:15
-            - v7 let indexed `indexed` => <unknown> @ 13:9-13:16
+            - v6 let repeat `repeat` => [u8; 3] @ 12:9-12:15
+            - v7 let indexed `indexed` => u8 @ 13:9-13:16
             - v8 let exclusive `exclusive` => <unknown> @ 14:9-14:18
             - v9 let inclusive `inclusive` => <unknown> @ 15:9-15:18
             - v10 let full `full` => <unknown> @ 16:9-16:13
             - v11 let casted `casted` => nominal struct body_common_expr_fixture[lib]::crate::User @ 17:9-17:15
             - v12 let field_after_cast `field_after_cast` => u8 @ 18:9-18:25
-            - v13 let unary `unary` => <unknown> @ 19:9-19:14
+            - v13 let unary `unary` => (bool, i32, u8) @ 19:9-19:14
             - v14 let binary `binary` => bool @ 20:9-20:15
             - v15 let hole `hole` => <unknown> @ 23:9-23:13
             body
             expr e66 block s1 => () @ 9:78-27:2
               stmt s0 let v4 @ 10:5-10:34
                 initializer
-                  expr e3 tuple => <unknown> @ 10:17-10:33
+                  expr e3 tuple => (u8, u8) @ 10:17-10:33
                     field
                       expr e0 path value -> local v2 => u8 @ 10:18-10:23
                     field
@@ -556,16 +658,16 @@ pub fn use_it(mut pair: (u8, u8), mut slots: [u8; 3], value: u8, user: User) {
                       expr e6 literal int `2` => i32 @ 11:28-11:29
               stmt s2 let v6 @ 12:5-12:29
                 initializer
-                  expr e10 repeat_array => <unknown> @ 12:18-12:28
+                  expr e10 repeat_array => [u8; 3] @ 12:18-12:28
                     initializer
                       expr e8 path value -> local v2 => u8 @ 12:19-12:24
                     repeat
                       expr e9 literal int `3` => i32 @ 12:26-12:27
               stmt s3 let v7 @ 13:5-13:28
                 initializer
-                  expr e13 index => <unknown> @ 13:19-13:27
+                  expr e13 index => u8 @ 13:19-13:27
                     base
-                      expr e11 path slots -> local v1 => syntax [u8; 3] @ 13:19-13:24
+                      expr e11 path slots -> local v1 => [u8; 3] @ 13:19-13:24
                     index
                       expr e12 literal int `0` => i32 @ 13:25-13:26
               stmt s4 let v8 @ 14:5-14:30
@@ -601,7 +703,7 @@ pub fn use_it(mut pair: (u8, u8), mut slots: [u8; 3], value: u8, user: User) {
                               expr e23 path user -> local v3 => nominal struct body_common_expr_fixture[lib]::crate::User @ 18:29-18:33
               stmt s9 let v13 @ 19:5-19:39
                 initializer
-                  expr e34 tuple => <unknown> @ 19:17-19:38
+                  expr e34 tuple => (bool, i32, u8) @ 19:17-19:38
                     field
                       expr e28 unary ! => bool @ 19:18-19:24
                         inner
@@ -638,17 +740,17 @@ pub fn use_it(mut pair: (u8, u8), mut slots: [u8; 3], value: u8, user: User) {
               stmt s11 expr; @ 21:5-21:31
                 expr e52 assign = => () @ 21:5-21:30
                   target
-                    expr e48 tuple => <unknown> @ 21:5-21:21
+                    expr e48 tuple => (u8, u8) @ 21:5-21:21
                       field
-                        expr e45 field 0 => <unknown> @ 21:6-21:12
+                        expr e45 field 0 => u8 @ 21:6-21:12
                           base
-                            expr e44 path pair -> local v0 => syntax (u8, u8) @ 21:6-21:10
+                            expr e44 path pair -> local v0 => (u8, u8) @ 21:6-21:10
                       field
-                        expr e47 field 1 => <unknown> @ 21:14-21:20
+                        expr e47 field 1 => u8 @ 21:14-21:20
                           base
-                            expr e46 path pair -> local v0 => syntax (u8, u8) @ 21:14-21:18
+                            expr e46 path pair -> local v0 => (u8, u8) @ 21:14-21:18
                   value
-                    expr e51 tuple => <unknown> @ 21:24-21:30
+                    expr e51 tuple => (i32, i32) @ 21:24-21:30
                       field
                         expr e49 literal int `1` => i32 @ 21:25-21:26
                       field
@@ -656,9 +758,9 @@ pub fn use_it(mut pair: (u8, u8), mut slots: [u8; 3], value: u8, user: User) {
               stmt s12 expr; @ 22:5-22:23
                 expr e57 assign += => () @ 22:5-22:22
                   target
-                    expr e55 index => <unknown> @ 22:5-22:13
+                    expr e55 index => u8 @ 22:5-22:13
                       base
-                        expr e53 path slots -> local v1 => syntax [u8; 3] @ 22:5-22:10
+                        expr e53 path slots -> local v1 => [u8; 3] @ 22:5-22:10
                       index
                         expr e54 literal int `0` => i32 @ 22:11-22:12
                   value

--- a/crates/engine/body-ir/src/tests/patterns.rs
+++ b/crates/engine/body-ir/src/tests/patterns.rs
@@ -106,32 +106,32 @@ pub fn destructure(
             bindings
             - v0 param param_left `param_left` => <unknown> @ 9:6-9:16
             - v1 param param_right `param_right` => <unknown> @ 9:18-9:29
-            - v2 param pair `pair`: (UserId, UserId) => syntax (UserId, UserId) @ 10:5-10:9
+            - v2 param pair `pair`: (UserId, UserId) => (nominal struct body_destructure_fixture[lib]::crate::UserId, nominal struct body_destructure_fixture[lib]::crate::UserId) @ 10:5-10:9
             - v3 param record `record`: Pair => nominal struct body_destructure_fixture[lib]::crate::Pair @ 11:5-11:11
-            - v4 param borrowed `borrowed`: &(UserId, UserId) => &syntax (UserId, UserId) @ 12:5-12:13
+            - v4 param borrowed `borrowed`: &(UserId, UserId) => &(nominal struct body_destructure_fixture[lib]::crate::UserId, nominal struct body_destructure_fixture[lib]::crate::UserId) @ 12:5-12:13
             - v5 let from_param `from_param`: UserId => nominal struct body_destructure_fixture[lib]::crate::UserId @ 14:9-14:19
-            - v6 let left `left` => <unknown> @ 15:10-15:14
-            - v7 let right `right` => <unknown> @ 15:16-15:21
+            - v6 let left `left` => nominal struct body_destructure_fixture[lib]::crate::UserId @ 15:10-15:14
+            - v7 let right `right` => nominal struct body_destructure_fixture[lib]::crate::UserId @ 15:16-15:21
             - v8 let field_left `field_left` => <unknown> @ 16:22-16:32
             - v9 let right `right` => <unknown> @ 16:34-16:39
             - v10 let borrowed_left `borrowed_left` => <unknown> @ 17:11-17:24
             - v11 let borrowed_right `borrowed_right` => <unknown> @ 17:26-17:40
             body
-            expr e5 block s1 => <unknown> @ 13:13-19:2
+            expr e5 block s1 => nominal struct body_destructure_fixture[lib]::crate::UserId @ 13:13-19:2
               stmt s0 let v5: UserId @ 14:5-14:41
                 initializer
                   expr e0 path param_left -> local v0 => <unknown> @ 14:30-14:40
               stmt s1 let v6, v7 @ 15:5-15:30
                 initializer
-                  expr e1 path pair -> local v2 => syntax (UserId, UserId) @ 15:25-15:29
+                  expr e1 path pair -> local v2 => (nominal struct body_destructure_fixture[lib]::crate::UserId, nominal struct body_destructure_fixture[lib]::crate::UserId) @ 15:25-15:29
               stmt s2 let v8, v9 @ 16:5-16:51
                 initializer
                   expr e2 path record -> local v3 => nominal struct body_destructure_fixture[lib]::crate::Pair @ 16:44-16:50
               stmt s3 let v10, v11 @ 17:5-17:53
                 initializer
-                  expr e3 path borrowed -> local v4 => &syntax (UserId, UserId) @ 17:44-17:52
+                  expr e3 path borrowed -> local v4 => &(nominal struct body_destructure_fixture[lib]::crate::UserId, nominal struct body_destructure_fixture[lib]::crate::UserId) @ 17:44-17:52
               tail
-                expr e4 path left -> local v6 => <unknown> @ 18:5-18:9
+                expr e4 path left -> local v6 => nominal struct body_destructure_fixture[lib]::crate::UserId @ 18:5-18:9
         "#]],
     );
 }

--- a/crates/engine/body-ir/src/tests/patterns.rs
+++ b/crates/engine/body-ir/src/tests/patterns.rs
@@ -192,7 +192,7 @@ pub fn shadowed(ready: u8, value: u8) -> u8 {
                   scrutinee
                     expr e0 path value -> local v0 => u8 @ 8:11-8:16
                   arm s2
-                    expr e1 literal int `0` => <unknown> @ 9:18-9:19
+                    expr e1 literal int `0` => i32 @ 9:18-9:19
                   arm s3
                     expr e2 path other -> local v2 => u8 @ 10:18-10:23
               stmt s1 let v3 @ 13:5-13:28
@@ -221,7 +221,7 @@ pub fn shadowed(ready: u8, value: u8) -> u8 {
                   arm s2
                     expr e1 path ready -> local v2 => u8 @ 19:18-19:23
                   arm s3
-                    expr e2 literal int `0` => <unknown> @ 20:14-20:15
+                    expr e2 literal int `0` => i32 @ 20:14-20:15
 
 
             body b2 const body_pattern_resolution_fixture[lib]::crate::ready @ 1:1-1:25
@@ -229,7 +229,7 @@ pub fn shadowed(ready: u8, value: u8) -> u8 {
             - s0 parent <none>: <none>
             bindings
             body
-            expr e0 literal int `1` => <unknown> @ 1:23-1:24
+            expr e0 literal int `1` => i32 @ 1:23-1:24
         "#]],
     );
 }

--- a/crates/engine/body-ir/src/tests/trait_methods.rs
+++ b/crates/engine/body-ir/src/tests/trait_methods.rs
@@ -106,7 +106,7 @@ pub fn use_it(user: User, wrapper: Wrapper<Error>) {
             - s0 parent <none>: v0
             - s1 parent s0: <none>
             bindings
-            - v0 self_param self `&self` => &Self struct body_trait_applicability_fixture[lib]::crate::Wrapper @ 23:16-23:21
+            - v0 self_param self `&self` => &Self struct body_trait_applicability_fixture[lib]::crate::Wrapper<syntax T> @ 23:16-23:21
             body
             expr e1 block s1 => nominal struct body_trait_applicability_fixture[lib]::crate::User @ 23:31-25:6
               tail
@@ -118,7 +118,7 @@ pub fn use_it(user: User, wrapper: Wrapper<Error>) {
             - s0 parent <none>: v0
             - s1 parent s0: <none>
             bindings
-            - v0 self_param self `&self` => &Self struct body_trait_applicability_fixture[lib]::crate::Wrapper @ 33:18-33:23
+            - v0 self_param self `&self` => &Self struct body_trait_applicability_fixture[lib]::crate::Wrapper<nominal struct body_trait_applicability_fixture[lib]::crate::User> @ 33:18-33:23
             body
             expr e1 block s1 => nominal struct body_trait_applicability_fixture[lib]::crate::User @ 33:33-35:6
               tail

--- a/crates/engine/body-ir/src/tests/trait_methods.rs
+++ b/crates/engine/body-ir/src/tests/trait_methods.rs
@@ -226,9 +226,9 @@ impl OtherExt for Maybe {
             bindings
             - v0 self_param self `&self` => &Self struct shared[lib]::crate::Maybe @ 8:17-8:22
             body
-            expr e1 block s1 => <unknown> @ 8:32-10:6
+            expr e1 block s1 => bool @ 8:32-10:6
               tail
-                expr e0 literal bool `true` => <unknown> @ 9:9-9:13
+                expr e0 literal bool `true` => bool @ 9:9-9:13
 
 
             package shared
@@ -241,9 +241,9 @@ impl OtherExt for Maybe {
             bindings
             - v0 self_param self `&self` => &Self struct shared[lib]::crate::Maybe @ 4:20-4:25
             body
-            expr e1 block s1 => <unknown> @ 4:35-6:6
+            expr e1 block s1 => bool @ 4:35-6:6
               tail
-                expr e0 literal bool `true` => <unknown> @ 5:9-5:13
+                expr e0 literal bool `true` => bool @ 5:9-5:13
         "#]],
     );
 }

--- a/crates/engine/body-ir/src/tests/trait_methods.rs
+++ b/crates/engine/body-ir/src/tests/trait_methods.rs
@@ -247,3 +247,71 @@ impl OtherExt for Maybe {
         "#]],
     );
 }
+
+#[test]
+fn resolves_trait_associated_consts_for_qualified_value_paths() {
+    check_project_body_ir(
+        r#"
+//- /Cargo.toml
+[package]
+name = "body_trait_assoc_const_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub enum StmtKind {
+    Let,
+}
+
+pub struct Stmt;
+
+pub trait HasAttrs {
+    const SUPPORTS_CUSTOM_INNER_ATTRS: bool;
+}
+
+impl HasAttrs for StmtKind {
+    const SUPPORTS_CUSTOM_INNER_ATTRS: bool = true;
+}
+
+impl HasAttrs for Stmt {
+    const SUPPORTS_CUSTOM_INNER_ATTRS: bool = StmtKind::SUPPORTS_CUSTOM_INNER_ATTRS;
+}
+
+pub fn use_it() {
+    let supports = StmtKind::SUPPORTS_CUSTOM_INNER_ATTRS;
+}
+"#,
+        expect![[r#"
+            package body_trait_assoc_const_fixture
+
+            body_trait_assoc_const_fixture [lib]
+            body b0 fn body_trait_assoc_const_fixture[lib]::crate::use_it @ 19:1-21:2
+            scopes
+            - s0 parent <none>: <none>
+            - s1 parent s0: v0
+            bindings
+            - v0 let supports `supports` => bool @ 20:9-20:17
+            body
+            expr e1 block s1 => () @ 19:17-21:2
+              stmt s0 let v0 @ 20:5-20:58
+                initializer
+                  expr e0 path StmtKind::SUPPORTS_CUSTOM_INNER_ATTRS -> const impl HasAttrs for StmtKind::SUPPORTS_CUSTOM_INNER_ATTRS => bool @ 20:20-20:57
+
+
+            body b1 const impl HasAttrs for StmtKind::SUPPORTS_CUSTOM_INNER_ATTRS @ 12:5-12:52
+            scopes
+            - s0 parent <none>: <none>
+            bindings
+            body
+            expr e0 literal bool `true` => bool @ 12:47-12:51
+
+
+            body b2 const impl HasAttrs for Stmt::SUPPORTS_CUSTOM_INNER_ATTRS @ 16:5-16:85
+            scopes
+            - s0 parent <none>: <none>
+            bindings
+            body
+            expr e0 path StmtKind::SUPPORTS_CUSTOM_INNER_ATTRS -> const impl HasAttrs for StmtKind::SUPPORTS_CUSTOM_INNER_ATTRS => bool @ 16:47-16:84
+        "#]],
+    );
+}

--- a/crates/engine/body-ir/src/tests/utils.rs
+++ b/crates/engine/body-ir/src/tests/utils.rs
@@ -571,6 +571,7 @@ impl TargetBodyIrSnapshot<'_> {
             ExprKind::RepeatArray {
                 initializer,
                 repeat,
+                ..
             } => {
                 if let Some(initializer) = initializer {
                     writeln!(dump, "{}initializer", indent(depth + 1))
@@ -981,6 +982,20 @@ impl TargetBodyIrSnapshot<'_> {
             Ty::Unit => "()".to_string(),
             Ty::Never => "!".to_string(),
             Ty::Primitive(primitive) => primitive.label().to_string(),
+            Ty::Tuple(fields) => {
+                let fields = fields
+                    .iter()
+                    .map(|ty| self.render_ty(ty))
+                    .collect::<Vec<_>>();
+                let suffix = if fields.len() == 1 { "," } else { "" };
+                format!("({}{suffix})", fields.join(", "))
+            }
+            Ty::Array { inner, len } => format!(
+                "[{}; {}]",
+                self.render_ty(inner),
+                len.as_deref().unwrap_or("<unknown>")
+            ),
+            Ty::Slice(inner) => format!("[{}]", self.render_ty(inner)),
             Ty::Syntax(ty) => format!("syntax {ty}"),
             Ty::Reference { mutability, inner } => {
                 format!("{}{}", mutability.render_prefix(), self.render_ty(inner))

--- a/crates/engine/body-ir/src/tests/utils.rs
+++ b/crates/engine/body-ir/src/tests/utils.rs
@@ -1032,6 +1032,19 @@ impl TargetBodyIrSnapshot<'_> {
             GenericArg::Type(ty) => self.render_ty(ty),
             GenericArg::Lifetime(lifetime) => lifetime.clone(),
             GenericArg::Const(value) => value.clone(),
+            GenericArg::FnTraitArgs { params, ret } => {
+                let params = params
+                    .iter()
+                    .map(|ty| self.render_ty(ty))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let mut text = format!("({params})");
+                if !matches!(ret.as_ref(), Ty::Unit) {
+                    text.push_str(" -> ");
+                    text.push_str(&self.render_ty(ret));
+                }
+                text
+            }
             GenericArg::AssocType { name, ty } => match ty {
                 Some(ty) => format!("{name} = {}", self.render_ty(ty)),
                 None => name.to_string(),

--- a/crates/engine/body-ir/src/tests/utils.rs
+++ b/crates/engine/body-ir/src/tests/utils.rs
@@ -16,7 +16,7 @@ use rg_ir_storage::ModuleOrigin;
 use rg_item_tree::FieldItem;
 use rg_package_store::PackageLoader;
 use rg_parse::{Package, ParseDb, Target};
-use rg_ty::{GenericArg, NominalTy, Ty};
+use rg_ty::{GenericArg, NominalTy, OpaqueTraitBound, Ty};
 
 pub(super) fn check_project_body_ir(fixture: &str, expect: Expect) {
     let db = BodyIrFixtureDb::build(fixture);
@@ -1005,6 +1005,14 @@ impl TargetBodyIrSnapshot<'_> {
             Ty::Reference { mutability, inner } => {
                 format!("{}{}", mutability.render_prefix(), self.render_ty(inner))
             }
+            Ty::Opaque { bounds } => {
+                let mut bounds = bounds
+                    .iter()
+                    .map(|bound| self.render_opaque_bound(bound))
+                    .collect::<Vec<_>>();
+                bounds.sort();
+                format!("impl {}", bounds.join(" + "))
+            }
             Ty::Nominal(types) => {
                 let mut types = types
                     .iter()
@@ -1023,6 +1031,14 @@ impl TargetBodyIrSnapshot<'_> {
             }
             Ty::Unknown => "<unknown>".to_string(),
         }
+    }
+
+    fn render_opaque_bound(&self, bound: &OpaqueTraitBound) -> String {
+        format!(
+            "{}{}",
+            self.render_trait_ref(bound.trait_ref),
+            self.render_generic_args(&bound.args)
+        )
     }
 
     fn render_body_nominal_ty(&self, ty: &NominalTy) -> String {

--- a/crates/engine/body-ir/src/tests/utils.rs
+++ b/crates/engine/body-ir/src/tests/utils.rs
@@ -928,8 +928,13 @@ impl TargetBodyIrSnapshot<'_> {
             ExprKind::Continue { label } => {
                 format!("continue{}", render_label_suffix(label.as_ref()))
             }
-            ExprKind::MethodCall { method_name, .. } => {
-                format!("method_call {method_name}")
+            ExprKind::MethodCall {
+                method_name,
+                generic_args,
+                ..
+            } => {
+                let generic_args = render_item_generic_args(generic_args);
+                format!("method_call {method_name}{generic_args}")
             }
             ExprKind::Field { field, .. } => {
                 let field = field
@@ -1522,6 +1527,20 @@ fn render_binding_list(bindings: &[BindingId]) -> String {
         .map(|binding| format!("v{}", binding.0))
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+fn render_item_generic_args(args: &[rg_item_tree::GenericArg]) -> String {
+    if args.is_empty() {
+        return String::new();
+    }
+
+    format!(
+        "<{}>",
+        args.iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
 }
 
 fn render_closure_param(param: &ClosureParamData) -> String {

--- a/crates/engine/body-ir/src/walk/mod.rs
+++ b/crates/engine/body-ir/src/walk/mod.rs
@@ -10,6 +10,6 @@ mod ty;
 
 pub(crate) use self::{
     pat::{PatWalkSite, walk_pat},
-    path::walk_body_path_type_refs,
+    path::{walk_body_path_type_refs, walk_generic_args_type_refs},
     ty::walk_type_ref_paths,
 };

--- a/crates/engine/body-ir/src/walk/path.rs
+++ b/crates/engine/body-ir/src/walk/path.rs
@@ -48,6 +48,12 @@ fn walk_segment_args_type_refs<'path>(
     for arg in args {
         match arg {
             GenericArg::Type(ty) => visit(ty),
+            GenericArg::FnTraitArgs { params, ret } => {
+                for param in params {
+                    visit(param);
+                }
+                visit(ret);
+            }
             GenericArg::AssocType { ty: Some(ty), .. } => visit(ty),
             GenericArg::Lifetime(_)
             | GenericArg::Const(_)

--- a/crates/engine/body-ir/src/walk/path.rs
+++ b/crates/engine/body-ir/src/walk/path.rs
@@ -45,20 +45,34 @@ fn walk_segment_args_type_refs<'path>(
         return;
     };
 
+    walk_generic_args_type_refs(args, visit);
+}
+
+pub(crate) fn walk_generic_args_type_refs<'path>(
+    args: &'path [GenericArg],
+    visit: &mut impl FnMut(&'path TypeRef),
+) {
     for arg in args {
-        match arg {
-            GenericArg::Type(ty) => visit(ty),
-            GenericArg::FnTraitArgs { params, ret } => {
-                for param in params {
-                    visit(param);
-                }
-                visit(ret);
+        walk_generic_arg_type_refs(arg, visit);
+    }
+}
+
+fn walk_generic_arg_type_refs<'path>(
+    arg: &'path GenericArg,
+    visit: &mut impl FnMut(&'path TypeRef),
+) {
+    match arg {
+        GenericArg::Type(ty) => visit(ty),
+        GenericArg::FnTraitArgs { params, ret } => {
+            for param in params {
+                visit(param);
             }
-            GenericArg::AssocType { ty: Some(ty), .. } => visit(ty),
-            GenericArg::Lifetime(_)
-            | GenericArg::Const(_)
-            | GenericArg::AssocType { ty: None, .. }
-            | GenericArg::Unsupported(_) => {}
+            visit(ret);
         }
+        GenericArg::AssocType { ty: Some(ty), .. } => visit(ty),
+        GenericArg::Lifetime(_)
+        | GenericArg::Const(_)
+        | GenericArg::AssocType { ty: None, .. }
+        | GenericArg::Unsupported(_) => {}
     }
 }

--- a/crates/engine/body-ir/src/walk/ty.rs
+++ b/crates/engine/body-ir/src/walk/ty.rs
@@ -13,6 +13,12 @@ pub(crate) fn walk_type_ref_paths<'ty>(ty: &'ty TypeRef, visit: &mut impl FnMut(
                 for arg in &segment.args {
                     match arg {
                         GenericArg::Type(ty) => walk_type_ref_paths(ty, visit),
+                        GenericArg::FnTraitArgs { params, ret } => {
+                            for param in params {
+                                walk_type_ref_paths(param, visit);
+                            }
+                            walk_type_ref_paths(ret, visit);
+                        }
                         GenericArg::AssocType { ty: Some(ty), .. } => {
                             walk_type_ref_paths(ty, visit);
                         }

--- a/crates/engine/def-map/src/build/finalize/mod.rs
+++ b/crates/engine/def-map/src/build/finalize/mod.rs
@@ -484,16 +484,46 @@ fn select_preludes(
         let interner = interners.package_mut(package_slot).with_context(|| {
             format!("while attempting to fetch name interner for package {package_slot}")
         })?;
-        let prelude_path = ImportPath::standard_prelude(workspace_package.edition, interner);
-
         // Each target resolves its edition prelude from its own crate root. Targets without a root
         // module are malformed enough that later phases will simply see no prelude.
         for (target_slot, state) in package_states.iter().enumerate() {
-            let Some(prelude_module) = PathResolver::new(&env)
-                .import_modules(state.target, state.root_module, &prelude_path)?
-                .into_iter()
-                .next()
-            else {
+            let mut prelude_module = None;
+
+            // Normal crates use `std` when available. No-std-shaped crates still need the same
+            // edition prelude, but rooted at `core`. The core crate itself has a crate-local
+            // `prelude` module, so resolve that shape relatively during this early pass.
+            // TODO: Parse crate-level `#![no_std]` and use it to select `core` prelude directly
+            // and avoid exposing `std` as an automatic extern root for that crate.
+            let prelude_paths = [
+                Some(ImportPath::standard_prelude(
+                    "std",
+                    workspace_package.edition,
+                    interner,
+                )),
+                Some(ImportPath::standard_prelude(
+                    "core",
+                    workspace_package.edition,
+                    interner,
+                )),
+                (workspace_package.name == "core").then(|| {
+                    ImportPath::crate_relative_standard_prelude(
+                        workspace_package.edition,
+                        interner,
+                    )
+                }),
+            ];
+
+            for prelude_path in prelude_paths.into_iter().flatten() {
+                prelude_module = PathResolver::new(&env)
+                    .import_modules(state.target, state.root_module, &prelude_path)?
+                    .into_iter()
+                    .next();
+                if prelude_module.is_some() {
+                    break;
+                }
+            }
+
+            let Some(prelude_module) = prelude_module else {
                 continue;
             };
 

--- a/crates/engine/def-map/src/build/finalize/mod.rs
+++ b/crates/engine/def-map/src/build/finalize/mod.rs
@@ -506,10 +506,7 @@ fn select_preludes(
                     interner,
                 )),
                 (workspace_package.name == "core").then(|| {
-                    ImportPath::crate_relative_standard_prelude(
-                        workspace_package.edition,
-                        interner,
-                    )
+                    ImportPath::crate_relative_standard_prelude(workspace_package.edition, interner)
                 }),
             ];
 

--- a/crates/engine/def-map/src/tests/path_resolution.rs
+++ b/crates/engine/def-map/src/tests/path_resolution.rs
@@ -271,6 +271,55 @@ pub mod prelude {
 }
 
 #[test]
+fn falls_back_to_core_prelude_when_std_is_unavailable() {
+    utils::check_project_path_resolution_with_sysroot(
+        r#"
+//- /Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct App;
+
+//- /sysroot/library/core/src/lib.rs
+extern crate self as core;
+
+pub mod marker {
+    pub struct CorePrelude;
+}
+
+pub mod prelude {
+    pub mod rust_2024 {
+        pub use crate::marker::CorePrelude;
+    }
+}
+
+pub mod child {
+    pub struct Child;
+}
+
+//- /sysroot/library/alloc/src/lib.rs
+pub struct Alloc;
+
+//- /sysroot/library/std/src/lib.rs
+pub mod prelude {
+    pub mod rust_2024 {}
+}
+"#,
+        &[PathResolutionQuery::lib(
+            "core",
+            "crate::child",
+            "CorePrelude",
+        )],
+        expect![[r#"
+            core [lib] crate::child resolves CorePrelude -> struct core[lib]::crate::marker::CorePrelude
+        "#]],
+    );
+}
+
+#[test]
 fn falls_back_to_extern_roots_when_wrong_namespace_bindings_match_first_segment() {
     utils::check_project_path_resolution(
         r#"

--- a/crates/engine/ir-model/Cargo.toml
+++ b/crates/engine/ir-model/Cargo.toml
@@ -18,6 +18,6 @@ rg_cfg_eval.workspace = true
 rg_memsize.workspace = true
 rg_parse.workspace = true
 rg_workspace.workspace = true
-rg_text.workspace = true
+rg_text = { workspace = true, features = ["memsize"] }
 rg_tt.workspace = true
 rg_wincode_utils.workspace = true

--- a/crates/engine/ir-model/src/items/type_ref.rs
+++ b/crates/engine/ir-model/src/items/type_ref.rs
@@ -334,6 +334,11 @@ impl TypePathSegment {
 impl fmt::Display for TypePathSegment {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name)?;
+        if let [GenericArg::FnTraitArgs { params, ret }] = self.args.as_slice() {
+            write_fn_trait_args(f, params, ret)?;
+            return Ok(());
+        }
+
         if !self.args.is_empty() {
             write!(f, "<")?;
             for (idx, arg) in self.args.iter().enumerate() {
@@ -355,6 +360,12 @@ pub enum GenericArg {
     Type(#[wincode(with = "rg_wincode_utils::WincodeDynamic<TypeRef>")] TypeRef),
     Lifetime(String),
     Const(String),
+    FnTraitArgs {
+        #[wincode(with = "rg_wincode_utils::WincodeDynamic<Vec<TypeRef>>")]
+        params: Vec<TypeRef>,
+        #[wincode(with = "rg_wincode_utils::WincodeDynamic<Box<TypeRef>>")]
+        ret: Box<TypeRef>,
+    },
     AssocType {
         name: Name,
         #[wincode(with = "rg_wincode_utils::WincodeDynamic<Option<TypeRef>>")]
@@ -368,9 +379,11 @@ impl GenericArg {
     pub fn type_ref(&self) -> Option<&TypeRef> {
         match self {
             Self::Type(ty) => Some(ty),
-            Self::Lifetime(_) | Self::Const(_) | Self::AssocType { .. } | Self::Unsupported(_) => {
-                None
-            }
+            Self::Lifetime(_)
+            | Self::Const(_)
+            | Self::FnTraitArgs { .. }
+            | Self::AssocType { .. }
+            | Self::Unsupported(_) => None,
         }
     }
 
@@ -381,6 +394,13 @@ impl GenericArg {
             Self::AssocType { ty, .. } => {
                 ty.as_ref().is_some_and(|ty| ty.mentions_type_param(params))
             }
+            Self::FnTraitArgs {
+                params: fn_params,
+                ret,
+            } => {
+                fn_params.iter().any(|ty| ty.mentions_type_param(params))
+                    || ret.mentions_type_param(params)
+            }
             Self::Lifetime(_) | Self::Const(_) | Self::Unsupported(_) => false,
         }
     }
@@ -390,6 +410,13 @@ impl GenericArg {
             Self::Type(ty) => ty.shrink_to_fit(),
             Self::Lifetime(lifetime) | Self::Const(lifetime) | Self::Unsupported(lifetime) => {
                 lifetime.shrink_to_fit();
+            }
+            Self::FnTraitArgs { params, ret } => {
+                params.shrink_to_fit();
+                for param in params {
+                    param.shrink_to_fit();
+                }
+                ret.shrink_to_fit();
             }
             Self::AssocType { name, ty } => {
                 name.shrink_to_fit();
@@ -411,9 +438,29 @@ impl fmt::Display for GenericArg {
                 Some(ty) => write!(f, "{name} = {ty}"),
                 None => write!(f, "{name}"),
             },
+            Self::FnTraitArgs { params, ret } => write_fn_trait_args(f, params, ret),
             Self::Unsupported(text) => write!(f, "<unsupported:{text}>"),
         }
     }
+}
+
+fn write_fn_trait_args(
+    f: &mut fmt::Formatter<'_>,
+    params: &[TypeRef],
+    ret: &TypeRef,
+) -> fmt::Result {
+    write!(f, "(")?;
+    for (idx, param) in params.iter().enumerate() {
+        if idx > 0 {
+            write!(f, ", ")?;
+        }
+        write!(f, "{param}")?;
+    }
+    write!(f, ")")?;
+    if !matches!(ret, TypeRef::Unit) {
+        write!(f, " -> {ret}")?;
+    }
+    Ok(())
 }
 
 #[derive(

--- a/crates/engine/ir-model/src/items/type_ref.rs
+++ b/crates/engine/ir-model/src/items/type_ref.rs
@@ -360,6 +360,7 @@ pub enum GenericArg {
     Type(#[wincode(with = "rg_wincode_utils::WincodeDynamic<TypeRef>")] TypeRef),
     Lifetime(String),
     Const(String),
+    /// Parenthesized argument syntax on function-trait paths, such as `FnOnce(T) -> R`.
     FnTraitArgs {
         #[wincode(with = "rg_wincode_utils::WincodeDynamic<Vec<TypeRef>>")]
         params: Vec<TypeRef>,

--- a/crates/engine/ir-storage/src/def_map/import.rs
+++ b/crates/engine/ir-storage/src/def_map/import.rs
@@ -133,11 +133,28 @@ impl ImportPath {
         }
     }
 
-    pub fn standard_prelude(edition: RustEdition, interner: &mut NameInterner) -> Self {
+    pub fn standard_prelude(
+        crate_name: &'static str,
+        edition: RustEdition,
+        interner: &mut NameInterner,
+    ) -> Self {
         Self {
             absolute: true,
             segments: vec![
-                PathSegment::Name(interner.intern("std")),
+                PathSegment::Name(interner.intern(crate_name)),
+                PathSegment::Name(interner.intern("prelude")),
+                PathSegment::Name(interner.intern(edition.prelude_module())),
+            ],
+        }
+    }
+
+    pub fn crate_relative_standard_prelude(
+        edition: RustEdition,
+        interner: &mut NameInterner,
+    ) -> Self {
+        Self {
+            absolute: false,
+            segments: vec![
                 PathSegment::Name(interner.intern("prelude")),
                 PathSegment::Name(interner.intern(edition.prelude_module())),
             ],

--- a/crates/engine/ir-storage/src/item/lookup_index.rs
+++ b/crates/engine/ir-storage/src/item/lookup_index.rs
@@ -18,7 +18,9 @@ pub struct ItemLookupIndex {
     // whose already-resolved `Self` type mentions that receiver, instead of re-scanning all impls.
     inherent_impls_by_type: HashMap<TypeDefRef, Vec<ImplRef>>,
     inherent_functions_by_type_and_name: HashMap<TypeDefRef, HashMap<Name, Vec<FunctionRef>>>,
+    structural_inherent_impls: Vec<ImplRef>,
     trait_impls_by_type: HashMap<TypeDefRef, Vec<TraitImplRef>>,
+    trait_impls_by_trait: HashMap<TraitRef, Vec<TraitImplRef>>,
     // Trait impl lookup produces trait identities first; this cache then expands each trait into
     // its associated function declarations without reopening the trait item every time.
     trait_functions_by_trait: HashMap<TraitRef, Vec<FunctionRef>>,
@@ -76,6 +78,13 @@ impl ItemLookupIndex {
             // resolved self type, and later applicability checks still decide whether candidates fit.
             for (impl_ref, impl_data) in store.impls_with_refs() {
                 if impl_data.trait_ref.is_none() {
+                    if impl_data.resolved_self_tys.is_empty() {
+                        // Inherent impls for shaped builtin types, such as `impl<T> [T]`, do not
+                        // have a nominal receiver key. Keep them in a small side list so structural
+                        // method lookup does not scan every visible impl.
+                        push_unique(&mut index.structural_inherent_impls, impl_ref);
+                    }
+
                     for self_ty in &impl_data.resolved_self_tys {
                         push_unique(
                             index.inherent_impls_by_type.entry(*self_ty).or_default(),
@@ -105,15 +114,24 @@ impl ItemLookupIndex {
                         }
                     }
                 } else {
-                    for self_ty in &impl_data.resolved_self_tys {
-                        let trait_impls = index.trait_impls_by_type.entry(*self_ty).or_default();
-                        for trait_ref in &impl_data.resolved_trait_refs {
+                    for trait_ref in &impl_data.resolved_trait_refs {
+                        let trait_impl = TraitImplRef {
+                            impl_ref,
+                            trait_ref: *trait_ref,
+                        };
+
+                        // Structural impls such as `impl<T> IntoIterator for &[T]` may not have a
+                        // nominal receiver key, but iterator-like queries can still start from the
+                        // canonical trait identity and ask which impls provide it.
+                        push_unique(
+                            index.trait_impls_by_trait.entry(*trait_ref).or_default(),
+                            trait_impl,
+                        );
+
+                        for self_ty in &impl_data.resolved_self_tys {
                             push_unique(
-                                trait_impls,
-                                TraitImplRef {
-                                    impl_ref,
-                                    trait_ref: *trait_ref,
-                                },
+                                index.trait_impls_by_type.entry(*self_ty).or_default(),
+                                trait_impl,
                             );
                         }
                     }
@@ -176,12 +194,30 @@ impl ItemLookupIndex {
             .unwrap_or(&[])
     }
 
+    /// Returns inherent impls whose `Self` type needs structural matching instead of a type key.
+    pub fn structural_inherent_impls(&self) -> &[ImplRef] {
+        &self.structural_inherent_impls
+    }
+
     /// Returns trait impl candidates indexed for a receiver type.
     pub fn trait_impls_for_type(&self, ty: TypeDefRef) -> &[TraitImplRef] {
         self.trait_impls_by_type
             .get(&ty)
             .map(Vec::as_slice)
             .unwrap_or(&[])
+    }
+
+    /// Returns trait impl candidates indexed by the implemented trait.
+    pub fn trait_impls_for_trait(&self, trait_ref: TraitRef) -> Option<&[TraitImplRef]> {
+        if let Some(trait_impls) = self.trait_impls_by_trait.get(&trait_ref) {
+            return Some(trait_impls);
+        }
+
+        // `Some(&[])` means the trait is visible and indexed, but no visible impl provides it.
+        // `None` means the caller may be looking across a context this index did not cover.
+        self.trait_functions_by_trait
+            .contains_key(&trait_ref)
+            .then_some(&[])
     }
 
     /// Returns trait-declared functions if the trait was visible when the index was built.

--- a/crates/engine/ir-storage/src/item/query/target.rs
+++ b/crates/engine/ir-storage/src/item/query/target.rs
@@ -1,9 +1,11 @@
 //! Target-scoped item lookup.
 
-use rg_ir_model::{DefMapRef, FunctionRef, ImplRef, TargetRef, TraitImplRef, TraitRef, TypeDefRef};
+use rg_ir_model::{
+    DefMapRef, FunctionRef, ImplRef, ModuleRef, TargetRef, TraitImplRef, TraitRef, TypeDefRef,
+};
 
 use super::{ItemStoreQuery, ItemStoreSource};
-use crate::{DefMapQuery, DefMapSource, ItemStore, push_unique};
+use crate::{DefMapQuery, DefMapSource, ItemStore, TargetResolutionEnv, push_unique};
 
 /// Item queries that need a Rust language visibility context.
 ///
@@ -31,6 +33,11 @@ where
 
     pub fn items(&self) -> &ItemStoreQuery<'item, I> {
         &self.items
+    }
+
+    /// Returns the root module of the target where lookup is performed.
+    pub fn use_site_root_module(&self) -> Result<Option<ModuleRef>, I::Error> {
+        self.def_maps.root_module(self.use_site)
     }
 
     /// Returns stores visible from this query's use-site target.

--- a/crates/engine/ir-storage/src/item/query/target.rs
+++ b/crates/engine/ir-storage/src/item/query/target.rs
@@ -77,6 +77,19 @@ where
         Ok(impls)
     }
 
+    /// Searches all visible inherent impls, including impls whose `Self` type is structural.
+    pub fn inherent_impls(&self) -> Result<Vec<ImplRef>, I::Error> {
+        let mut impls = Vec::new();
+        for store in self.visible_stores()? {
+            for (impl_ref, data) in store.impls_with_refs() {
+                if data.trait_ref.is_none() {
+                    push_unique(&mut impls, impl_ref);
+                }
+            }
+        }
+        Ok(impls)
+    }
+
     /// Collects inherent functions for callers that care about callable members, not impl blocks.
     pub fn inherent_functions_for_type(
         &self,

--- a/crates/engine/ir-storage/src/item/query/target.rs
+++ b/crates/engine/ir-storage/src/item/query/target.rs
@@ -70,6 +70,24 @@ where
         Ok(impls)
     }
 
+    /// Searches visible impls for a trait ref and returns the trait identity used by each impl.
+    pub fn trait_impls_for_trait(
+        &self,
+        trait_ref: TraitRef,
+    ) -> Result<Vec<TraitImplRef>, I::Error> {
+        let mut trait_impls = Vec::new();
+        for impl_ref in self.impls_for_trait(trait_ref)? {
+            push_unique(
+                &mut trait_impls,
+                TraitImplRef {
+                    impl_ref,
+                    trait_ref,
+                },
+            );
+        }
+        Ok(trait_impls)
+    }
+
     /// Narrows type impl lookup to inherent impls, which is the path used for method completion.
     pub fn inherent_impls_for_type(&self, ty: TypeDefRef) -> Result<Vec<ImplRef>, I::Error> {
         let mut impls = Vec::new();

--- a/crates/engine/ir-view/src/display/ty_label.rs
+++ b/crates/engine/ir-view/src/display/ty_label.rs
@@ -73,6 +73,22 @@ impl<'a, 'db> TypeRenderer<'a, 'db> {
             GenericArg::Type(ty) => Ok(self.render(ty)?.unwrap_or_else(|| "_".to_string())),
             GenericArg::Lifetime(lifetime) => Ok(lifetime.clone()),
             GenericArg::Const(value) => Ok(value.clone()),
+            GenericArg::FnTraitArgs { params, ret } => {
+                let params = params
+                    .iter()
+                    .map(|ty| {
+                        self.render(ty)
+                            .map(|ty| ty.unwrap_or_else(|| "_".to_string()))
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()?
+                    .join(", ");
+                let mut text = format!("({params})");
+                if !matches!(ret.as_ref(), Ty::Unit) {
+                    text.push_str(" -> ");
+                    text.push_str(&self.render(ret)?.unwrap_or_else(|| "_".to_string()));
+                }
+                Ok(text)
+            }
             GenericArg::AssocType { name, ty } => match ty {
                 Some(ty) => Ok(format!(
                     "{name} = {}",

--- a/crates/engine/ir-view/src/display/ty_label.rs
+++ b/crates/engine/ir-view/src/display/ty_label.rs
@@ -5,9 +5,9 @@
 //! are useful while reading code.
 
 use rg_ir_storage::ItemStoreQuery;
-use rg_ty::{GenericArg, NominalTy, Ty};
+use rg_ty::{GenericArg, NominalTy, OpaqueTraitBound, Ty};
 
-use crate::IndexedViewDb;
+use crate::{IndexedViewDb, item::path::PathView};
 
 pub struct TypeRenderer<'a, 'db>(&'a IndexedViewDb<'db>);
 
@@ -45,6 +45,13 @@ impl<'a, 'db> TypeRenderer<'a, 'db> {
             Ty::Reference { mutability, inner } => Ok(self
                 .render(inner)?
                 .map(|inner| format!("{}{inner}", mutability.render_prefix()))),
+            Ty::Opaque { bounds } => {
+                let bounds = bounds
+                    .iter()
+                    .map(|bound| self.render_opaque_bound(bound))
+                    .collect::<anyhow::Result<Vec<_>>>()?;
+                Ok((!bounds.is_empty()).then(|| format!("impl {}", bounds.join(" + "))))
+            }
             Ty::Nominal(types) | Ty::SelfTy(types) => {
                 let mut labels = Vec::new();
                 for ty in types {
@@ -73,6 +80,16 @@ impl<'a, 'db> TypeRenderer<'a, 'db> {
             "{name}{}",
             self.render_generic_args(&ty.args)?
         )))
+    }
+
+    fn render_opaque_bound(&self, bound: &OpaqueTraitBound) -> anyhow::Result<String> {
+        let trait_path = PathView::new(self.0)
+            .trait_path(bound.trait_ref)?
+            .unwrap_or_else(|| "<trait>".to_string());
+        Ok(format!(
+            "{trait_path}{}",
+            self.render_generic_args(&bound.args)?
+        ))
     }
 
     fn render_generic_args(&self, args: &[GenericArg]) -> anyhow::Result<String> {

--- a/crates/engine/ir-view/src/display/ty_label.rs
+++ b/crates/engine/ir-view/src/display/ty_label.rs
@@ -21,6 +21,26 @@ impl<'a, 'db> TypeRenderer<'a, 'db> {
             Ty::Unit => Ok(Some("()".to_string())),
             Ty::Never => Ok(Some("!".to_string())),
             Ty::Primitive(primitive) => Ok(Some(primitive.label().to_string())),
+            Ty::Tuple(fields) => {
+                let fields = fields
+                    .iter()
+                    .map(|ty| {
+                        self.render(ty)
+                            .map(|ty| ty.unwrap_or_else(|| "_".to_string()))
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()?;
+                let suffix = if fields.len() == 1 { "," } else { "" };
+                Ok(Some(format!("({}{suffix})", fields.join(", "))))
+            }
+            Ty::Array { inner, len } => Ok(Some(format!(
+                "[{}; {}]",
+                self.render(inner)?.unwrap_or_else(|| "_".to_string()),
+                len.as_deref().unwrap_or("<unknown>")
+            ))),
+            Ty::Slice(inner) => Ok(Some(format!(
+                "[{}]",
+                self.render(inner)?.unwrap_or_else(|| "_".to_string())
+            ))),
             Ty::Syntax(ty) => Ok(Some(ty.to_string())),
             Ty::Reference { mutability, inner } => Ok(self
                 .render(inner)?

--- a/crates/engine/item-tree/src/item/mod.rs
+++ b/crates/engine/item-tree/src/item/mod.rs
@@ -34,10 +34,6 @@ pub trait MaybeFromAst<Mode = ()> {
 }
 
 fn normalized_syntax(node: &impl rg_syntax::AstNode) -> String {
-    node.syntax()
-        .text()
-        .to_string()
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
+    // TODO: Either remove completely or at least re-export instead.
+    rg_syntax::utils::normalized_syntax_text(node)
 }

--- a/crates/engine/item-tree/src/item/type_ref.rs
+++ b/crates/engine/item-tree/src/item/type_ref.rs
@@ -163,9 +163,24 @@ fn type_path_segment_from_ast(
     }
 
     if let Some(parenthesized_args) = segment.parenthesized_arg_list() {
-        args.push(GenericArg::Unsupported(normalized_syntax(
-            &parenthesized_args,
-        )));
+        let params = parenthesized_args
+            .type_args()
+            .map(|arg| {
+                arg.ty()
+                    .map(|ty| TypeRef::from_ast(&ty, (line_index, &mut *interner)))
+                    .unwrap_or_else(|| TypeRef::unknown_from_text(normalized_syntax(&arg)))
+            })
+            .collect();
+        let ret = segment
+            .ret_type()
+            .and_then(|ret_ty| ret_ty.ty())
+            .map(|ty| TypeRef::from_ast(&ty, (line_index, &mut *interner)))
+            .unwrap_or(TypeRef::Unit);
+
+        args.push(GenericArg::FnTraitArgs {
+            params,
+            ret: Box::new(ret),
+        });
     }
 
     TypePathSegment {

--- a/crates/engine/semantic-ir/src/cursor.rs
+++ b/crates/engine/semantic-ir/src/cursor.rs
@@ -471,6 +471,12 @@ impl SignatureCursorScanner<'_, '_> {
     fn push_generic_arg(&mut self, context: TypePathContext, arg: &GenericArg, file_id: FileId) {
         match arg {
             GenericArg::Type(ty) => self.push_type_ref(context, ty, file_id),
+            GenericArg::FnTraitArgs { params, ret } => {
+                for param in params {
+                    self.push_type_ref(context, param, file_id);
+                }
+                self.push_type_ref(context, ret, file_id);
+            }
             GenericArg::AssocType { ty: Some(ty), .. } => {
                 self.push_type_ref(context, ty, file_id);
             }

--- a/crates/engine/semantic-ir/src/tests/mod.rs
+++ b/crates/engine/semantic-ir/src/tests/mod.rs
@@ -2,7 +2,10 @@ mod utils;
 
 use expect_test::expect;
 
-use self::utils::{SemanticQuery, check_project_semantic_ir, check_project_semantic_queries};
+use self::utils::{
+    SemanticQuery, check_project_semantic_ir, check_project_semantic_queries,
+    check_project_semantic_queries_with_sysroot,
+};
 
 #[test]
 fn dumps_semantic_ir_signatures() {
@@ -220,6 +223,126 @@ impl ImportedTrait for Local {
             - fn trait dep[lib]::crate::ExternalTrait::required
             trait impl functions
             - fn impl ImportedTrait for Local::required
+        "#]],
+    );
+}
+
+#[test]
+fn resolves_core_prelude_trait_impl_headers() {
+    check_project_semantic_queries_with_sysroot(
+        r#"
+//- /Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct App;
+
+//- /sysroot/library/core/src/lib.rs
+extern crate self as core;
+
+pub mod marker {
+    pub trait Marker {
+        fn mark(&self);
+    }
+}
+
+pub mod prelude {
+    pub mod rust_2024 {
+        pub use crate::marker::Marker;
+    }
+}
+
+pub struct CoreType;
+
+impl Marker for CoreType {
+    fn mark(&self) {}
+}
+
+//- /sysroot/library/alloc/src/lib.rs
+pub struct Alloc;
+
+//- /sysroot/library/std/src/lib.rs
+pub mod prelude {
+    pub mod rust_2024 {}
+}
+"#,
+        &[SemanticQuery::lib("core", "CoreType")],
+        expect![[r#"
+            query core [lib] crate resolves CoreType -> struct core[lib]::crate::CoreType
+            impls
+            - impl Marker for CoreType
+            trait impls
+            - impl Marker for CoreType => trait core[lib]::crate::marker::Marker
+            traits
+            - trait core[lib]::crate::marker::Marker
+            inherent functions
+            - <none>
+            trait functions
+            - fn trait core[lib]::crate::marker::Marker::mark
+            trait impl functions
+            - fn impl Marker for CoreType::mark
+        "#]],
+    );
+}
+
+#[test]
+fn resolves_alloc_impl_headers_through_core_prelude() {
+    check_project_semantic_queries_with_sysroot(
+        r#"
+//- /Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct App;
+
+//- /sysroot/library/core/src/lib.rs
+extern crate self as core;
+
+pub mod marker {
+    pub trait Marker {
+        fn mark(&self);
+    }
+}
+
+pub mod prelude {
+    pub mod rust_2024 {
+        pub use crate::marker::Marker;
+    }
+}
+
+//- /sysroot/library/alloc/src/lib.rs
+pub struct AllocType;
+
+impl Marker for AllocType {
+    fn mark(&self) {}
+}
+
+//- /sysroot/library/std/src/lib.rs
+pub mod prelude {
+    pub mod rust_2024 {}
+}
+"#,
+        &[SemanticQuery::lib("alloc", "AllocType")],
+        expect![[r#"
+            query alloc [lib] crate resolves AllocType -> struct alloc[lib]::crate::AllocType
+            impls
+            - impl Marker for AllocType
+            trait impls
+            - impl Marker for AllocType => trait core[lib]::crate::marker::Marker
+            traits
+            - trait core[lib]::crate::marker::Marker
+            inherent functions
+            - <none>
+            trait functions
+            - fn trait core[lib]::crate::marker::Marker::mark
+            trait impl functions
+            - fn impl Marker for AllocType::mark
         "#]],
     );
 }

--- a/crates/engine/semantic-ir/src/tests/utils.rs
+++ b/crates/engine/semantic-ir/src/tests/utils.rs
@@ -34,6 +34,17 @@ pub(super) fn check_project_semantic_queries(
     expect.assert_eq(&actual);
 }
 
+pub(super) fn check_project_semantic_queries_with_sysroot(
+    fixture: &str,
+    queries: &[SemanticQuery],
+    expect: Expect,
+) {
+    let db = SemanticIrFixtureDb::build_with_sysroot(fixture);
+    let actual = ProjectSemanticQuerySnapshot::new(&db, queries).render();
+    let actual = format!("{}\n", actual.trim_end());
+    expect.assert_eq(&actual);
+}
+
 pub(super) struct SemanticQuery {
     package_name: &'static str,
     target_kind: TargetKind,

--- a/crates/engine/syntax/src/tests.rs
+++ b/crates/engine/syntax/src/tests.rs
@@ -10,7 +10,12 @@ use rayon::prelude::*;
 use stdx::format_to_acc;
 use test_utils::{bench, bench_fixture, project_root};
 
-use crate::{AstNode, SourceFile, SyntaxError, ast, fuzz};
+use crate::{
+    AstNode, SourceFile, SyntaxError,
+    ast::{self, ArrayExprKind},
+    fuzz,
+    utils::normalized_syntax_text,
+};
 
 #[test]
 fn parse_smoke_test() {
@@ -23,6 +28,31 @@ fn main() {
     let parse = SourceFile::parse(code, Edition::CURRENT);
     // eprintln!("{:#?}", parse.syntax_node());
     assert!(parse.ok().is_ok());
+}
+
+#[test]
+fn normalized_syntax_text_preserves_non_trivia_tokens() {
+    let source = r#"
+fn main() {
+    let _ = [0; "a  b".len()
+        + 1];
+}
+    "#;
+    let file = SourceFile::parse(source, Edition::CURRENT).tree();
+    let array = file
+        .syntax()
+        .descendants()
+        .find_map(ast::ArrayExpr::cast)
+        .expect("fixture should contain a repeat array expression");
+    let ArrayExprKind::Repeat {
+        repeat: Some(repeat),
+        ..
+    } = array.kind()
+    else {
+        panic!("fixture array should use repeat syntax");
+    };
+
+    assert_eq!(normalized_syntax_text(&repeat), r#""a  b".len() + 1"#);
 }
 
 #[test]

--- a/crates/engine/syntax/src/utils.rs
+++ b/crates/engine/syntax/src/utils.rs
@@ -1,9 +1,34 @@
 //! A set of utils methods to reuse on other abstraction levels
 
-use crate::SyntaxKind;
+use crate::{AstNode, SyntaxKind};
 
 #[inline]
 pub fn is_raw_identifier(name: &str, edition: parser::Edition) -> bool {
     let is_keyword = SyntaxKind::from_keyword(name, edition).is_some();
     is_keyword && !matches!(name, "self" | "crate" | "super" | "Self")
+}
+
+/// Compacts syntax by normalizing trivia while preserving each non-trivia token exactly.
+pub fn normalized_syntax_text(node: &impl AstNode) -> String {
+    let mut text = String::new();
+    let mut pending_trivia = false;
+
+    for token in node
+        .syntax()
+        .descendants_with_tokens()
+        .filter_map(|it| it.into_token())
+    {
+        if token.kind().is_trivia() {
+            pending_trivia = !text.is_empty();
+            continue;
+        }
+
+        if pending_trivia {
+            text.push(' ');
+            pending_trivia = false;
+        }
+        text.push_str(token.text());
+    }
+
+    text
 }

--- a/crates/engine/ty/src/associated_type.rs
+++ b/crates/engine/ty/src/associated_type.rs
@@ -1,0 +1,193 @@
+//! Shared projection for associated types declared by trait impls.
+//!
+//! This is intentionally much smaller than a trait solver: callers first decide that an impl is a
+//! relevant candidate, then this helper reads a named associated type from that impl and resolves it
+//! with the substitutions supplied by `ImplMatcher`.
+
+use rg_ir_model::{
+    AssocItemId, TraitImplRef, TraitRef, TypeAliasRef, TypePathResolution, hir::items::ImplData,
+};
+use rg_ir_storage::{DefMapSource, ItemStoreSource, Path, TargetItemQuery, TypePathContext};
+
+use crate::{GenericArg, ItemPathQuery, OpaqueTraitBound, Ty, TypeSubst};
+
+pub(crate) struct AssociatedTypeProjector<'a, 'query, D, I> {
+    item_paths: &'a ItemPathQuery<'query, D, I>,
+    target_items: &'a TargetItemQuery<'query, D, I>,
+}
+
+impl<'a, 'query, D, I> AssociatedTypeProjector<'a, 'query, D, I>
+where
+    D: DefMapSource,
+    I: ItemStoreSource<'query, Error = D::Error>,
+{
+    pub(crate) fn new(
+        item_paths: &'a ItemPathQuery<'query, D, I>,
+        target_items: &'a TargetItemQuery<'query, D, I>,
+    ) -> Self {
+        Self {
+            item_paths,
+            target_items,
+        }
+    }
+
+    pub(crate) fn trait_impl_resolves_to_path(
+        &self,
+        trait_impl: TraitImplRef,
+        context: TypePathContext,
+        trait_path: &Path,
+    ) -> Result<bool, D::Error> {
+        Ok(self
+            .trait_refs_for_path(context, trait_path)?
+            .contains(&trait_impl.trait_ref))
+    }
+
+    pub(crate) fn trait_refs_for_path(
+        &self,
+        context: TypePathContext,
+        trait_path: &Path,
+    ) -> Result<Vec<TraitRef>, D::Error> {
+        let TypePathResolution::Traits(traits) =
+            self.item_paths.resolve_type_path(context, trait_path)?
+        else {
+            return Ok(Vec::new());
+        };
+        Ok(traits)
+    }
+
+    pub(crate) fn trait_refs_for_path_from_impl_and_use_site(
+        &self,
+        impl_data: &ImplData,
+        trait_path: &Path,
+    ) -> Result<Vec<TraitRef>, D::Error> {
+        let mut traits = Vec::new();
+
+        // Impls written outside `core` can resolve `::core::path::Trait` from their own module.
+        // Impls written inside the core crate itself need the lookup target's extern-root view
+        // instead, because a fixture package may not name itself `core` internally.
+        let impl_context = TypePathContext {
+            module: impl_data.owner,
+            impl_ref: None,
+        };
+        self.push_trait_refs_for_path(impl_context, trait_path, &mut traits)?;
+
+        if let Some(use_site_root) = self.target_items.use_site_root_module()? {
+            self.push_trait_refs_for_path(
+                TypePathContext {
+                    module: use_site_root,
+                    impl_ref: None,
+                },
+                trait_path,
+                &mut traits,
+            )?;
+        }
+
+        Ok(traits)
+    }
+
+    pub(crate) fn trait_refs_for_path_from_use_site(
+        &self,
+        trait_path: &Path,
+    ) -> Result<Vec<TraitRef>, D::Error> {
+        let mut traits = Vec::new();
+        let Some(use_site_root) = self.target_items.use_site_root_module()? else {
+            return Ok(traits);
+        };
+
+        self.push_trait_refs_for_path(
+            TypePathContext {
+                module: use_site_root,
+                impl_ref: None,
+            },
+            trait_path,
+            &mut traits,
+        )?;
+        Ok(traits)
+    }
+
+    fn push_trait_refs_for_path(
+        &self,
+        context: TypePathContext,
+        trait_path: &Path,
+        traits: &mut Vec<TraitRef>,
+    ) -> Result<(), D::Error> {
+        for trait_ref in self.trait_refs_for_path(context, trait_path)? {
+            push_unique(traits, trait_ref);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn associated_type_from_impl(
+        &self,
+        trait_impl: TraitImplRef,
+        impl_data: &ImplData,
+        assoc_name: &str,
+        subst: &TypeSubst,
+    ) -> Result<Option<Ty>, D::Error> {
+        let item_query = self.item_paths.items();
+        for item in &impl_data.items {
+            let AssocItemId::TypeAlias(type_alias_id) = item else {
+                continue;
+            };
+            let type_alias_ref = TypeAliasRef {
+                origin: trait_impl.impl_ref.origin,
+                id: *type_alias_id,
+            };
+            let Some(type_alias_data) = item_query.type_alias_data(type_alias_ref)? else {
+                continue;
+            };
+            if type_alias_data.name.as_str() != assoc_name {
+                continue;
+            }
+            let Some(aliased_ty) = type_alias_data.signature.aliased_ty() else {
+                continue;
+            };
+
+            let context = TypePathContext {
+                module: impl_data.owner,
+                impl_ref: Some(trait_impl.impl_ref),
+            };
+            let ty = self.item_paths.resolve_type_ref(
+                aliased_ty,
+                context,
+                Ty::syntax(aliased_ty.clone()),
+                subst,
+            )?;
+            return Ok(ty.is_projectable().then_some(ty));
+        }
+
+        Ok(None)
+    }
+
+    pub(crate) fn push_associated_types_from_opaque_bounds(
+        &self,
+        candidates: &mut Vec<Ty>,
+        bounds: &[OpaqueTraitBound],
+        canonical_traits: &[TraitRef],
+        assoc_name: &str,
+    ) {
+        for bound in bounds {
+            if !canonical_traits.contains(&bound.trait_ref) {
+                continue;
+            }
+
+            // Opaque types expose only their declared bounds. Associated type equalities such as
+            // `impl Iterator<Item = User>` are precise facts even though the hidden concrete type
+            // remains unknown.
+            for arg in &bound.args {
+                let GenericArg::AssocType { name, ty: Some(ty) } = arg else {
+                    continue;
+                };
+                if name.as_str() == assoc_name && ty.is_projectable() {
+                    push_unique(candidates, (**ty).clone());
+                }
+            }
+        }
+    }
+}
+
+fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
+    if !items.contains(&item) {
+        items.push(item);
+    }
+}

--- a/crates/engine/ty/src/autoderef.rs
+++ b/crates/engine/ty/src/autoderef.rs
@@ -110,6 +110,10 @@ impl AutoderefMode {
     fn allows_trait_deref(self) -> bool {
         matches!(self, Self::FieldLookup | Self::MethodReceiver)
     }
+
+    fn allows_array_to_slice_adjustment(self) -> bool {
+        matches!(self, Self::MethodReceiver)
+    }
 }
 
 /// One adjusted candidate type produced by `Autoderef`.
@@ -195,6 +199,15 @@ impl<'ty> PendingAutoderefTy<'ty> {
             Self::Owned(_) => None,
         }
     }
+
+    fn array_to_slice_adjustment(&self) -> Option<Self> {
+        match self.as_ref() {
+            // Array-to-slice is a builtin receiver adjustment, not a trait-backed deref. Returning
+            // an owned slice candidate lets method lookup reuse ordinary `impl<T> [T]` handling.
+            Ty::Array { inner, .. } => Some(Self::Owned(Ty::slice((**inner).clone()))),
+            _ => None,
+        }
+    }
 }
 
 impl<'query, 'ty, D, I> Iterator for AutoderefCandidates<'query, 'ty, D, I>
@@ -215,6 +228,14 @@ where
                             ty: inner,
                             depth: candidate.depth + 1,
                             mutability: Some(mutability),
+                        });
+                    } else if mode.allows_array_to_slice_adjustment()
+                        && let Some(slice) = candidate.ty.array_to_slice_adjustment()
+                    {
+                        pending.push_back(PendingAutoderefCandidate {
+                            ty: slice,
+                            depth: candidate.depth + 1,
+                            mutability: candidate.mutability,
                         });
                     } else if mode.allows_trait_deref() {
                         match self.autoderef.deref_targets(candidate.ty.as_ref()) {

--- a/crates/engine/ty/src/call_arg.rs
+++ b/crates/engine/ty/src/call_arg.rs
@@ -1,0 +1,185 @@
+use rg_ir_model::items::{GenericParams, Mutability, ParamItem, TypeRef};
+use rg_text::Name;
+
+use crate::{RefMutability, Ty, TypeSubst};
+
+#[derive(Debug, Clone, Copy)]
+pub enum CallArgMapping {
+    /// The written call args line up with signature params from the beginning.
+    FunctionCall,
+    /// Method-call syntax stores the receiver separately, so written args start after `self`.
+    MethodCall,
+}
+
+impl CallArgMapping {
+    fn first_param_idx(self) -> usize {
+        match self {
+            Self::FunctionCall => 0,
+            Self::MethodCall => 1,
+        }
+    }
+}
+
+/// Infers direct function-generic substitutions from already-known call argument types.
+pub struct CallArgInference<'signature, 'arg> {
+    generics: Option<&'signature GenericParams>,
+    params: &'signature [ParamItem],
+    arg_tys: &'arg [Ty],
+    arg_mapping: CallArgMapping,
+    existing_subst: &'arg TypeSubst,
+}
+
+impl<'signature, 'arg> CallArgInference<'signature, 'arg> {
+    pub fn new(
+        generics: Option<&'signature GenericParams>,
+        params: &'signature [ParamItem],
+        arg_tys: &'arg [Ty],
+        arg_mapping: CallArgMapping,
+        existing_subst: &'arg TypeSubst,
+    ) -> Self {
+        Self {
+            generics,
+            params,
+            arg_tys,
+            arg_mapping,
+            existing_subst,
+        }
+    }
+
+    pub fn infer(&self) -> TypeSubst {
+        let Some(generics) = self.generics else {
+            return TypeSubst::new();
+        };
+        if self.arg_tys.is_empty() {
+            return TypeSubst::new();
+        }
+
+        let type_params = generics
+            .types
+            .iter()
+            .map(|param| param.name.as_str())
+            .collect::<Vec<_>>();
+        let mut subst = TypeSubst::new();
+
+        for (param, arg_ty) in self
+            .params
+            .iter()
+            .skip(self.arg_mapping.first_param_idx())
+            .zip(self.arg_tys)
+        {
+            let Some(param_ty) = &param.ty else {
+                continue;
+            };
+            self.infer_type_ref_subst(param_ty, arg_ty, &type_params, &mut subst);
+        }
+
+        subst
+    }
+
+    fn infer_type_ref_subst(
+        &self,
+        param_ty: &TypeRef,
+        arg_ty: &Ty,
+        type_params: &[&str],
+        subst: &mut TypeSubst,
+    ) {
+        // This is intentionally a small, syntax-directed matcher. It binds `T` from positions
+        // where the written parameter type directly exposes `T`; nominal containers like
+        // `Vec<T>` are left for a later, more deliberate unification step.
+        if let Some(name) = param_ty.type_param_name()
+            && type_params.contains(&name.as_str())
+        {
+            self.push_inferred_call_subst(subst, name, arg_ty);
+            return;
+        }
+
+        match (param_ty, arg_ty) {
+            (
+                TypeRef::Reference {
+                    mutability: param_mutability,
+                    inner: param_inner,
+                    ..
+                },
+                Ty::Reference {
+                    mutability: arg_mutability,
+                    inner: arg_inner,
+                },
+            ) if Self::ref_mutability_matches(*param_mutability, *arg_mutability) => {
+                self.infer_type_ref_subst(param_inner, arg_inner, type_params, subst);
+            }
+            (TypeRef::Tuple(param_fields), Ty::Tuple(arg_fields))
+                if param_fields.len() == arg_fields.len() =>
+            {
+                for (param_field, arg_field) in param_fields.iter().zip(arg_fields) {
+                    self.infer_type_ref_subst(param_field, arg_field, type_params, subst);
+                }
+            }
+            (TypeRef::Slice(param_inner), Ty::Slice(arg_inner)) => {
+                self.infer_type_ref_subst(param_inner, arg_inner, type_params, subst);
+            }
+            (
+                TypeRef::Array {
+                    inner: param_inner,
+                    len: param_len,
+                },
+                Ty::Array {
+                    inner: arg_inner,
+                    len: arg_len,
+                },
+            ) if param_len == arg_len => {
+                self.infer_type_ref_subst(param_inner, arg_inner, type_params, subst);
+            }
+            _ => {}
+        }
+    }
+
+    fn push_inferred_call_subst(&self, subst: &mut TypeSubst, name: Name, arg_ty: &Ty) {
+        if !Self::ty_is_inferable_arg(arg_ty) {
+            return;
+        }
+
+        if let Some(existing_ty) = self.existing_subst.get(name.as_str())
+            && !matches!(existing_ty, Ty::Unknown)
+        {
+            return;
+        }
+
+        if let Some(existing_ty) = subst.get(name.as_str()) {
+            if matches!(existing_ty, Ty::Unknown) || existing_ty == arg_ty {
+                return;
+            }
+
+            subst.push(name, Ty::Unknown);
+            return;
+        }
+
+        subst.push(name, arg_ty.clone());
+    }
+
+    fn ref_mutability_matches(param_mutability: Mutability, arg_mutability: RefMutability) -> bool {
+        matches!(
+            (param_mutability, arg_mutability),
+            (Mutability::Shared, RefMutability::Shared)
+                | (Mutability::Mutable, RefMutability::Mutable)
+        )
+    }
+
+    fn ty_is_inferable_arg(ty: &Ty) -> bool {
+        !matches!(ty, Ty::Unknown | Ty::Syntax(_))
+    }
+}
+
+/// Function generics shadow outer impl generics with the same names.
+pub fn function_generic_shadow_subst(generics: Option<&GenericParams>) -> TypeSubst {
+    let Some(generics) = generics else {
+        return TypeSubst::new();
+    };
+
+    // Seed function generics as unknown first; explicit turbofish args and argument inference can
+    // overwrite these placeholders once call-site information is available.
+    generics
+        .types
+        .iter()
+        .map(|param| (param.name.clone(), Ty::Unknown))
+        .collect()
+}

--- a/crates/engine/ty/src/deref.rs
+++ b/crates/engine/ty/src/deref.rs
@@ -3,17 +3,16 @@
 //! This module deliberately stays narrow: it recognizes `core::ops::Deref` impls for a known
 //! nominal receiver and resolves the impl's associated `Target` type with the receiver substitution.
 
-use rg_ir_model::items::TypeRef;
-use rg_ir_model::{
-    AssocItemId, TraitImplRef, TypeAliasRef, TypePathResolution, hir::items::ImplData,
-};
+use rg_ir_model::{TraitImplRef, hir::items::ImplData};
 use rg_ir_storage::{
     DefMapSource, ItemLookupIndex, ItemStoreSource, Path, PathSegment, TargetItemQuery,
     TypePathContext,
 };
 use rg_text::Name;
 
-use crate::{ImplMatcher, ItemPathQuery, NominalTy, Ty, TypeSubst};
+use crate::{
+    ImplMatcher, ItemPathQuery, NominalTy, Ty, TypeSubst, associated_type::AssociatedTypeProjector,
+};
 
 /// Resolves the associated `Target` type for applicable `core::ops::Deref` impls.
 #[derive(Clone)]
@@ -109,13 +108,8 @@ where
             impl_ref: Some(trait_impl.impl_ref),
         };
 
-        Ok(match self.item_paths.resolve_type_path(context, &path)? {
-            TypePathResolution::Traits(traits) => traits.contains(&trait_impl.trait_ref),
-            TypePathResolution::SelfType(_)
-            | TypePathResolution::TypeDefs(_)
-            | TypePathResolution::TypeAliases(_)
-            | TypePathResolution::Unknown => false,
-        })
+        AssociatedTypeProjector::new(&self.item_paths, &self.target_items)
+            .trait_impl_resolves_to_path(trait_impl, context, &path)
     }
 
     /// Resolves the `type Target = ...` item declared in a matching `Deref` impl.
@@ -125,49 +119,8 @@ where
         impl_data: &ImplData,
         subst: &TypeSubst,
     ) -> Result<Option<Ty>, D::Error> {
-        let item_query = self.item_paths.items();
-        for item in &impl_data.items {
-            let AssocItemId::TypeAlias(type_alias_id) = item else {
-                continue;
-            };
-            let type_alias_ref = TypeAliasRef {
-                origin: trait_impl.impl_ref.origin,
-                id: *type_alias_id,
-            };
-            let Some(type_alias_data) = item_query.type_alias_data(type_alias_ref)? else {
-                continue;
-            };
-            if type_alias_data.name.as_str() != "Target" {
-                continue;
-            }
-            let Some(target_ty) = type_alias_data.signature.aliased_ty() else {
-                continue;
-            };
-
-            let resolved = self.ty_from_target_type_ref(trait_impl, impl_data, target_ty, subst)?;
-            if matches!(resolved, Ty::Unknown | Ty::Syntax(_)) {
-                return Ok(None);
-            }
-            return Ok(Some(resolved));
-        }
-
-        Ok(None)
-    }
-
-    /// Converts the associated target type after applying impl substitutions.
-    fn ty_from_target_type_ref(
-        &self,
-        trait_impl: TraitImplRef,
-        impl_data: &ImplData,
-        target_ty: &TypeRef,
-        subst: &TypeSubst,
-    ) -> Result<Ty, D::Error> {
-        let context = TypePathContext {
-            module: impl_data.owner,
-            impl_ref: Some(trait_impl.impl_ref),
-        };
-        self.item_paths
-            .resolve_type_ref(target_ty, context, Ty::syntax(target_ty.clone()), subst)
+        AssociatedTypeProjector::new(&self.item_paths, &self.target_items)
+            .associated_type_from_impl(trait_impl, impl_data, "Target", subst)
     }
 }
 

--- a/crates/engine/ty/src/generic_arg.rs
+++ b/crates/engine/ty/src/generic_arg.rs
@@ -11,6 +11,7 @@ pub enum GenericArg {
     Type(#[wincode(with = "rg_wincode_utils::WincodeDynamic<Box<Ty>>")] Box<Ty>),
     Lifetime(String),
     Const(String),
+    /// Parenthesized argument syntax on function-trait paths, such as `FnOnce(T) -> R`.
     FnTraitArgs {
         #[wincode(with = "rg_wincode_utils::WincodeDynamic<Vec<Ty>>")]
         params: Vec<Ty>,

--- a/crates/engine/ty/src/generic_arg.rs
+++ b/crates/engine/ty/src/generic_arg.rs
@@ -36,6 +36,18 @@ impl GenericArg {
             | Self::Unsupported(_) => None,
         }
     }
+
+    pub(crate) fn is_projectable(&self) -> bool {
+        match self {
+            Self::Type(ty) => ty.is_projectable(),
+            Self::Lifetime(_) | Self::Const(_) => true,
+            Self::FnTraitArgs { params, ret } => {
+                params.iter().all(Ty::is_projectable) && ret.is_projectable()
+            }
+            Self::AssocType { ty, .. } => ty.as_deref().is_none_or(Ty::is_projectable),
+            Self::Unsupported(_) => false,
+        }
+    }
 }
 
 impl Shrink for GenericArg {

--- a/crates/engine/ty/src/generic_arg.rs
+++ b/crates/engine/ty/src/generic_arg.rs
@@ -11,6 +11,12 @@ pub enum GenericArg {
     Type(#[wincode(with = "rg_wincode_utils::WincodeDynamic<Box<Ty>>")] Box<Ty>),
     Lifetime(String),
     Const(String),
+    FnTraitArgs {
+        #[wincode(with = "rg_wincode_utils::WincodeDynamic<Vec<Ty>>")]
+        params: Vec<Ty>,
+        #[wincode(with = "rg_wincode_utils::WincodeDynamic<Box<Ty>>")]
+        ret: Box<Ty>,
+    },
     AssocType {
         name: Name,
         #[wincode(with = "rg_wincode_utils::WincodeDynamic<Option<Box<Ty>>>")]
@@ -23,9 +29,11 @@ impl GenericArg {
     pub fn as_ty(&self) -> Option<&Ty> {
         match self {
             Self::Type(ty) => Some(ty),
-            Self::Lifetime(_) | Self::Const(_) | Self::AssocType { .. } | Self::Unsupported(_) => {
-                None
-            }
+            Self::Lifetime(_)
+            | Self::Const(_)
+            | Self::FnTraitArgs { .. }
+            | Self::AssocType { .. }
+            | Self::Unsupported(_) => None,
         }
     }
 }
@@ -36,6 +44,13 @@ impl Shrink for GenericArg {
             Self::Type(ty) => ty.shrink_to_fit(),
             Self::Lifetime(text) | Self::Const(text) | Self::Unsupported(text) => {
                 text.shrink_to_fit();
+            }
+            Self::FnTraitArgs { params, ret } => {
+                params.shrink_to_fit();
+                for param in params {
+                    param.shrink_to_fit();
+                }
+                ret.shrink_to_fit();
             }
             Self::AssocType { name, ty } => {
                 name.shrink_to_fit();

--- a/crates/engine/ty/src/impl_match.rs
+++ b/crates/engine/ty/src/impl_match.rs
@@ -367,7 +367,9 @@ where
                 };
                 Ok(impl_const_params.contains(&impl_arg.as_str()) || impl_arg == receiver_arg)
             }
-            ItemGenericArg::AssocType { .. } | ItemGenericArg::Unsupported(_) => Ok(false),
+            ItemGenericArg::FnTraitArgs { .. }
+            | ItemGenericArg::AssocType { .. }
+            | ItemGenericArg::Unsupported(_) => Ok(false),
         }
     }
 

--- a/crates/engine/ty/src/impl_match.rs
+++ b/crates/engine/ty/src/impl_match.rs
@@ -294,8 +294,9 @@ where
         impl_data: &ImplData,
         receiver_ty: &NominalTy,
     ) -> Result<bool, D::Error> {
-        // Type parameters in the impl self type act as wildcards. Concrete args such as
-        // `impl Wrapper<User>` must equal the receiver's known args.
+        // Type and const parameters in the impl self type act as wildcards. Concrete args such as
+        // `impl Wrapper<User>` or `impl Foo<1>` must equal the receiver's known args. Lifetimes do
+        // not select inherent impls, so they only need to line up as lifetime arguments.
         let TypeRef::Path(self_ty) = &impl_data.self_ty else {
             return Ok(true);
         };
@@ -303,42 +304,71 @@ where
             return Ok(true);
         };
 
-        let Some(impl_type_args) = Self::item_tree_type_args(&segment.args) else {
-            return Ok(false);
-        };
-        let Some(receiver_type_args) = Self::ty_args(&receiver_ty.args) else {
-            return Ok(false);
-        };
-        if impl_type_args.len() != receiver_type_args.len() {
+        if segment.args.len() != receiver_ty.args.len() {
             return Ok(false);
         }
 
         let impl_type_params = Self::impl_type_param_names(&impl_data.generics);
-        for (impl_arg, receiver_arg) in impl_type_args.into_iter().zip(receiver_type_args) {
-            if impl_arg
-                .type_param_name()
-                .as_deref()
-                .is_some_and(|name| impl_type_params.contains(&name))
-            {
-                continue;
-            }
-
-            let context = TypePathContext {
-                module: impl_data.owner,
-                impl_ref: Some(impl_ref),
-            };
-            let impl_arg_ty = self.item_paths.resolve_type_ref(
+        let impl_const_params = Self::impl_const_param_names(&impl_data.generics);
+        for (impl_arg, receiver_arg) in segment.args.iter().zip(&receiver_ty.args) {
+            if !self.impl_self_arg_matches_receiver(
+                impl_ref,
+                impl_data,
                 impl_arg,
-                context,
-                Ty::syntax(impl_arg.clone()),
-                &TypeSubst::new(),
-            )?;
-            if impl_arg_ty != receiver_arg {
+                receiver_arg,
+                &impl_type_params,
+                &impl_const_params,
+            )? {
                 return Ok(false);
             }
         }
 
         Ok(true)
+    }
+
+    fn impl_self_arg_matches_receiver(
+        &self,
+        impl_ref: ImplRef,
+        impl_data: &ImplData,
+        impl_arg: &ItemGenericArg,
+        receiver_arg: &GenericArg,
+        impl_type_params: &[&str],
+        impl_const_params: &[&str],
+    ) -> Result<bool, D::Error> {
+        match impl_arg {
+            ItemGenericArg::Type(impl_arg) => {
+                let Some(receiver_arg) = receiver_arg.as_ty().cloned() else {
+                    return Ok(false);
+                };
+                if impl_arg
+                    .type_param_name()
+                    .as_deref()
+                    .is_some_and(|name| impl_type_params.contains(&name))
+                {
+                    return Ok(true);
+                }
+
+                let context = TypePathContext {
+                    module: impl_data.owner,
+                    impl_ref: Some(impl_ref),
+                };
+                let impl_arg_ty = self.item_paths.resolve_type_ref(
+                    impl_arg,
+                    context,
+                    Ty::syntax(impl_arg.clone()),
+                    &TypeSubst::new(),
+                )?;
+                Ok(impl_arg_ty == receiver_arg)
+            }
+            ItemGenericArg::Lifetime(_) => Ok(matches!(receiver_arg, GenericArg::Lifetime(_))),
+            ItemGenericArg::Const(impl_arg) => {
+                let GenericArg::Const(receiver_arg) = receiver_arg else {
+                    return Ok(false);
+                };
+                Ok(impl_const_params.contains(&impl_arg.as_str()) || impl_arg == receiver_arg)
+            }
+            ItemGenericArg::AssocType { .. } | ItemGenericArg::Unsupported(_) => Ok(false),
+        }
     }
 
     /// Performs the trait-impl self-type argument check with uncertainty preserved.
@@ -526,6 +556,15 @@ where
     fn impl_type_param_names(generics: &GenericParams) -> Vec<&str> {
         generics
             .types
+            .iter()
+            .map(|param| param.name.as_str())
+            .collect()
+    }
+
+    /// Lists the const parameters declared by an impl header.
+    fn impl_const_param_names(generics: &GenericParams) -> Vec<&str> {
+        generics
+            .consts
             .iter()
             .map(|param| param.name.as_str())
             .collect()

--- a/crates/engine/ty/src/impl_match.rs
+++ b/crates/engine/ty/src/impl_match.rs
@@ -4,8 +4,8 @@
 //! items. They compare explicit impl self types against known receiver types and produce the
 //! substitutions that make associated signatures readable in the receiver context.
 
-use crate::{GenericArg, ItemPathQuery, NominalTy, Ty, TypeSubst};
-use rg_ir_model::items::{GenericArg as ItemGenericArg, GenericParams, TypeRef};
+use crate::{GenericArg, ItemPathQuery, NominalTy, RefMutability, Ty, TypeSubst};
+use rg_ir_model::items::{GenericArg as ItemGenericArg, GenericParams, Mutability, TypeRef};
 use rg_ir_model::{
     FunctionRef, ImplRef, ItemOwner, TraitApplicability, TraitImplRef, hir::items::ImplData,
 };
@@ -105,6 +105,43 @@ where
         }
 
         self.impl_self_args_match_receiver(impl_ref, impl_data, receiver_ty)
+    }
+
+    /// Matches an inherent impl whose `Self` type is structural rather than nominal.
+    ///
+    /// This covers impl headers such as `impl<T> [T]`, which cannot participate in the
+    /// `TypeDefRef`-keyed receiver index used for nominal impls. The match is deliberately strict:
+    /// only already-modeled structural types and direct type-parameter substitutions are accepted.
+    pub fn structural_inherent_impl_subst(
+        &self,
+        impl_ref: ImplRef,
+        impl_data: &ImplData,
+        receiver_ty: &Ty,
+    ) -> Result<Option<TypeSubst>, D::Error> {
+        // Structural impl lookup is a precise receiver adjustment, not an optimistic completion
+        // heuristic. Once generic constraints appear, a real solver would be needed to know
+        // whether the impl applies.
+        if impl_data.trait_ref.is_some()
+            || !Self::impl_header_has_only_plain_type_params(impl_data)
+            || !Self::type_ref_uses_structural_receiver_lookup(&impl_data.self_ty)
+        {
+            return Ok(None);
+        }
+
+        let impl_type_params = Self::impl_type_param_names(&impl_data.generics);
+        let mut subst = TypeSubst::new();
+        if self.structural_type_ref_matches_ty(
+            impl_ref,
+            impl_data,
+            &impl_data.self_ty,
+            receiver_ty,
+            &impl_type_params,
+            &mut subst,
+        )? {
+            Ok(Some(subst))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Matches one trait impl against a receiver.
@@ -542,6 +579,139 @@ where
                     .then_some((name, receiver_arg))
             })
             .collect()
+    }
+
+    /// Recursively matches a structural impl `Self` type against an adjusted receiver type.
+    fn structural_type_ref_matches_ty(
+        &self,
+        impl_ref: ImplRef,
+        impl_data: &ImplData,
+        impl_ty: &TypeRef,
+        receiver_ty: &Ty,
+        impl_type_params: &[&str],
+        subst: &mut TypeSubst,
+    ) -> Result<bool, D::Error> {
+        // A bare impl type param is the only unification-like operation this matcher performs:
+        // `impl<T> [T]` matched with `[Package]` records `T -> Package`.
+        if let Some(name) = impl_ty.type_param_name()
+            && impl_type_params.contains(&name.as_str())
+        {
+            return Ok(Self::push_structural_subst(
+                subst,
+                name,
+                receiver_ty.clone(),
+            ));
+        }
+
+        Ok(match (impl_ty, receiver_ty) {
+            (TypeRef::Tuple(impl_fields), Ty::Tuple(receiver_fields)) => {
+                if impl_fields.len() != receiver_fields.len() {
+                    return Ok(false);
+                }
+
+                for (impl_field, receiver_field) in impl_fields.iter().zip(receiver_fields) {
+                    if !self.structural_type_ref_matches_ty(
+                        impl_ref,
+                        impl_data,
+                        impl_field,
+                        receiver_field,
+                        impl_type_params,
+                        subst,
+                    )? {
+                        return Ok(false);
+                    }
+                }
+                true
+            }
+            (TypeRef::Slice(impl_inner), Ty::Slice(receiver_inner)) => self
+                .structural_type_ref_matches_ty(
+                    impl_ref,
+                    impl_data,
+                    impl_inner,
+                    receiver_inner,
+                    impl_type_params,
+                    subst,
+                )?,
+            (
+                TypeRef::Array {
+                    inner: impl_inner,
+                    len: impl_len,
+                },
+                Ty::Array {
+                    inner: receiver_inner,
+                    len: receiver_len,
+                },
+            ) if impl_len == receiver_len => self.structural_type_ref_matches_ty(
+                impl_ref,
+                impl_data,
+                impl_inner,
+                receiver_inner,
+                impl_type_params,
+                subst,
+            )?,
+            (
+                TypeRef::Reference {
+                    mutability: impl_mutability,
+                    inner: impl_inner,
+                    ..
+                },
+                Ty::Reference {
+                    mutability: receiver_mutability,
+                    inner: receiver_inner,
+                },
+            ) if Self::ref_mutability_matches(*impl_mutability, *receiver_mutability) => self
+                .structural_type_ref_matches_ty(
+                    impl_ref,
+                    impl_data,
+                    impl_inner,
+                    receiver_inner,
+                    impl_type_params,
+                    subst,
+                )?,
+            _ => {
+                // If a structural shape contains a nested generic pattern we do not understand,
+                // reject it instead of guessing. Concrete nested types can still be resolved and
+                // compared directly below.
+                if impl_ty.mentions_type_param(impl_type_params) {
+                    return Ok(false);
+                }
+
+                let context = TypePathContext {
+                    module: impl_data.owner,
+                    impl_ref: Some(impl_ref),
+                };
+                let impl_ty = self.item_paths.resolve_type_ref(
+                    impl_ty,
+                    context,
+                    Ty::syntax(impl_ty.clone()),
+                    &TypeSubst::new(),
+                )?;
+                !Self::type_arg_comparison_is_uncertain(&impl_ty)
+                    && !Self::type_arg_comparison_is_uncertain(receiver_ty)
+                    && impl_ty == *receiver_ty
+            }
+        })
+    }
+
+    fn ref_mutability_matches(
+        impl_mutability: Mutability,
+        receiver_mutability: RefMutability,
+    ) -> bool {
+        matches!(
+            (impl_mutability, receiver_mutability),
+            (Mutability::Shared, RefMutability::Shared)
+                | (Mutability::Mutable, RefMutability::Mutable)
+        )
+    }
+
+    fn type_ref_uses_structural_receiver_lookup(ty: &TypeRef) -> bool {
+        matches!(
+            ty,
+            TypeRef::Tuple(_)
+                | TypeRef::Reference { .. }
+                | TypeRef::Slice(_)
+                | TypeRef::Array { .. }
+        )
     }
 
     /// Records a strict direct-param substitution, rejecting conflicting repeated params.

--- a/crates/engine/ty/src/impl_match.rs
+++ b/crates/engine/ty/src/impl_match.rs
@@ -5,12 +5,15 @@
 //! substitutions that make associated signatures readable in the receiver context.
 
 use crate::{GenericArg, ItemPathQuery, NominalTy, RefMutability, Ty, TypeSubst};
-use rg_ir_model::items::{GenericArg as ItemGenericArg, GenericParams, Mutability, TypeRef};
+use rg_ir_model::items::{
+    GenericArg as ItemGenericArg, GenericParams, Mutability, TypePath, TypeRef,
+};
 use rg_ir_model::{
-    FunctionRef, ImplRef, ItemOwner, TraitApplicability, TraitImplRef, hir::items::ImplData,
+    FunctionRef, ImplRef, ItemOwner, TraitApplicability, TraitImplRef, TypePathResolution,
+    hir::items::ImplData,
 };
 use rg_ir_storage::{
-    DefMapSource, ItemLookupIndex, ItemStoreSource, TargetItemQuery, TypePathContext,
+    DefMapSource, ItemLookupIndex, ItemStoreSource, Path, TargetItemQuery, TypePathContext,
 };
 use rg_text::Name;
 
@@ -208,6 +211,51 @@ where
         }
 
         self.impl_self_structural_subst(trait_impl.impl_ref, impl_data, receiver_ty)
+    }
+
+    /// Matches a trait impl for associated-type projection against any known receiver `Ty`.
+    ///
+    /// This is the strict path used by adjustments and iterator item flow. It accepts direct
+    /// generic bindings inside already-modeled nominal or structural self types, but rejects
+    /// bounded blanket impls unless the caller handles a specific blanket shape itself.
+    pub(crate) fn trait_impl_projection_subst_for_ty(
+        &self,
+        trait_impl: TraitImplRef,
+        impl_data: &ImplData,
+        receiver_ty: &Ty,
+    ) -> Result<Option<TypeSubst>, D::Error> {
+        if !impl_data
+            .resolved_trait_refs
+            .contains(&trait_impl.trait_ref)
+            || !Self::impl_header_is_projectable(impl_data)
+            || impl_data.self_ty.type_param_name().is_some_and(|name| {
+                Self::impl_type_param_names(&impl_data.generics).contains(&name.as_str())
+            })
+        {
+            return Ok(None);
+        }
+
+        let impl_type_params = Self::impl_type_param_names(&impl_data.generics);
+        let impl_lifetime_params = Self::impl_lifetime_param_names(&impl_data.generics);
+        let impl_const_params = Self::impl_const_param_names(&impl_data.generics);
+        let mut subst = TypeSubst::new();
+
+        if self.projection_type_ref_matches_ty(
+            trait_impl.impl_ref,
+            impl_data,
+            &impl_data.self_ty,
+            receiver_ty,
+            &ImplParamNames {
+                types: &impl_type_params,
+                lifetimes: &impl_lifetime_params,
+                consts: &impl_const_params,
+            },
+            &mut subst,
+        )? {
+            Ok(Some(subst))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Returns only the yes/maybe/no part of `trait_impl_match`.
@@ -581,6 +629,243 @@ where
             .collect()
     }
 
+    /// Recursively matches an impl `Self` type against a receiver for real type projection.
+    fn projection_type_ref_matches_ty(
+        &self,
+        impl_ref: ImplRef,
+        impl_data: &ImplData,
+        impl_ty: &TypeRef,
+        receiver_ty: &Ty,
+        params: &ImplParamNames<'_>,
+        subst: &mut TypeSubst,
+    ) -> Result<bool, D::Error> {
+        // A direct type parameter inside a concrete shape is the only binding operation here.
+        // Bare blanket impls such as `impl<T> Trait for T` are rejected before this matcher is
+        // entered because they need trait-bound reasoning.
+        if let Some(name) = impl_ty.type_param_name()
+            && params.types.contains(&name.as_str())
+        {
+            return Ok(Self::push_projection_subst(
+                subst,
+                name,
+                receiver_ty.clone(),
+            ));
+        }
+
+        Ok(match (impl_ty, receiver_ty) {
+            (TypeRef::Unit, Ty::Unit) | (TypeRef::Never, Ty::Never) => true,
+            (TypeRef::Tuple(impl_fields), Ty::Tuple(receiver_fields)) => {
+                if impl_fields.len() != receiver_fields.len() {
+                    return Ok(false);
+                }
+                for (impl_field, receiver_field) in impl_fields.iter().zip(receiver_fields) {
+                    if !self.projection_type_ref_matches_ty(
+                        impl_ref,
+                        impl_data,
+                        impl_field,
+                        receiver_field,
+                        params,
+                        subst,
+                    )? {
+                        return Ok(false);
+                    }
+                }
+                true
+            }
+            (
+                TypeRef::Reference {
+                    mutability: impl_mutability,
+                    inner: impl_inner,
+                    ..
+                },
+                Ty::Reference {
+                    mutability: receiver_mutability,
+                    inner: receiver_inner,
+                },
+            ) if Self::ref_mutability_matches(*impl_mutability, *receiver_mutability) => self
+                .projection_type_ref_matches_ty(
+                    impl_ref,
+                    impl_data,
+                    impl_inner,
+                    receiver_inner,
+                    params,
+                    subst,
+                )?,
+            (TypeRef::Slice(impl_inner), Ty::Slice(receiver_inner)) => self
+                .projection_type_ref_matches_ty(
+                    impl_ref,
+                    impl_data,
+                    impl_inner,
+                    receiver_inner,
+                    params,
+                    subst,
+                )?,
+            (
+                TypeRef::Array {
+                    inner: impl_inner,
+                    len: impl_len,
+                },
+                Ty::Array {
+                    inner: receiver_inner,
+                    len: receiver_len,
+                },
+            ) if Self::array_len_matches(impl_len, receiver_len, params.consts) => self
+                .projection_type_ref_matches_ty(
+                    impl_ref,
+                    impl_data,
+                    impl_inner,
+                    receiver_inner,
+                    params,
+                    subst,
+                )?,
+            (TypeRef::Path(path), _) => self.projection_path_type_ref_matches_ty(
+                impl_ref,
+                impl_data,
+                path,
+                receiver_ty,
+                params,
+                subst,
+            )?,
+            _ => {
+                if impl_ty.mentions_type_param(params.types) {
+                    return Ok(false);
+                }
+
+                let context = TypePathContext {
+                    module: impl_data.owner,
+                    impl_ref: Some(impl_ref),
+                };
+                let impl_ty = self.item_paths.resolve_type_ref(
+                    impl_ty,
+                    context,
+                    Ty::syntax(impl_ty.clone()),
+                    &TypeSubst::new(),
+                )?;
+                impl_ty.is_projectable() && receiver_ty.is_projectable() && impl_ty == *receiver_ty
+            }
+        })
+    }
+
+    fn projection_path_type_ref_matches_ty(
+        &self,
+        impl_ref: ImplRef,
+        impl_data: &ImplData,
+        impl_path: &TypePath,
+        receiver_ty: &Ty,
+        params: &ImplParamNames<'_>,
+        subst: &mut TypeSubst,
+    ) -> Result<bool, D::Error> {
+        let path = Path::from_type_path(impl_path);
+        let context = TypePathContext {
+            module: impl_data.owner,
+            impl_ref: Some(impl_ref),
+        };
+        let impl_args = impl_path
+            .segments
+            .last()
+            .map(|segment| segment.args.as_slice())
+            .unwrap_or(&[]);
+
+        match self.item_paths.resolve_type_path(context, &path)? {
+            TypePathResolution::TypeDefs(type_defs) | TypePathResolution::SelfType(type_defs) => {
+                for nominal in receiver_ty.as_nominals() {
+                    if !type_defs.contains(&nominal.def) {
+                        continue;
+                    }
+                    if self.projection_generic_args_match_ty_args(
+                        impl_ref,
+                        impl_data,
+                        impl_args,
+                        &nominal.args,
+                        params,
+                        subst,
+                    )? {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            }
+            TypePathResolution::TypeAliases(_)
+            | TypePathResolution::Traits(_)
+            | TypePathResolution::Unknown => {
+                if let Some(name) = impl_path.single_name()
+                    && params.types.contains(&name.as_str())
+                {
+                    return Ok(Self::push_projection_subst(
+                        subst,
+                        name.clone(),
+                        receiver_ty.clone(),
+                    ));
+                }
+
+                let impl_ty = self.item_paths.resolve_type_ref(
+                    &TypeRef::Path(impl_path.clone()),
+                    context,
+                    Ty::syntax(TypeRef::Path(impl_path.clone())),
+                    &TypeSubst::new(),
+                )?;
+                Ok(impl_ty.is_projectable()
+                    && receiver_ty.is_projectable()
+                    && impl_ty == *receiver_ty)
+            }
+        }
+    }
+
+    fn projection_generic_args_match_ty_args(
+        &self,
+        impl_ref: ImplRef,
+        impl_data: &ImplData,
+        impl_args: &[ItemGenericArg],
+        receiver_args: &[GenericArg],
+        params: &ImplParamNames<'_>,
+        subst: &mut TypeSubst,
+    ) -> Result<bool, D::Error> {
+        if impl_args.len() != receiver_args.len() {
+            return Ok(false);
+        }
+
+        for (impl_arg, receiver_arg) in impl_args.iter().zip(receiver_args) {
+            match impl_arg {
+                ItemGenericArg::Type(impl_ty) => {
+                    let Some(receiver_ty) = receiver_arg.as_ty() else {
+                        return Ok(false);
+                    };
+                    if !self.projection_type_ref_matches_ty(
+                        impl_ref,
+                        impl_data,
+                        impl_ty,
+                        receiver_ty,
+                        params,
+                        subst,
+                    )? {
+                        return Ok(false);
+                    }
+                }
+                ItemGenericArg::Lifetime(lifetime) => {
+                    if !matches!(receiver_arg, GenericArg::Lifetime(_))
+                        || (!params.lifetimes.contains(&lifetime.as_str())
+                            && !matches!(receiver_arg, GenericArg::Lifetime(receiver) if receiver == lifetime))
+                    {
+                        return Ok(false);
+                    }
+                }
+                ItemGenericArg::Const(value) => {
+                    if params.consts.contains(&value.as_str()) {
+                        continue;
+                    }
+                    if !matches!(receiver_arg, GenericArg::Const(receiver) if receiver == value) {
+                        return Ok(false);
+                    }
+                }
+                ItemGenericArg::FnTraitArgs { .. }
+                | ItemGenericArg::AssocType { .. }
+                | ItemGenericArg::Unsupported(_) => return Ok(false),
+            }
+        }
+
+        Ok(true)
+    }
+
     /// Recursively matches a structural impl `Self` type against an adjusted receiver type.
     fn structural_type_ref_matches_ty(
         &self,
@@ -704,6 +989,17 @@ where
         )
     }
 
+    fn array_len_matches(
+        impl_len: &Option<String>,
+        receiver_len: &Option<String>,
+        const_params: &[&str],
+    ) -> bool {
+        match impl_len {
+            Some(len) if const_params.contains(&len.as_str()) => true,
+            _ => impl_len == receiver_len,
+        }
+    }
+
     fn type_ref_uses_structural_receiver_lookup(ty: &TypeRef) -> bool {
         matches!(
             ty,
@@ -712,6 +1008,20 @@ where
                 | TypeRef::Slice(_)
                 | TypeRef::Array { .. }
         )
+    }
+
+    /// Records a strict projection substitution, rejecting unknowns and repeated conflicts.
+    fn push_projection_subst(subst: &mut TypeSubst, name: Name, ty: Ty) -> bool {
+        if !ty.is_projectable() {
+            return false;
+        }
+
+        if let Some(existing_ty) = subst.get(name.as_str()) {
+            return existing_ty == &ty;
+        }
+
+        subst.push(name, ty);
+        true
     }
 
     /// Records a strict direct-param substitution, rejecting conflicting repeated params.
@@ -728,6 +1038,15 @@ where
     fn impl_type_param_names(generics: &GenericParams) -> Vec<&str> {
         generics
             .types
+            .iter()
+            .map(|param| param.name.as_str())
+            .collect()
+    }
+
+    /// Lists the lifetime parameters declared by an impl header.
+    fn impl_lifetime_param_names(generics: &GenericParams) -> Vec<&str> {
+        generics
+            .lifetimes
             .iter()
             .map(|param| param.name.as_str())
             .collect()
@@ -792,6 +1111,30 @@ where
                 .is_none_or(|trait_ref| !trait_ref.has_generic_args())
     }
 
+    /// Returns whether an impl is simple enough for real associated-type projection.
+    fn impl_header_is_projectable(impl_data: &ImplData) -> bool {
+        impl_data.generics.where_predicates.is_empty()
+            && impl_data
+                .generics
+                .lifetimes
+                .iter()
+                .all(|param| param.bounds.is_empty())
+            && impl_data
+                .generics
+                .types
+                .iter()
+                .all(|param| param.bounds.is_empty() && param.default.is_none())
+            && impl_data
+                .generics
+                .consts
+                .iter()
+                .all(|param| param.default.is_none())
+            && impl_data
+                .trait_ref
+                .as_ref()
+                .is_some_and(|trait_ref| !trait_ref.has_generic_args())
+    }
+
     /// Returns whether the impl header has no generic or where-clause uncertainty.
     fn impl_header_is_definitely_direct(impl_data: &ImplData) -> bool {
         impl_data.generics.lifetimes.is_empty()
@@ -813,6 +1156,7 @@ where
                 Self::type_arg_comparison_is_uncertain(inner)
             }
             Ty::Reference { inner, .. } => Self::type_arg_comparison_is_uncertain(inner),
+            Ty::Opaque { .. } => true,
             Ty::Unit | Ty::Never | Ty::Primitive(_) | Ty::Nominal(_) | Ty::SelfTy(_) => false,
         }
     }
@@ -822,4 +1166,10 @@ fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
     if !items.contains(&item) {
         items.push(item);
     }
+}
+
+struct ImplParamNames<'a> {
+    types: &'a [&'a str],
+    lifetimes: &'a [&'a str],
+    consts: &'a [&'a str],
 }

--- a/crates/engine/ty/src/impl_match.rs
+++ b/crates/engine/ty/src/impl_match.rs
@@ -638,6 +638,10 @@ where
     fn type_arg_comparison_is_uncertain(ty: &Ty) -> bool {
         match ty {
             Ty::Syntax(_) | Ty::Unknown => true,
+            Ty::Tuple(fields) => fields.iter().any(Self::type_arg_comparison_is_uncertain),
+            Ty::Array { inner, .. } | Ty::Slice(inner) => {
+                Self::type_arg_comparison_is_uncertain(inner)
+            }
             Ty::Reference { inner, .. } => Self::type_arg_comparison_is_uncertain(inner),
             Ty::Unit | Ty::Never | Ty::Primitive(_) | Ty::Nominal(_) | Ty::SelfTy(_) => false,
         }

--- a/crates/engine/ty/src/item_path.rs
+++ b/crates/engine/ty/src/item_path.rs
@@ -216,6 +216,18 @@ where
                 )?)),
                 ItemGenericArg::Lifetime(lifetime) => GenericArg::Lifetime(lifetime.clone()),
                 ItemGenericArg::Const(value) => GenericArg::Const(value.clone()),
+                ItemGenericArg::FnTraitArgs { params, ret } => GenericArg::FnTraitArgs {
+                    params: params
+                        .iter()
+                        .map(|ty| self.resolve_type_ref(ty, context, Ty::syntax(ty.clone()), subst))
+                        .collect::<Result<_, _>>()?,
+                    ret: Box::new(self.resolve_type_ref(
+                        ret,
+                        context,
+                        Ty::syntax((**ret).clone()),
+                        subst,
+                    )?),
+                },
                 ItemGenericArg::AssocType { name, ty } => GenericArg::AssocType {
                     name: name.clone(),
                     ty: match ty {

--- a/crates/engine/ty/src/item_path.rs
+++ b/crates/engine/ty/src/item_path.rs
@@ -4,13 +4,13 @@
 //! answers "which semantic item does this local definition lower to?". Type algorithms use this
 //! query to stay independent from the concrete target/body storage that provided those answers.
 
-use rg_ir_model::items::{GenericArg as ItemGenericArg, Mutability, TypePath, TypeRef};
+use rg_ir_model::items::{GenericArg as ItemGenericArg, Mutability, TypeBound, TypePath, TypeRef};
 use rg_ir_model::{DefId, ModuleRef, SemanticItemRef, TraitRef, TypeDefRef, TypePathResolution};
 use rg_ir_storage::{
     DefMapQuery, DefMapSource, ItemStoreQuery, ItemStoreSource, Path, TypePathContext,
 };
 
-use crate::{GenericArg, PrimitiveTy, RefMutability, Ty, TypeSubst};
+use crate::{GenericArg, OpaqueTraitBound, PrimitiveTy, RefMutability, Ty, TypeSubst};
 
 /// Resolves paths into semantic-shaped item refs using independent DefMap and ItemStore sources.
 #[derive(Clone)]
@@ -98,6 +98,14 @@ where
                 self.resolve_type_ref(inner, context, Ty::syntax((**inner).clone()), subst)?,
                 len.clone(),
             )),
+            TypeRef::ImplTrait(bounds) => {
+                let opaque_bounds = self.opaque_trait_bounds(bounds, context, subst)?;
+                Ok(if opaque_bounds.is_empty() {
+                    Ty::syntax(ty.clone())
+                } else {
+                    Ty::opaque(opaque_bounds)
+                })
+            }
             _ => Ok(Ty::syntax(ty.clone())),
         }
     }
@@ -262,6 +270,40 @@ where
             generic_args.push(generic_arg);
         }
         Ok(generic_args)
+    }
+
+    fn opaque_trait_bounds(
+        &self,
+        bounds: &[TypeBound],
+        context: TypePathContext,
+        subst: &TypeSubst,
+    ) -> Result<Vec<OpaqueTraitBound>, D::Error> {
+        let mut opaque_bounds = Vec::new();
+
+        for bound in bounds {
+            match bound {
+                TypeBound::Trait(TypeRef::Path(bound_path)) => {
+                    let TypePathResolution::Traits(traits) =
+                        self.resolve_type_path(context, &Path::from_type_path(bound_path))?
+                    else {
+                        continue;
+                    };
+                    let args = self.generic_args_from_type_path(bound_path, context, subst)?;
+                    for trait_ref in traits {
+                        push_unique(
+                            &mut opaque_bounds,
+                            OpaqueTraitBound {
+                                trait_ref,
+                                args: args.clone(),
+                            },
+                        );
+                    }
+                }
+                TypeBound::Trait(_) | TypeBound::Lifetime(_) | TypeBound::Unsupported(_) => {}
+            }
+        }
+
+        Ok(opaque_bounds)
     }
 }
 

--- a/crates/engine/ty/src/item_path.rs
+++ b/crates/engine/ty/src/item_path.rs
@@ -82,6 +82,22 @@ where
             )),
             TypeRef::Unknown(_) | TypeRef::Infer => Ok(Ty::Unknown),
             TypeRef::Tuple(types) if types.is_empty() => Ok(Ty::Unit),
+            TypeRef::Tuple(types) => Ok(Ty::tuple(
+                types
+                    .iter()
+                    .map(|ty| self.resolve_type_ref(ty, context, Ty::syntax(ty.clone()), subst))
+                    .collect::<Result<_, _>>()?,
+            )),
+            TypeRef::Slice(inner) => Ok(Ty::slice(self.resolve_type_ref(
+                inner,
+                context,
+                Ty::syntax((**inner).clone()),
+                subst,
+            )?)),
+            TypeRef::Array { inner, len } => Ok(Ty::array(
+                self.resolve_type_ref(inner, context, Ty::syntax((**inner).clone()), subst)?,
+                len.clone(),
+            )),
             _ => Ok(Ty::syntax(ty.clone())),
         }
     }

--- a/crates/engine/ty/src/iteration.rs
+++ b/crates/engine/ty/src/iteration.rs
@@ -160,7 +160,7 @@ where
                         trait_ref: *trait_ref,
                     };
                     if !self
-                        .is_canonical_trait_impl(&projector, trait_impl, impl_data, trait_kind)?
+                        .is_canonical_trait_impl(projector, trait_impl, impl_data, trait_kind)?
                     {
                         continue;
                     }

--- a/crates/engine/ty/src/iteration.rs
+++ b/crates/engine/ty/src/iteration.rs
@@ -9,7 +9,8 @@ use rg_ir_model::{
     AssocItemId, ImplRef, TraitImplRef, TraitRef, TypeAliasRef, hir::items::ImplData,
 };
 use rg_ir_storage::{
-    DefMapSource, ItemStoreSource, Path, PathSegment, TargetItemQuery, TypePathContext,
+    DefMapSource, ItemLookupIndex, ItemStoreSource, Path, PathSegment, TargetItemQuery,
+    TypePathContext,
 };
 use rg_text::Name;
 
@@ -20,6 +21,7 @@ use crate::{ImplMatcher, ItemPathQuery, Ty, associated_type::AssociatedTypeProje
 pub struct IterationItemResolver<'query, D, I> {
     item_paths: ItemPathQuery<'query, D, I>,
     target_items: TargetItemQuery<'query, D, I>,
+    lookup_index: Option<&'query ItemLookupIndex>,
 }
 
 impl<'query, D, I> IterationItemResolver<'query, D, I>
@@ -34,6 +36,20 @@ where
         Self {
             item_paths,
             target_items,
+            lookup_index: None,
+        }
+    }
+
+    /// Creates an iteration resolver that can reuse a target-scoped item lookup index.
+    pub fn with_index(
+        item_paths: ItemPathQuery<'query, D, I>,
+        target_items: TargetItemQuery<'query, D, I>,
+        lookup_index: &'query ItemLookupIndex,
+    ) -> Self {
+        Self {
+            item_paths,
+            target_items,
+            lookup_index: Some(lookup_index),
         }
     }
 
@@ -58,10 +74,9 @@ where
 
         let projector = AssociatedTypeProjector::new(&self.item_paths, &self.target_items);
         let matcher = ImplMatcher::new(self.item_paths.clone(), self.target_items.clone());
+        let canonical_traits = self.canonical_trait_refs_from_use_site(&projector, trait_kind)?;
         let mut candidates = Vec::new();
         if let Ty::Opaque { bounds } = ty {
-            let canonical_traits =
-                self.canonical_trait_refs_from_use_site(&projector, trait_kind)?;
             projector.push_associated_types_from_opaque_bounds(
                 &mut candidates,
                 bounds,
@@ -70,6 +85,69 @@ where
             );
         }
 
+        let item_query = self.item_paths.items();
+        for trait_impl in self.trait_impl_candidates(&projector, &canonical_traits, trait_kind)? {
+            let Some(impl_data) = item_query.impl_data(trait_impl.impl_ref)? else {
+                continue;
+            };
+
+            if matches!(trait_kind, CanonicalIteratorTrait::IntoIterator)
+                && let Some(item_ty) = self.blanket_into_iterator_item_for_ty(
+                    &projector,
+                    trait_impl.impl_ref,
+                    impl_data,
+                    ty,
+                )?
+            {
+                push_unique(&mut candidates, item_ty);
+                continue;
+            }
+
+            let Some(subst) =
+                matcher.trait_impl_projection_subst_for_ty(trait_impl, impl_data, ty)?
+            else {
+                continue;
+            };
+            let Some(item_ty) =
+                projector.associated_type_from_impl(trait_impl, impl_data, "Item", &subst)?
+            else {
+                continue;
+            };
+            push_unique(&mut candidates, item_ty);
+        }
+
+        Ok(Ty::one_or_unknown(candidates))
+    }
+
+    fn trait_impl_candidates(
+        &self,
+        projector: &AssociatedTypeProjector<'_, 'query, D, I>,
+        canonical_traits: &[TraitRef],
+        trait_kind: CanonicalIteratorTrait,
+    ) -> Result<Vec<TraitImplRef>, D::Error> {
+        let mut candidates = Vec::new();
+        for trait_ref in canonical_traits {
+            if let Some(indexed_impls) = self
+                .lookup_index
+                .and_then(|index| index.trait_impls_for_trait(*trait_ref))
+            {
+                for trait_impl in indexed_impls {
+                    push_unique(&mut candidates, *trait_impl);
+                }
+                continue;
+            }
+
+            for trait_impl in self.target_items.trait_impls_for_trait(*trait_ref)? {
+                push_unique(&mut candidates, trait_impl);
+            }
+        }
+
+        if !canonical_traits.is_empty() {
+            return Ok(candidates);
+        }
+
+        // Some fixture/core-like contexts cannot resolve `::core` from the use-site root. Keep the
+        // older impl-context scan as a rare fallback so the fast path does not narrow semantics.
         for store in self.target_items.visible_stores()? {
             for (impl_ref, impl_data) in store.impls_with_refs() {
                 if impl_data.trait_ref.is_none() {
@@ -87,31 +165,12 @@ where
                         continue;
                     }
 
-                    if matches!(trait_kind, CanonicalIteratorTrait::IntoIterator)
-                        && let Some(item_ty) = self.blanket_into_iterator_item_for_ty(
-                            &projector, impl_ref, impl_data, ty,
-                        )?
-                    {
-                        push_unique(&mut candidates, item_ty);
-                        continue;
-                    }
-
-                    let Some(subst) =
-                        matcher.trait_impl_projection_subst_for_ty(trait_impl, impl_data, ty)?
-                    else {
-                        continue;
-                    };
-                    let Some(item_ty) = projector
-                        .associated_type_from_impl(trait_impl, impl_data, "Item", &subst)?
-                    else {
-                        continue;
-                    };
-                    push_unique(&mut candidates, item_ty);
+                    push_unique(&mut candidates, trait_impl);
                 }
             }
         }
 
-        Ok(Ty::one_or_unknown(candidates))
+        Ok(candidates)
     }
 
     /// Checks whether this trait impl resolved to the canonical iterator trait path.

--- a/crates/engine/ty/src/iteration.rs
+++ b/crates/engine/ty/src/iteration.rs
@@ -1,0 +1,312 @@
+//! Trait-backed iteration item lookup.
+//!
+//! This module mirrors the narrow shape of `DerefResolver`: it recognizes canonical iterator
+//! traits and projects their associated `Item` type for impls whose self type can be matched
+//! without a solver.
+
+use rg_ir_model::items::{TypeBound, TypeRef};
+use rg_ir_model::{
+    AssocItemId, ImplRef, TraitImplRef, TraitRef, TypeAliasRef, hir::items::ImplData,
+};
+use rg_ir_storage::{
+    DefMapSource, ItemStoreSource, Path, PathSegment, TargetItemQuery, TypePathContext,
+};
+use rg_text::Name;
+
+use crate::{ImplMatcher, ItemPathQuery, Ty, associated_type::AssociatedTypeProjector};
+
+/// Resolves the associated `Item` type for applicable iterator-shaped trait impls.
+#[derive(Clone)]
+pub struct IterationItemResolver<'query, D, I> {
+    item_paths: ItemPathQuery<'query, D, I>,
+    target_items: TargetItemQuery<'query, D, I>,
+}
+
+impl<'query, D, I> IterationItemResolver<'query, D, I>
+where
+    D: DefMapSource + Clone,
+    I: ItemStoreSource<'query, Error = D::Error> + Clone,
+{
+    pub fn new(
+        item_paths: ItemPathQuery<'query, D, I>,
+        target_items: TargetItemQuery<'query, D, I>,
+    ) -> Self {
+        Self {
+            item_paths,
+            target_items,
+        }
+    }
+
+    /// Returns the item yielded by `for pat in value`, i.e. `IntoIterator::Item`.
+    pub fn into_iterator_item_for_ty(&self, ty: &Ty) -> Result<Ty, D::Error> {
+        self.associated_item_for_trait(ty, CanonicalIteratorTrait::IntoIterator)
+    }
+
+    /// Returns the item yielded by a value already known to implement `Iterator`.
+    pub fn iterator_item_for_ty(&self, ty: &Ty) -> Result<Ty, D::Error> {
+        self.associated_item_for_trait(ty, CanonicalIteratorTrait::Iterator)
+    }
+
+    fn associated_item_for_trait(
+        &self,
+        ty: &Ty,
+        trait_kind: CanonicalIteratorTrait,
+    ) -> Result<Ty, D::Error> {
+        if matches!(ty, Ty::Unknown | Ty::Syntax(_)) {
+            return Ok(Ty::Unknown);
+        }
+
+        let projector = AssociatedTypeProjector::new(&self.item_paths, &self.target_items);
+        let matcher = ImplMatcher::new(self.item_paths.clone(), self.target_items.clone());
+        let mut candidates = Vec::new();
+        if let Ty::Opaque { bounds } = ty {
+            let canonical_traits =
+                self.canonical_trait_refs_from_use_site(&projector, trait_kind)?;
+            projector.push_associated_types_from_opaque_bounds(
+                &mut candidates,
+                bounds,
+                &canonical_traits,
+                "Item",
+            );
+        }
+
+        for store in self.target_items.visible_stores()? {
+            for (impl_ref, impl_data) in store.impls_with_refs() {
+                if impl_data.trait_ref.is_none() {
+                    continue;
+                }
+
+                for trait_ref in &impl_data.resolved_trait_refs {
+                    let trait_impl = TraitImplRef {
+                        impl_ref,
+                        trait_ref: *trait_ref,
+                    };
+                    if !self
+                        .is_canonical_trait_impl(&projector, trait_impl, impl_data, trait_kind)?
+                    {
+                        continue;
+                    }
+
+                    if matches!(trait_kind, CanonicalIteratorTrait::IntoIterator)
+                        && let Some(item_ty) = self.blanket_into_iterator_item_for_ty(
+                            &projector, impl_ref, impl_data, ty,
+                        )?
+                    {
+                        push_unique(&mut candidates, item_ty);
+                        continue;
+                    }
+
+                    let Some(subst) =
+                        matcher.trait_impl_projection_subst_for_ty(trait_impl, impl_data, ty)?
+                    else {
+                        continue;
+                    };
+                    let Some(item_ty) = projector
+                        .associated_type_from_impl(trait_impl, impl_data, "Item", &subst)?
+                    else {
+                        continue;
+                    };
+                    push_unique(&mut candidates, item_ty);
+                }
+            }
+        }
+
+        Ok(Ty::one_or_unknown(candidates))
+    }
+
+    /// Checks whether this trait impl resolved to the canonical iterator trait path.
+    fn is_canonical_trait_impl(
+        &self,
+        projector: &AssociatedTypeProjector<'_, 'query, D, I>,
+        trait_impl: TraitImplRef,
+        impl_data: &ImplData,
+        trait_kind: CanonicalIteratorTrait,
+    ) -> Result<bool, D::Error> {
+        Ok(self
+            .canonical_trait_refs(projector, impl_data, trait_kind)?
+            .contains(&trait_impl.trait_ref))
+    }
+
+    fn canonical_trait_refs(
+        &self,
+        projector: &AssociatedTypeProjector<'_, 'query, D, I>,
+        impl_data: &ImplData,
+        trait_kind: CanonicalIteratorTrait,
+    ) -> Result<Vec<TraitRef>, D::Error> {
+        projector
+            .trait_refs_for_path_from_impl_and_use_site(impl_data, &trait_kind.absolute_core_path())
+    }
+
+    fn canonical_trait_refs_from_use_site(
+        &self,
+        projector: &AssociatedTypeProjector<'_, 'query, D, I>,
+        trait_kind: CanonicalIteratorTrait,
+    ) -> Result<Vec<TraitRef>, D::Error> {
+        projector.trait_refs_for_path_from_use_site(&trait_kind.absolute_core_path())
+    }
+
+    fn blanket_into_iterator_item_for_ty(
+        &self,
+        projector: &AssociatedTypeProjector<'_, 'query, D, I>,
+        impl_ref: ImplRef,
+        impl_data: &ImplData,
+        receiver_ty: &Ty,
+    ) -> Result<Option<Ty>, D::Error> {
+        let Some(param_name) =
+            self.blanket_into_iterator_param_name(projector, impl_ref, impl_data)?
+        else {
+            return Ok(None);
+        };
+        if !self.impl_item_aliases_type_param_item(impl_ref, impl_data, &param_name)? {
+            return Ok(None);
+        }
+
+        // This is the one blanket impl we model: `impl<I: Iterator> IntoIterator for I`.
+        // Instead of solving the bound generally, ask the same resolver for `Iterator::Item`
+        // on the concrete receiver and reuse that projection when it is unambiguous.
+        let item_ty = self.iterator_item_for_ty(receiver_ty)?;
+        Ok(item_ty.is_projectable().then_some(item_ty))
+    }
+
+    fn blanket_into_iterator_param_name(
+        &self,
+        projector: &AssociatedTypeProjector<'_, 'query, D, I>,
+        impl_ref: ImplRef,
+        impl_data: &ImplData,
+    ) -> Result<Option<Name>, D::Error> {
+        if !impl_data.generics.lifetimes.is_empty()
+            || !impl_data.generics.consts.is_empty()
+            || !impl_data.generics.where_predicates.is_empty()
+        {
+            return Ok(None);
+        }
+
+        let [param] = impl_data.generics.types.as_slice() else {
+            return Ok(None);
+        };
+        if param.default.is_some() || param.bounds.len() != 1 {
+            return Ok(None);
+        }
+        if impl_data
+            .self_ty
+            .type_param_name()
+            .is_none_or(|name| name != param.name)
+        {
+            return Ok(None);
+        }
+        if !self.type_bound_is_canonical_trait(
+            projector,
+            impl_ref,
+            impl_data,
+            &param.bounds[0],
+            CanonicalIteratorTrait::Iterator,
+        )? {
+            return Ok(None);
+        }
+
+        Ok(Some(param.name.clone()))
+    }
+
+    fn type_bound_is_canonical_trait(
+        &self,
+        projector: &AssociatedTypeProjector<'_, 'query, D, I>,
+        impl_ref: ImplRef,
+        impl_data: &ImplData,
+        bound: &TypeBound,
+        trait_kind: CanonicalIteratorTrait,
+    ) -> Result<bool, D::Error> {
+        let TypeBound::Trait(bound_ty) = bound else {
+            return Ok(false);
+        };
+        let Some(bound_path) = Path::from_type_ref(bound_ty) else {
+            return Ok(false);
+        };
+
+        let bound_context = TypePathContext {
+            module: impl_data.owner,
+            impl_ref: Some(impl_ref),
+        };
+        let bound_traits = projector.trait_refs_for_path(bound_context, &bound_path)?;
+
+        let canonical_traits = self.canonical_trait_refs(projector, impl_data, trait_kind)?;
+        Ok(bound_traits
+            .into_iter()
+            .any(|trait_ref| canonical_traits.contains(&trait_ref)))
+    }
+
+    fn impl_item_aliases_type_param_item(
+        &self,
+        impl_ref: ImplRef,
+        impl_data: &ImplData,
+        param_name: &Name,
+    ) -> Result<bool, D::Error> {
+        let item_query = self.item_paths.items();
+        for item in &impl_data.items {
+            let AssocItemId::TypeAlias(type_alias_id) = item else {
+                continue;
+            };
+            let type_alias_ref = TypeAliasRef {
+                origin: impl_ref.origin,
+                id: *type_alias_id,
+            };
+            let Some(type_alias_data) = item_query.type_alias_data(type_alias_ref)? else {
+                continue;
+            };
+            if type_alias_data.name.as_str() != "Item" {
+                continue;
+            }
+
+            return Ok(type_alias_data
+                .signature
+                .aliased_ty()
+                .is_some_and(|ty| Self::is_type_param_assoc_item(ty, param_name, "Item")));
+        }
+
+        Ok(false)
+    }
+
+    fn is_type_param_assoc_item(ty: &TypeRef, param_name: &Name, assoc_name: &str) -> bool {
+        let TypeRef::Path(path) = ty else {
+            return false;
+        };
+        let [param_segment, assoc_segment] = path.segments.as_slice() else {
+            return false;
+        };
+
+        !path.absolute
+            && param_segment.name == *param_name
+            && param_segment.args.is_empty()
+            && assoc_segment.name.as_str() == assoc_name
+            && assoc_segment.args.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CanonicalIteratorTrait {
+    IntoIterator,
+    Iterator,
+}
+
+impl CanonicalIteratorTrait {
+    fn absolute_core_path(self) -> Path {
+        let trait_name = match self {
+            Self::IntoIterator => "IntoIterator",
+            Self::Iterator => "Iterator",
+        };
+
+        Path {
+            absolute: true,
+            segments: vec![
+                PathSegment::Name(Name::new("core")),
+                PathSegment::Name(Name::new("iter")),
+                PathSegment::Name(Name::new(trait_name)),
+            ],
+        }
+    }
+}
+
+fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
+    if !items.contains(&item) {
+        items.push(item);
+    }
+}

--- a/crates/engine/ty/src/lib.rs
+++ b/crates/engine/ty/src/lib.rs
@@ -1,6 +1,7 @@
 //! Type vocabulary shared by indexing and analysis layers.
 
 mod autoderef;
+mod call_arg;
 mod deref;
 mod generic_arg;
 mod impl_match;
@@ -15,6 +16,7 @@ pub use self::{
         Autoderef, AutoderefCandidate, AutoderefCandidates, AutoderefMode,
         ReferencePeelingCandidates,
     },
+    call_arg::{CallArgInference, CallArgMapping, function_generic_shadow_subst},
     generic_arg::GenericArg,
     impl_match::ImplMatcher,
     implementation::ImplementationQuery,

--- a/crates/engine/ty/src/lib.rs
+++ b/crates/engine/ty/src/lib.rs
@@ -1,5 +1,6 @@
 //! Type vocabulary shared by indexing and analysis layers.
 
+mod associated_type;
 mod autoderef;
 mod call_arg;
 mod deref;
@@ -7,6 +8,7 @@ mod generic_arg;
 mod impl_match;
 mod implementation;
 mod item_path;
+mod iteration;
 mod member;
 mod primitive;
 mod ty;
@@ -21,7 +23,8 @@ pub use self::{
     impl_match::ImplMatcher,
     implementation::ImplementationQuery,
     item_path::ItemPathQuery,
+    iteration::IterationItemResolver,
     member::{MemberMethodCandidateRef, MemberMethodOrigin, MemberQuery},
     primitive::{FloatTy, PrimitiveTy, RefMutability, SignedIntTy, UnsignedIntTy},
-    ty::{NominalTy, Ty, TypeSubst},
+    ty::{NominalTy, OpaqueTraitBound, Ty, TypeSubst},
 };

--- a/crates/engine/ty/src/primitive.rs
+++ b/crates/engine/ty/src/primitive.rs
@@ -102,6 +102,9 @@ pub enum FloatTy {
 }
 
 impl PrimitiveTy {
+    pub const DEFAULT_INT: Self = Self::SignedInt(SignedIntTy::I32);
+    pub const DEFAULT_FLOAT: Self = Self::Float(FloatTy::F64);
+
     pub const ALL: &'static [Self] = &[
         Self::Bool,
         Self::Char,
@@ -143,6 +146,40 @@ impl PrimitiveTy {
             "f64" => Self::Float(FloatTy::F64),
             _ => return None,
         })
+    }
+
+    pub fn from_integer_suffix(suffix: Option<&str>) -> Option<Self> {
+        match suffix {
+            Some(suffix) => Self::from_name(suffix).filter(|ty| ty.is_integral()),
+            None => Some(Self::DEFAULT_INT),
+        }
+    }
+
+    pub fn from_float_suffix(suffix: Option<&str>) -> Option<Self> {
+        match suffix {
+            Some(suffix) => Self::from_name(suffix).filter(|ty| ty.is_float()),
+            None => Some(Self::DEFAULT_FLOAT),
+        }
+    }
+
+    pub fn is_bool(self) -> bool {
+        matches!(self, Self::Bool)
+    }
+
+    pub fn is_integral(self) -> bool {
+        matches!(self, Self::SignedInt(_) | Self::UnsignedInt(_))
+    }
+
+    pub fn is_float(self) -> bool {
+        matches!(self, Self::Float(_))
+    }
+
+    pub fn is_numeric(self) -> bool {
+        self.is_integral() || self.is_float()
+    }
+
+    pub fn is_signed_numeric(self) -> bool {
+        matches!(self, Self::SignedInt(_) | Self::Float(_))
     }
 
     pub fn label(self) -> &'static str {

--- a/crates/engine/ty/src/ty.rs
+++ b/crates/engine/ty/src/ty.rs
@@ -73,6 +73,13 @@ pub enum Ty {
     Unit,
     Never,
     Primitive(PrimitiveTy),
+    Tuple(#[wincode(with = "rg_wincode_utils::WincodeDynamic<Vec<Ty>>")] Vec<Ty>),
+    Array {
+        #[wincode(with = "rg_wincode_utils::WincodeDynamic<Box<Ty>>")]
+        inner: Box<Ty>,
+        len: Option<String>,
+    },
+    Slice(#[wincode(with = "rg_wincode_utils::WincodeDynamic<Box<Ty>>")] Box<Ty>),
     Reference {
         mutability: RefMutability,
         #[wincode(with = "rg_wincode_utils::WincodeDynamic<Box<Ty>>")]
@@ -111,6 +118,25 @@ impl NominalTy {
 }
 
 impl Ty {
+    pub fn tuple(fields: Vec<Self>) -> Self {
+        if fields.is_empty() {
+            return Self::Unit;
+        }
+
+        Self::Tuple(fields)
+    }
+
+    pub fn array(inner: Self, len: Option<String>) -> Self {
+        Self::Array {
+            inner: Box::new(inner),
+            len,
+        }
+    }
+
+    pub fn slice(inner: Self) -> Self {
+        Self::Slice(Box::new(inner))
+    }
+
     pub fn reference(mutability: RefMutability, inner: Self) -> Self {
         if matches!(inner, Self::Unknown) {
             return Self::Unknown;
@@ -180,6 +206,9 @@ impl Ty {
             Self::Unit
             | Self::Never
             | Self::Primitive(_)
+            | Self::Tuple(_)
+            | Self::Array { .. }
+            | Self::Slice(_)
             | Self::Reference { .. }
             | Self::Syntax(_)
             | Self::Unknown => &[],
@@ -192,6 +221,9 @@ impl Ty {
             Self::Unit
             | Self::Never
             | Self::Primitive(_)
+            | Self::Tuple(_)
+            | Self::Array { .. }
+            | Self::Slice(_)
             | Self::Syntax(_)
             | Self::Nominal(_)
             | Self::SelfTy(_)
@@ -209,6 +241,19 @@ impl Ty {
 
     pub fn shrink_to_fit(&mut self) {
         match self {
+            Self::Tuple(fields) => {
+                fields.shrink_to_fit();
+                for field in fields {
+                    field.shrink_to_fit();
+                }
+            }
+            Self::Array { inner, len } => {
+                inner.shrink_to_fit();
+                if let Some(len) = len {
+                    len.shrink_to_fit();
+                }
+            }
+            Self::Slice(inner) => inner.shrink_to_fit(),
             Self::Reference { inner, .. } => inner.shrink_to_fit(),
             Self::Syntax(ty) => ty.shrink_to_fit(),
             Self::Nominal(types) | Self::SelfTy(types) => {

--- a/crates/engine/ty/src/ty.rs
+++ b/crates/engine/ty/src/ty.rs
@@ -131,6 +131,10 @@ impl Ty {
     }
 
     pub fn self_ty(types: Vec<NominalTy>) -> Self {
+        if types.is_empty() {
+            return Self::Unknown;
+        }
+
         Self::SelfTy(types)
     }
 

--- a/crates/engine/ty/src/ty.rs
+++ b/crates/engine/ty/src/ty.rs
@@ -1,5 +1,5 @@
 use rg_ir_model::items::{GenericParams, TypeRef};
-use rg_ir_model::{TypeDefRef, TypePathResolution};
+use rg_ir_model::{TraitRef, TypeDefRef, TypePathResolution};
 use rg_memsize::Shrink;
 use rg_text::Name;
 
@@ -85,6 +85,10 @@ pub enum Ty {
         #[wincode(with = "rg_wincode_utils::WincodeDynamic<Box<Ty>>")]
         inner: Box<Ty>,
     },
+    Opaque {
+        #[wincode(with = "rg_wincode_utils::WincodeDynamic<Vec<OpaqueTraitBound>>")]
+        bounds: Vec<OpaqueTraitBound>,
+    },
     Syntax(TypeRef),
     Nominal(#[wincode(with = "rg_wincode_utils::WincodeDynamic<Vec<NominalTy>>")] Vec<NominalTy>),
     SelfTy(#[wincode(with = "rg_wincode_utils::WincodeDynamic<Vec<NominalTy>>")] Vec<NominalTy>),
@@ -99,6 +103,25 @@ pub struct NominalTy {
     pub def: TypeDefRef,
     #[wincode(with = "rg_wincode_utils::WincodeDynamic<Vec<GenericArg>>")]
     pub args: Vec<GenericArg>,
+}
+
+/// Resolved trait bound preserved for opaque `impl Trait` types.
+#[derive(
+    Debug, Clone, PartialEq, Eq, wincode::SchemaRead, wincode::SchemaWrite, rg_memsize::MemorySize,
+)]
+pub struct OpaqueTraitBound {
+    pub trait_ref: TraitRef,
+    #[wincode(with = "rg_wincode_utils::WincodeDynamic<Vec<GenericArg>>")]
+    pub args: Vec<GenericArg>,
+}
+
+impl OpaqueTraitBound {
+    fn shrink_to_fit(&mut self) {
+        self.args.shrink_to_fit();
+        for arg in &mut self.args {
+            arg.shrink_to_fit();
+        }
+    }
 }
 
 impl NominalTy {
@@ -150,6 +173,14 @@ impl Ty {
 
     pub fn syntax(ty: TypeRef) -> Self {
         Self::Syntax(ty)
+    }
+
+    pub fn opaque(bounds: Vec<OpaqueTraitBound>) -> Self {
+        if bounds.is_empty() {
+            return Self::Unknown;
+        }
+
+        Self::Opaque { bounds }
     }
 
     pub fn nominal(types: Vec<NominalTy>) -> Self {
@@ -210,6 +241,7 @@ impl Ty {
             | Self::Array { .. }
             | Self::Slice(_)
             | Self::Reference { .. }
+            | Self::Opaque { .. }
             | Self::Syntax(_)
             | Self::Unknown => &[],
         }
@@ -224,6 +256,7 @@ impl Ty {
             | Self::Tuple(_)
             | Self::Array { .. }
             | Self::Slice(_)
+            | Self::Opaque { .. }
             | Self::Syntax(_)
             | Self::Nominal(_)
             | Self::SelfTy(_)
@@ -236,6 +269,21 @@ impl Ty {
             tys.pop().expect("one type should exist")
         } else {
             Self::Unknown
+        }
+    }
+
+    pub(crate) fn is_projectable(&self) -> bool {
+        match self {
+            Self::Unknown | Self::Syntax(_) => false,
+            Self::Tuple(fields) => fields.iter().all(Self::is_projectable),
+            Self::Array { inner, .. } | Self::Slice(inner) => inner.is_projectable(),
+            Self::Reference { inner, .. } => inner.is_projectable(),
+            Self::Opaque { bounds } => bounds
+                .iter()
+                .all(|bound| bound.args.iter().all(GenericArg::is_projectable)),
+            Self::Unit | Self::Never | Self::Primitive(_) | Self::Nominal(_) | Self::SelfTy(_) => {
+                true
+            }
         }
     }
 
@@ -255,6 +303,12 @@ impl Ty {
             }
             Self::Slice(inner) => inner.shrink_to_fit(),
             Self::Reference { inner, .. } => inner.shrink_to_fit(),
+            Self::Opaque { bounds } => {
+                bounds.shrink_to_fit();
+                for bound in bounds {
+                    bound.shrink_to_fit();
+                }
+            }
             Self::Syntax(ty) => ty.shrink_to_fit(),
             Self::Nominal(types) | Self::SelfTy(types) => {
                 types.shrink_to_fit();


### PR DESCRIPTION
Support many common type inference cases:
- Less strict matching on lifetime generics arguments
- Primitives + operations on primitives
- fn trait generics
- Structural types support (with method resolution)
- Array-to-slice coercion (implemented via autoderef)
- Turbofish
- For loops (partially)
- Core prelude (prereq for iterator support in real projects)
- Trait associated consts


This PR is not "type inference is complete", but it is meant to be a reasonable chunk of work that can be implemented on the existing foundation without pivoting too much. The next slice will probably be _actual_ inference (still incomplete), but it's a separate scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced type inference for numeric literals, operators, and method calls with explicit generic arguments.
  * Improved iterator type propagation through method calls and trait-based iteration.
  * Refined trait method and associated constant resolution for qualified paths.
  * Better hover information for function-trait parameters and complex type expressions.
  * Added fallback to `core` prelude when `std` is unavailable for improved cross-platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->