### PR TITLE
test: Add engine/lsp/extension tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,6 +1550,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "derive_more",
+ "expect-test",
  "futures",
  "ls-types",
  "rg_analysis",
@@ -1561,6 +1562,7 @@ dependencies = [
  "rg_std",
  "rg_workspace",
  "tarpc",
+ "test_fixture",
  "tokio",
  "tracing",
 ]

--- a/crates/lsp/engine/Cargo.toml
+++ b/crates/lsp/engine/Cargo.toml
@@ -27,3 +27,7 @@ rg_workspace.workspace = true
 tarpc = { workspace = true, features = ["serde-transport", "serde-transport-json", "tcp", "tokio1"] }
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
+
+[dev-dependencies]
+expect-test.workspace = true
+test_fixture.workspace = true

--- a/crates/lsp/engine/src/lib.rs
+++ b/crates/lsp/engine/src/lib.rs
@@ -14,6 +14,9 @@ mod proto;
 mod rpc;
 mod service;
 
+#[cfg(test)]
+mod tests;
+
 pub use self::{
     memory::{AllocatorPurgeResult, AllocatorStats, MemoryControl},
     rpc::run_rpc,

--- a/crates/lsp/engine/src/service/mod.rs
+++ b/crates/lsp/engine/src/service/mod.rs
@@ -11,6 +11,9 @@ use crate::{
     memory::MemoryControl,
 };
 
+#[cfg(test)]
+pub(crate) use self::notifications::ServiceNotificationPublisher;
+
 /// RPC-facing façade owned by one engine process.
 ///
 /// `Service` is the boundary visible to the LSP server: it accepts editor-shaped requests and

--- a/crates/lsp/engine/src/service/notifications.rs
+++ b/crates/lsp/engine/src/service/notifications.rs
@@ -1,4 +1,10 @@
+use std::sync::Arc;
+
 use rg_lsp_proto::{NotificationsServiceClient, ServiceNotification};
+
+pub(crate) trait ServiceNotificationPublisher: std::fmt::Debug + Send + Sync {
+    fn send(&self, notification: ServiceNotification);
+}
 
 /// Fire-and-forget notifications from the service to the LSP orchestrator.
 ///
@@ -7,15 +13,32 @@ use rg_lsp_proto::{NotificationsServiceClient, ServiceNotification};
 /// boundary.
 #[derive(Clone, Debug)]
 pub struct ServiceNotificationsSink {
+    publisher: Arc<dyn ServiceNotificationPublisher>,
+}
+
+#[derive(Clone, Debug)]
+struct TarpcServiceNotificationPublisher {
     notifications: NotificationsServiceClient,
 }
 
 impl ServiceNotificationsSink {
     pub fn new(notifications: NotificationsServiceClient) -> Self {
-        Self { notifications }
+        Self::from_publisher(TarpcServiceNotificationPublisher { notifications })
+    }
+
+    pub(crate) fn from_publisher(publisher: impl ServiceNotificationPublisher + 'static) -> Self {
+        Self {
+            publisher: Arc::new(publisher),
+        }
     }
 
     pub(crate) fn send(&self, notification: ServiceNotification) {
+        self.publisher.send(notification);
+    }
+}
+
+impl ServiceNotificationPublisher for TarpcServiceNotificationPublisher {
+    fn send(&self, notification: ServiceNotification) {
         let notifications = self.notifications.clone();
         tokio::spawn(async move {
             match notifications

--- a/crates/lsp/engine/src/tests/dirty_flow.rs
+++ b/crates/lsp/engine/src/tests/dirty_flow.rs
@@ -1,0 +1,90 @@
+use expect_test::expect;
+use test_fixture::testonly::MarkedText;
+
+use super::utils::{LspEngineFixture, LspQuery};
+
+#[tokio::test]
+async fn queries_use_dirty_full_text_overlay() {
+    let fixture = LspEngineFixture::initialized(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "lsp_dirty_flow"
+        version = "0.1.0"
+        edition = "2024"
+
+        //- /src/lib.rs
+        pub struct SavedUser {
+            pub saved_field: SavedName,
+        }
+
+        pub struct SavedName;
+
+        pub fn demo(user: SavedUser) {
+            let _ = user.saved_field;
+        }
+        "#,
+    )
+    .await;
+
+    fixture.did_open_saved("src/lib.rs", 1).await;
+    let dirty = fixture
+        .did_change_full(
+            "src/lib.rs",
+            2,
+            MarkedText::parse(
+                r#"
+pub struct DirtyUser {
+    /// Field that exists only in the unsaved buffer.
+    pub dirty_field: DirtyName,
+}
+
+pub struct DirtyName;
+
+pub fn demo(user: DirtyUser) {
+    let _completion = user.$complete$;
+    let _hover = user.dirty_$hover$field;
+}
+"#,
+            ),
+        )
+        .await;
+
+    fixture
+        .check_dirty(
+            &dirty,
+            &[
+                LspQuery::completion("complete dirty field", "complete"),
+                LspQuery::hover("hover dirty field", "hover"),
+                LspQuery::document_symbol("dirty document symbols", "src/lib.rs"),
+            ],
+            expect![[r#"
+                complete dirty field
+                - dirty_field Field
+                  detail: pub dirty_field: DirtyName
+                  edit: /src/lib.rs:9:27-9:27 -> dirty_field
+
+                hover dirty field
+                - range: /src/lib.rs:10:22-10:33
+                - markdown:
+                  ```rust
+                  lsp_dirty_flow::DirtyUser
+                  ```
+
+                  ```rust
+                  pub dirty_field: DirtyName
+                  ```
+
+                  Field that exists only in the unsaved buffer.
+
+                dirty document symbols
+                - Struct DirtyUser 1:11-1:20
+                  - Field dirty_field 3:8-3:19
+                - Struct DirtyName 6:11-6:20
+                - Function demo 8:7-8:11
+            "#]],
+        )
+        .await;
+
+    fixture.shutdown().await;
+}

--- a/crates/lsp/engine/src/tests/flow.rs
+++ b/crates/lsp/engine/src/tests/flow.rs
@@ -1,0 +1,80 @@
+use expect_test::expect;
+
+use super::utils::{LspEngineFixture, LspQuery};
+
+#[tokio::test]
+async fn answers_lsp_queries_from_saved_project() {
+    let fixture = LspEngineFixture::initialized(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "lsp_saved_flow"
+        version = "0.1.0"
+        edition = "2024"
+
+        //- /src/lib.rs
+        /// Display name shown in the UI.
+        pub struct Name;
+
+        /// User account stored by the service.
+        pub struct User {
+            /// The user's display name.
+            pub name: Name,
+        }
+
+        /// Builds a user.
+        pub fn make_user() -> User {
+            User { name: Name }
+        }
+
+        pub fn demo() {
+            let user = make_u$goto$ser();
+            let _hover = make_$hover$user();
+            let _name = user.na$complete$;
+        }
+        "#,
+    )
+    .await;
+
+    fixture
+        .check(
+            &[
+                LspQuery::goto_definition("goto function", "goto"),
+                LspQuery::hover("hover function", "hover"),
+                LspQuery::completion("complete field", "complete"),
+                LspQuery::document_symbol("document symbols", "src/lib.rs"),
+            ],
+            expect![[r#"
+                goto function
+                - /src/lib.rs:10:7-10:16
+
+                hover function
+                - range: /src/lib.rs:16:17-16:26
+                - markdown:
+                  ```rust
+                  lsp_saved_flow::make_user
+                  ```
+
+                  ```rust
+                  pub fn make_user() -> User
+                  ```
+
+                  Builds a user.
+
+                complete field
+                - name Field
+                  detail: pub name: Name
+                  edit: /src/lib.rs:17:21-17:23 -> name
+
+                document symbols
+                - Struct Name 1:11-1:15
+                - Struct User 4:11-4:15
+                  - Field name 6:8-6:12
+                - Function make_user 10:7-10:16
+                - Function demo 14:7-14:11
+            "#]],
+        )
+        .await;
+
+    fixture.shutdown().await;
+}

--- a/crates/lsp/engine/src/tests/mod.rs
+++ b/crates/lsp/engine/src/tests/mod.rs
@@ -1,2 +1,3 @@
+mod dirty_flow;
 mod flow;
 mod utils;

--- a/crates/lsp/engine/src/tests/mod.rs
+++ b/crates/lsp/engine/src/tests/mod.rs
@@ -1,3 +1,4 @@
 mod dirty_flow;
 mod flow;
+mod save_flow;
 mod utils;

--- a/crates/lsp/engine/src/tests/mod.rs
+++ b/crates/lsp/engine/src/tests/mod.rs
@@ -1,0 +1,2 @@
+mod flow;
+mod utils;

--- a/crates/lsp/engine/src/tests/mod.rs
+++ b/crates/lsp/engine/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod dirty_flow;
 mod flow;
+mod rename_flow;
 mod save_flow;
 mod utils;

--- a/crates/lsp/engine/src/tests/rename_flow.rs
+++ b/crates/lsp/engine/src/tests/rename_flow.rs
@@ -1,0 +1,97 @@
+use expect_test::expect;
+use test_fixture::testonly::MarkedText;
+
+use super::utils::LspEngineFixture;
+
+#[tokio::test]
+async fn rename_returns_workspace_edit_for_clean_document() {
+    let fixture = LspEngineFixture::initialized(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "lsp_rename_clean_flow"
+        version = "0.1.0"
+        edition = "2024"
+
+        //- /src/lib.rs
+        pub struct User;
+
+        pub fn demo() {
+            let _user: Us$rename$er;
+        }
+        "#,
+    )
+    .await;
+
+    fixture
+        .check_rename(
+            "rename clean type",
+            "rename",
+            "Account",
+            expect![[r#"
+                rename clean type
+                - /src/lib.rs
+                  - 0:11-0:15 -> Account
+                  - 3:15-3:19 -> Account
+            "#]],
+        )
+        .await;
+
+    fixture.shutdown().await;
+}
+
+#[tokio::test]
+async fn rename_rejects_when_other_documents_are_dirty() {
+    let fixture = LspEngineFixture::initialized(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "lsp_rename_flow"
+        version = "0.1.0"
+        edition = "2024"
+
+        //- /src/lib.rs
+        mod other;
+
+        pub struct User;
+
+        pub fn demo() {
+            let _user: Us$rename$er;
+        }
+
+        //- /src/other.rs
+        pub fn helper() {}
+        "#,
+    )
+    .await;
+
+    fixture.did_open_saved("src/lib.rs", 1).await;
+    fixture.did_open_saved("src/other.rs", 1).await;
+    fixture
+        .did_change_full(
+            "src/other.rs",
+            2,
+            MarkedText::parse(
+                r#"
+pub fn helper() {
+    let _dirty = 1;
+}
+"#,
+            ),
+        )
+        .await;
+
+    fixture
+        .check_rename_error(
+            "rename with dirty sibling document",
+            "rename",
+            "Account",
+            expect![[r#"
+                rename with dirty sibling document
+                - rename requires saving other dirty Rust documents first
+            "#]],
+        )
+        .await;
+
+    fixture.shutdown().await;
+}

--- a/crates/lsp/engine/src/tests/save_flow.rs
+++ b/crates/lsp/engine/src/tests/save_flow.rs
@@ -1,0 +1,94 @@
+use expect_test::expect;
+use test_fixture::testonly::MarkedText;
+
+use super::utils::{LspEngineFixture, LspQuery};
+
+#[tokio::test]
+async fn save_promotes_dirty_text_to_saved_project() {
+    let fixture = LspEngineFixture::initialized(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "lsp_save_flow"
+        version = "0.1.0"
+        edition = "2024"
+
+        //- /src/lib.rs
+        pub struct SavedUser {
+            pub saved_field: SavedName,
+        }
+
+        pub struct SavedName;
+
+        pub fn demo(user: SavedUser) {
+            let _ = user.saved_field;
+        }
+        "#,
+    )
+    .await;
+
+    fixture.did_open_saved("src/lib.rs", 1).await;
+    let dirty = fixture
+        .did_change_full(
+            "src/lib.rs",
+            2,
+            MarkedText::parse(
+                r#"
+pub struct SavedUser {
+    pub renamed_field: SavedName,
+}
+
+pub struct SavedName;
+
+pub fn demo(user: SavedUser) {
+    let _completion = user.$complete$;
+    let _hover = user.renamed_$hover$field;
+}
+"#,
+            ),
+        )
+        .await;
+
+    fixture.did_save_dirty(&dirty).await;
+
+    fixture
+        .check_dirty(
+            &dirty,
+            &[
+                LspQuery::completion("complete saved field after save", "complete"),
+                LspQuery::hover("hover saved field after save", "hover"),
+                LspQuery::document_symbol("saved document symbols after save", "src/lib.rs"),
+            ],
+            expect![[r#"
+                complete saved field after save
+                - renamed_field Field
+                  detail: pub renamed_field: SavedName
+                  edit: /src/lib.rs:8:27-8:27 -> renamed_field
+
+                hover saved field after save
+                - range: /src/lib.rs:9:22-9:35
+                - markdown:
+                  ```rust
+                  lsp_save_flow::SavedUser
+                  ```
+
+                  ```rust
+                  pub renamed_field: SavedName
+                  ```
+
+                saved document symbols after save
+                - Struct SavedUser 1:11-1:20
+                  - Field renamed_field 2:8-2:21
+                - Struct SavedName 5:11-5:20
+                - Function demo 7:7-7:11
+            "#]],
+        )
+        .await;
+
+    fixture.check_notification_effects(expect![[r#"
+        notifications
+        - inlay hint refresh
+    "#]]);
+
+    fixture.shutdown().await;
+}

--- a/crates/lsp/engine/src/tests/utils.rs
+++ b/crates/lsp/engine/src/tests/utils.rs
@@ -26,6 +26,7 @@ pub(super) struct LspEngineFixture {
     fixture: CrateFixture,
     markers: FixtureMarkers,
     service: Service,
+    notifications: RecordingNotifications,
 }
 
 impl LspEngineFixture {
@@ -40,13 +41,14 @@ impl LspEngineFixture {
         let notifications = RecordingNotifications::default();
         let service = Service::spawn(
             Arc::new(()) as Arc<dyn MemoryControl>,
-            ServiceNotificationsSink::from_publisher(notifications),
+            ServiceNotificationsSink::from_publisher(notifications.clone()),
         );
 
         Self {
             fixture,
             markers,
             service,
+            notifications,
         }
     }
 
@@ -131,6 +133,94 @@ impl LspEngineFixture {
             .expect("fixture dirty document should change");
 
         DirtyDocument { path, text }
+    }
+
+    pub(super) async fn did_save_dirty(&self, dirty: &DirtyDocument) {
+        self.notifications.clear();
+        std::fs::write(self.fixture.path(dirty.path), dirty.text.text())
+            .expect("fixture dirty document should be writable before save");
+
+        self.service
+            .clone()
+            .did_save(
+                context::current(),
+                self.fixture.path(dirty.path),
+                Some(dirty.text.text().to_string()),
+            )
+            .await
+            .expect("fixture dirty document should save");
+    }
+
+    pub(super) fn check_notification_effects(&self, expect: Expect) {
+        let mut rendered = String::new();
+        writeln!(rendered, "notifications").expect("snapshot should be writable");
+
+        let notifications = self.notifications.snapshot();
+        if notifications.is_empty() {
+            writeln!(rendered, "- none").expect("snapshot should be writable");
+        }
+
+        let mut rendered_inlay_hint_refresh = false;
+        for notification in notifications {
+            match notification {
+                ServiceNotification::PublishDiagnostics {
+                    path,
+                    diagnostics,
+                    version,
+                } => {
+                    writeln!(
+                        rendered,
+                        "- publish diagnostics {} version {:?} count {}",
+                        self.render_path(path.as_path()),
+                        version,
+                        diagnostics.len(),
+                    )
+                    .expect("snapshot should be writable");
+                }
+                ServiceNotification::BeginWorkDoneProgress {
+                    token,
+                    title,
+                    message,
+                } => {
+                    writeln!(
+                        rendered,
+                        "- begin progress {token:?}: {title}{}",
+                        message
+                            .as_deref()
+                            .map(|message| format!(" ({message})"))
+                            .unwrap_or_default(),
+                    )
+                    .expect("snapshot should be writable");
+                }
+                ServiceNotification::EndWorkDoneProgress { token, message } => {
+                    writeln!(
+                        rendered,
+                        "- end progress {token:?}{}",
+                        message
+                            .as_deref()
+                            .map(|message| format!(" ({message})"))
+                            .unwrap_or_default(),
+                    )
+                    .expect("snapshot should be writable");
+                }
+                ServiceNotification::InlayHintRefresh => {
+                    // This snapshot records stable editor-facing effects, not the exact event log.
+                    // `didChange` may have a pending debounced refresh while `didSave` sends an
+                    // immediate refresh, so duplicate invalidations are intentionally collapsed.
+                    if !rendered_inlay_hint_refresh {
+                        writeln!(rendered, "- inlay hint refresh")
+                            .expect("snapshot should be writable");
+                        rendered_inlay_hint_refresh = true;
+                    }
+                }
+                ServiceNotification::LogMessage { level, message } => {
+                    writeln!(rendered, "- log {level:?}: {message}")
+                        .expect("snapshot should be writable");
+                }
+            }
+        }
+
+        expect.assert_eq(&rendered);
     }
 
     pub(super) async fn shutdown(&self) {
@@ -485,5 +575,21 @@ impl ServiceNotificationPublisher for RecordingNotifications {
             .lock()
             .expect("recorded notifications should not be poisoned")
             .push(notification);
+    }
+}
+
+impl RecordingNotifications {
+    fn clear(&self) {
+        self.notifications
+            .lock()
+            .expect("recorded notifications should not be poisoned")
+            .clear();
+    }
+
+    fn snapshot(&self) -> Vec<ServiceNotification> {
+        self.notifications
+            .lock()
+            .expect("recorded notifications should not be poisoned")
+            .clone()
     }
 }

--- a/crates/lsp/engine/src/tests/utils.rs
+++ b/crates/lsp/engine/src/tests/utils.rs
@@ -7,7 +7,7 @@ use std::{
 use expect_test::Expect;
 use ls_types::{
     CompletionItem, CompletionTextEdit, DocumentSymbol, Hover, HoverContents, Location, Position,
-    Range,
+    Range, WorkspaceEdit,
 };
 use rg_lsp_proto::{
     CompletionClientCapabilities, EngineConfig, EngineService, ServiceNotification,
@@ -220,6 +220,49 @@ impl LspEngineFixture {
             }
         }
 
+        expect.assert_eq(&rendered);
+    }
+
+    pub(super) async fn check_rename_error(
+        &self,
+        title: &'static str,
+        marker: &'static str,
+        new_name: &'static str,
+        expect: Expect,
+    ) {
+        let path = self.marker_path(QueryMarkers::Saved, marker);
+        let position = self.marker_position(QueryMarkers::Saved, marker);
+        let error = self
+            .service
+            .clone()
+            .rename(context::current(), path, position, new_name.to_string())
+            .await
+            .expect_err("rename should fail in this fixture");
+
+        let actual = format!("{title}\n- {error}\n");
+        expect.assert_eq(&actual);
+    }
+
+    pub(super) async fn check_rename(
+        &self,
+        title: &'static str,
+        marker: &'static str,
+        new_name: &'static str,
+        expect: Expect,
+    ) {
+        let path = self.marker_path(QueryMarkers::Saved, marker);
+        let position = self.marker_position(QueryMarkers::Saved, marker);
+        let edit = self
+            .service
+            .clone()
+            .rename(context::current(), path, position, new_name.to_string())
+            .await
+            .expect("rename query should succeed")
+            .expect("rename query should produce a workspace edit");
+
+        let mut rendered = String::new();
+        writeln!(rendered, "{title}").expect("snapshot should be writable");
+        self.render_workspace_edit(&mut rendered, &edit);
         expect.assert_eq(&rendered);
     }
 
@@ -467,6 +510,30 @@ impl LspEngineFixture {
             self.render_uri_path(&location.uri),
             Self::render_range(location.range)
         )
+    }
+
+    fn render_workspace_edit(&self, rendered: &mut String, edit: &WorkspaceEdit) {
+        let Some(changes) = &edit.changes else {
+            writeln!(rendered, "- no changes").expect("snapshot should be writable");
+            return;
+        };
+
+        let mut changes = changes.iter().collect::<Vec<_>>();
+        changes.sort_by(|(left, _), (right, _)| left.as_str().cmp(right.as_str()));
+
+        for (uri, edits) in changes {
+            writeln!(rendered, "- {}", self.render_uri_path(uri))
+                .expect("snapshot should be writable");
+            for edit in edits {
+                writeln!(
+                    rendered,
+                    "  - {} -> {}",
+                    Self::render_range(edit.range),
+                    Self::render_text(&edit.new_text),
+                )
+                .expect("snapshot should be writable");
+            }
+        }
     }
 
     fn render_uri_path(&self, uri: &ls_types::Uri) -> String {

--- a/crates/lsp/engine/src/tests/utils.rs
+++ b/crates/lsp/engine/src/tests/utils.rs
@@ -14,7 +14,9 @@ use rg_lsp_proto::{
 };
 use rg_parse::LineIndex;
 use tarpc::context;
-use test_fixture::{CrateFixture, FixtureMarkers, fixture_crate_with_markers};
+use test_fixture::{
+    CrateFixture, FixtureMarkers, fixture_crate_with_markers, testonly::MarkedText,
+};
 
 use crate::{
     MemoryControl, Service, ServiceNotificationsSink, service::ServiceNotificationPublisher,
@@ -61,6 +63,26 @@ impl LspEngineFixture {
     }
 
     pub(super) async fn check(&self, queries: &[LspQuery], expect: Expect) {
+        self.check_with_markers(QueryMarkers::Saved, queries, expect)
+            .await;
+    }
+
+    pub(super) async fn check_dirty(
+        &self,
+        dirty: &DirtyDocument,
+        queries: &[LspQuery],
+        expect: Expect,
+    ) {
+        self.check_with_markers(QueryMarkers::Dirty(dirty), queries, expect)
+            .await;
+    }
+
+    async fn check_with_markers(
+        &self,
+        markers: QueryMarkers<'_>,
+        queries: &[LspQuery],
+        expect: Expect,
+    ) {
         let mut rendered = String::new();
 
         for (idx, query) in queries.iter().enumerate() {
@@ -68,10 +90,47 @@ impl LspEngineFixture {
                 rendered.push('\n');
             }
 
-            self.render_query(&mut rendered, query).await;
+            self.render_query(&mut rendered, markers, query).await;
         }
 
         expect.assert_eq(&rendered);
+    }
+
+    pub(super) async fn did_open_saved(&self, path: &str, version: i32) {
+        let text = std::fs::read_to_string(self.fixture.path(path))
+            .expect("fixture saved document should be readable");
+
+        self.service
+            .clone()
+            .did_open(
+                context::current(),
+                self.fixture.path(path),
+                Some(version),
+                text,
+            )
+            .await
+            .expect("fixture saved document should open");
+    }
+
+    pub(super) async fn did_change_full(
+        &self,
+        path: &'static str,
+        version: i32,
+        text: MarkedText,
+    ) -> DirtyDocument {
+        self.service
+            .clone()
+            .did_change(
+                context::current(),
+                self.fixture.path(path),
+                Some(version),
+                Some(text.text().to_string()),
+                1,
+            )
+            .await
+            .expect("fixture dirty document should change");
+
+        DirtyDocument { path, text }
     }
 
     pub(super) async fn shutdown(&self) {
@@ -82,11 +141,16 @@ impl LspEngineFixture {
             .expect("fixture LSP engine should shut down");
     }
 
-    async fn render_query(&self, rendered: &mut String, query: &LspQuery) {
+    async fn render_query(
+        &self,
+        rendered: &mut String,
+        markers: QueryMarkers<'_>,
+        query: &LspQuery,
+    ) {
         match query {
             LspQuery::GotoDefinition { title, marker } => {
-                let path = self.marker_path(marker);
-                let position = self.marker_position(marker);
+                let path = self.marker_path(markers, marker);
+                let position = self.marker_position(markers, marker);
                 let locations = self
                     .service
                     .clone()
@@ -98,8 +162,8 @@ impl LspEngineFixture {
                 self.render_locations(rendered, &locations);
             }
             LspQuery::Hover { title, marker } => {
-                let path = self.marker_path(marker);
-                let position = self.marker_position(marker);
+                let path = self.marker_path(markers, marker);
+                let position = self.marker_position(markers, marker);
                 let hover = self
                     .service
                     .clone()
@@ -111,8 +175,8 @@ impl LspEngineFixture {
                 self.render_hover(rendered, path.as_path(), hover.as_ref());
             }
             LspQuery::Completion { title, marker } => {
-                let path = self.marker_path(marker);
-                let position = self.marker_position(marker);
+                let path = self.marker_path(markers, marker);
+                let position = self.marker_position(markers, marker);
                 let completions = self
                     .service
                     .clone()
@@ -142,16 +206,30 @@ impl LspEngineFixture {
         }
     }
 
-    fn marker_path(&self, marker: &str) -> std::path::PathBuf {
-        let marker = self.markers.position(marker);
-        self.fixture.path(&marker.path)
+    fn marker_path(&self, markers: QueryMarkers<'_>, marker: &str) -> std::path::PathBuf {
+        match markers {
+            QueryMarkers::Saved => {
+                let marker = self.markers.position(marker);
+                self.fixture.path(&marker.path)
+            }
+            QueryMarkers::Dirty(document) => self.fixture.path(document.path),
+        }
     }
 
-    fn marker_position(&self, marker: &str) -> Position {
-        let marker = self.markers.position(marker);
-        let text = std::fs::read_to_string(self.fixture.path(&marker.path))
-            .expect("fixture marker file should be readable");
-        let position = LineIndex::new(&text).utf16_position(marker.offset);
+    fn marker_position(&self, markers: QueryMarkers<'_>, marker: &str) -> Position {
+        let position = match markers {
+            QueryMarkers::Saved => {
+                let marker = self.markers.position(marker);
+                let text = std::fs::read_to_string(self.fixture.path(&marker.path))
+                    .expect("fixture marker file should be readable");
+                LineIndex::new(&text).utf16_position(marker.offset)
+            }
+            QueryMarkers::Dirty(document) => {
+                let offset = u32::try_from(document.text.offset(marker))
+                    .expect("dirty marker offset should fit into u32");
+                LineIndex::new(document.text.text()).utf16_position(offset)
+            }
+        };
 
         Position::new(position.line, position.column)
     }
@@ -346,6 +424,17 @@ impl LspEngineFixture {
             }
         }
     }
+}
+
+pub(super) struct DirtyDocument {
+    path: &'static str,
+    text: MarkedText,
+}
+
+#[derive(Clone, Copy)]
+enum QueryMarkers<'a> {
+    Saved,
+    Dirty(&'a DirtyDocument),
 }
 
 pub(super) enum LspQuery {

--- a/crates/lsp/engine/src/tests/utils.rs
+++ b/crates/lsp/engine/src/tests/utils.rs
@@ -1,0 +1,400 @@
+use std::{
+    fmt::Write as _,
+    path::Path,
+    sync::{Arc, Mutex},
+};
+
+use expect_test::Expect;
+use ls_types::{
+    CompletionItem, CompletionTextEdit, DocumentSymbol, Hover, HoverContents, Location, Position,
+    Range,
+};
+use rg_lsp_proto::{
+    CompletionClientCapabilities, EngineConfig, EngineService, ServiceNotification,
+};
+use rg_parse::LineIndex;
+use tarpc::context;
+use test_fixture::{CrateFixture, FixtureMarkers, fixture_crate_with_markers};
+
+use crate::{
+    MemoryControl, Service, ServiceNotificationsSink, service::ServiceNotificationPublisher,
+};
+
+pub(super) struct LspEngineFixture {
+    fixture: CrateFixture,
+    markers: FixtureMarkers,
+    service: Service,
+}
+
+impl LspEngineFixture {
+    pub(super) async fn initialized(fixture: &str) -> Self {
+        let mut fixture = Self::new(fixture);
+        fixture.initialize().await;
+        fixture
+    }
+
+    fn new(fixture: &str) -> Self {
+        let (fixture, markers) = fixture_crate_with_markers(fixture);
+        let notifications = RecordingNotifications::default();
+        let service = Service::spawn(
+            Arc::new(()) as Arc<dyn MemoryControl>,
+            ServiceNotificationsSink::from_publisher(notifications),
+        );
+
+        Self {
+            fixture,
+            markers,
+            service,
+        }
+    }
+
+    async fn initialize(&mut self) {
+        self.service
+            .clone()
+            .initialize(
+                context::current(),
+                self.fixture.path(""),
+                EngineConfig::default(),
+            )
+            .await
+            .expect("fixture LSP engine should initialize");
+    }
+
+    pub(super) async fn check(&self, queries: &[LspQuery], expect: Expect) {
+        let mut rendered = String::new();
+
+        for (idx, query) in queries.iter().enumerate() {
+            if idx > 0 {
+                rendered.push('\n');
+            }
+
+            self.render_query(&mut rendered, query).await;
+        }
+
+        expect.assert_eq(&rendered);
+    }
+
+    pub(super) async fn shutdown(&self) {
+        self.service
+            .clone()
+            .shutdown(context::current())
+            .await
+            .expect("fixture LSP engine should shut down");
+    }
+
+    async fn render_query(&self, rendered: &mut String, query: &LspQuery) {
+        match query {
+            LspQuery::GotoDefinition { title, marker } => {
+                let path = self.marker_path(marker);
+                let position = self.marker_position(marker);
+                let locations = self
+                    .service
+                    .clone()
+                    .goto_definition(context::current(), path, position)
+                    .await
+                    .expect("goto definition query should succeed");
+
+                writeln!(rendered, "{title}").expect("snapshot should be writable");
+                self.render_locations(rendered, &locations);
+            }
+            LspQuery::Hover { title, marker } => {
+                let path = self.marker_path(marker);
+                let position = self.marker_position(marker);
+                let hover = self
+                    .service
+                    .clone()
+                    .hover(context::current(), path.clone(), position)
+                    .await
+                    .expect("hover query should succeed");
+
+                writeln!(rendered, "{title}").expect("snapshot should be writable");
+                self.render_hover(rendered, path.as_path(), hover.as_ref());
+            }
+            LspQuery::Completion { title, marker } => {
+                let path = self.marker_path(marker);
+                let position = self.marker_position(marker);
+                let completions = self
+                    .service
+                    .clone()
+                    .completion(
+                        context::current(),
+                        path.clone(),
+                        position,
+                        CompletionClientCapabilities::default(),
+                    )
+                    .await
+                    .expect("completion query should succeed");
+
+                writeln!(rendered, "{title}").expect("snapshot should be writable");
+                self.render_completions(rendered, path.as_path(), &completions);
+            }
+            LspQuery::DocumentSymbol { title, path } => {
+                let symbols = self
+                    .service
+                    .clone()
+                    .document_symbol(context::current(), self.fixture.path(path))
+                    .await
+                    .expect("document symbol query should succeed");
+
+                writeln!(rendered, "{title}").expect("snapshot should be writable");
+                self.render_document_symbols(rendered, &symbols, 0);
+            }
+        }
+    }
+
+    fn marker_path(&self, marker: &str) -> std::path::PathBuf {
+        let marker = self.markers.position(marker);
+        self.fixture.path(&marker.path)
+    }
+
+    fn marker_position(&self, marker: &str) -> Position {
+        let marker = self.markers.position(marker);
+        let text = std::fs::read_to_string(self.fixture.path(&marker.path))
+            .expect("fixture marker file should be readable");
+        let position = LineIndex::new(&text).utf16_position(marker.offset);
+
+        Position::new(position.line, position.column)
+    }
+
+    fn render_locations(&self, rendered: &mut String, locations: &[Location]) {
+        if locations.is_empty() {
+            writeln!(rendered, "- none").expect("snapshot should be writable");
+            return;
+        }
+
+        for location in locations {
+            writeln!(rendered, "- {}", self.render_location(location))
+                .expect("snapshot should be writable");
+        }
+    }
+
+    fn render_hover(&self, rendered: &mut String, path: &Path, hover: Option<&Hover>) {
+        let Some(hover) = hover else {
+            writeln!(rendered, "- none").expect("snapshot should be writable");
+            return;
+        };
+
+        if let Some(range) = hover.range {
+            writeln!(
+                rendered,
+                "- range: {}:{}",
+                self.render_path(path),
+                Self::render_range(range),
+            )
+            .expect("snapshot should be writable");
+        }
+
+        writeln!(rendered, "- markdown:").expect("snapshot should be writable");
+        match &hover.contents {
+            HoverContents::Markup(markup) => Self::write_indented(rendered, &markup.value, "  "),
+            HoverContents::Scalar(marked) => {
+                Self::write_indented(rendered, &format!("{marked:?}"), "  ")
+            }
+            HoverContents::Array(marked) => {
+                for value in marked {
+                    Self::write_indented(rendered, &format!("{value:?}"), "  ");
+                }
+            }
+        }
+    }
+
+    fn render_completions(
+        &self,
+        rendered: &mut String,
+        path: &Path,
+        completions: &[CompletionItem],
+    ) {
+        if completions.is_empty() {
+            writeln!(rendered, "- none").expect("snapshot should be writable");
+            return;
+        }
+
+        for completion in completions {
+            let kind = completion
+                .kind
+                .map(|kind| format!("{kind:?}"))
+                .unwrap_or_else(|| "Unknown".to_string());
+            writeln!(rendered, "- {} {kind}", completion.label)
+                .expect("snapshot should be writable");
+
+            if let Some(detail) = &completion.detail {
+                writeln!(rendered, "  detail: {detail}").expect("snapshot should be writable");
+            }
+
+            if let Some(edit) = &completion.text_edit {
+                self.render_completion_edit(rendered, path, edit);
+            }
+        }
+    }
+
+    fn render_completion_edit(
+        &self,
+        rendered: &mut String,
+        path: &Path,
+        edit: &CompletionTextEdit,
+    ) {
+        match edit {
+            CompletionTextEdit::Edit(edit) => {
+                writeln!(
+                    rendered,
+                    "  edit: {}:{} -> {}",
+                    self.render_path(path),
+                    Self::render_range(edit.range),
+                    Self::render_text(&edit.new_text),
+                )
+                .expect("snapshot should be writable");
+            }
+            CompletionTextEdit::InsertAndReplace(edit) => {
+                writeln!(
+                    rendered,
+                    "  insert: {}:{} -> {}",
+                    self.render_path(path),
+                    Self::render_range(edit.insert),
+                    Self::render_text(&edit.new_text),
+                )
+                .expect("snapshot should be writable");
+                writeln!(
+                    rendered,
+                    "  replace: {}:{} -> {}",
+                    self.render_path(path),
+                    Self::render_range(edit.replace),
+                    Self::render_text(&edit.new_text),
+                )
+                .expect("snapshot should be writable");
+            }
+        }
+    }
+
+    fn render_document_symbols(
+        &self,
+        rendered: &mut String,
+        symbols: &[DocumentSymbol],
+        depth: usize,
+    ) {
+        if symbols.is_empty() && depth == 0 {
+            writeln!(rendered, "- none").expect("snapshot should be writable");
+            return;
+        }
+
+        let indent = "  ".repeat(depth);
+        for symbol in symbols {
+            writeln!(
+                rendered,
+                "{indent}- {:?} {} {}",
+                symbol.kind,
+                symbol.name,
+                Self::render_range(symbol.selection_range),
+            )
+            .expect("snapshot should be writable");
+
+            if let Some(children) = &symbol.children {
+                self.render_document_symbols(rendered, children, depth + 1);
+            }
+        }
+    }
+
+    fn render_location(&self, location: &Location) -> String {
+        format!(
+            "{}:{}",
+            self.render_uri_path(&location.uri),
+            Self::render_range(location.range)
+        )
+    }
+
+    fn render_uri_path(&self, uri: &ls_types::Uri) -> String {
+        uri.to_file_path()
+            .map(|path| self.render_path(path.as_ref()))
+            .unwrap_or_else(|| uri.as_str().to_string())
+    }
+
+    fn render_path(&self, path: &Path) -> String {
+        let root = self
+            .fixture
+            .path("")
+            .canonicalize()
+            .expect("fixture root should canonicalize");
+        let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+
+        if let Ok(relative) = path.strip_prefix(root) {
+            return format!("/{}", relative.display());
+        }
+
+        path.display().to_string()
+    }
+
+    fn render_range(range: Range) -> String {
+        format!(
+            "{}:{}-{}:{}",
+            range.start.line, range.start.character, range.end.line, range.end.character
+        )
+    }
+
+    fn render_text(text: &str) -> String {
+        if text.contains('\n') {
+            format!("{text:?}")
+        } else {
+            text.to_string()
+        }
+    }
+
+    fn write_indented(rendered: &mut String, text: &str, indent: &str) {
+        for line in text.lines() {
+            if line.is_empty() {
+                rendered.push('\n');
+            } else {
+                writeln!(rendered, "{indent}{line}").expect("snapshot should be writable");
+            }
+        }
+    }
+}
+
+pub(super) enum LspQuery {
+    GotoDefinition {
+        title: &'static str,
+        marker: &'static str,
+    },
+    Hover {
+        title: &'static str,
+        marker: &'static str,
+    },
+    Completion {
+        title: &'static str,
+        marker: &'static str,
+    },
+    DocumentSymbol {
+        title: &'static str,
+        path: &'static str,
+    },
+}
+
+impl LspQuery {
+    pub(super) fn goto_definition(title: &'static str, marker: &'static str) -> Self {
+        Self::GotoDefinition { title, marker }
+    }
+
+    pub(super) fn hover(title: &'static str, marker: &'static str) -> Self {
+        Self::Hover { title, marker }
+    }
+
+    pub(super) fn completion(title: &'static str, marker: &'static str) -> Self {
+        Self::Completion { title, marker }
+    }
+
+    pub(super) fn document_symbol(title: &'static str, path: &'static str) -> Self {
+        Self::DocumentSymbol { title, path }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct RecordingNotifications {
+    notifications: Arc<Mutex<Vec<ServiceNotification>>>,
+}
+
+impl ServiceNotificationPublisher for RecordingNotifications {
+    fn send(&self, notification: ServiceNotification) {
+        self.notifications
+            .lock()
+            .expect("recorded notifications should not be poisoned")
+            .push(notification);
+    }
+}

--- a/crates/lsp/server/src/backend.rs
+++ b/crates/lsp/server/src/backend.rs
@@ -443,3 +443,46 @@ fn workspace_folders(params: &InitializeParams) -> Vec<PathBuf> {
     folders.dedup();
     folders
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{path::Path, str::FromStr};
+
+    use tower_lsp_server::ls_types::{InitializeParams, Uri, WorkspaceFolder};
+
+    use super::workspace_folders;
+
+    #[test]
+    fn workspace_folders_keep_unique_filesystem_roots_in_stable_order() {
+        let root = std::env::current_dir()
+            .expect("test process should have a current directory")
+            .join("server-workspaces");
+        let project_a = root.join("project_a");
+        let project_b = root.join("project_b");
+        let params = InitializeParams {
+            workspace_folders: Some(vec![
+                workspace_folder(&project_b),
+                workspace_folder(&project_a),
+                workspace_folder(&project_b),
+                WorkspaceFolder {
+                    uri: Uri::from_str("untitled:Scratch").expect("untitled URI should be valid"),
+                    name: "scratch".to_string(),
+                },
+            ]),
+            ..Default::default()
+        };
+
+        assert_eq!(workspace_folders(&params), vec![project_a, project_b]);
+    }
+
+    fn workspace_folder(path: &Path) -> WorkspaceFolder {
+        WorkspaceFolder {
+            uri: Uri::from_file_path(path).expect("test path should convert to URI"),
+            name: path
+                .file_name()
+                .expect("test path should have a file name")
+                .to_string_lossy()
+                .into_owned(),
+        }
+    }
+}

--- a/crates/lsp/server/src/client_notifications.rs
+++ b/crates/lsp/server/src/client_notifications.rs
@@ -59,3 +59,61 @@ impl ActiveWorkspaceState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_workspace_changed_params_render_state_and_optional_message() {
+        let cases = [
+            (
+                ActiveWorkspaceStatus {
+                    root: PathBuf::from("workspace/project_a"),
+                    state: ActiveWorkspaceState::Indexing,
+                    message: None,
+                },
+                "root: workspace/project_a\nstate: indexing",
+            ),
+            (
+                ActiveWorkspaceStatus {
+                    root: PathBuf::from("workspace/project_b"),
+                    state: ActiveWorkspaceState::Ready,
+                    message: None,
+                },
+                "root: workspace/project_b\nstate: ready",
+            ),
+            (
+                ActiveWorkspaceStatus {
+                    root: PathBuf::from("workspace/project_c"),
+                    state: ActiveWorkspaceState::Failed,
+                    message: Some("engine process exited unexpectedly".to_string()),
+                },
+                "message: engine process exited unexpectedly\nroot: workspace/project_c\nstate: failed",
+            ),
+        ];
+
+        for (status, expected) in cases {
+            let actual = render_params(ActiveWorkspaceChanged::params(&status));
+            assert_eq!(actual, expected);
+        }
+    }
+
+    fn render_params(params: LSPAny) -> String {
+        let LSPAny::Object(params) = params else {
+            panic!("active workspace notification params should be an object");
+        };
+
+        let mut entries = params
+            .into_iter()
+            .map(|(key, value)| {
+                let LSPAny::String(value) = value else {
+                    panic!("active workspace notification field `{key}` should be a string");
+                };
+                format!("{key}: {value}")
+            })
+            .collect::<Vec<_>>();
+        entries.sort();
+        entries.join("\n")
+    }
+}

--- a/crates/lsp/server/src/methods/mod.rs
+++ b/crates/lsp/server/src/methods/mod.rs
@@ -53,3 +53,35 @@ pub(crate) fn uri_to_path(uri: &Uri) -> Option<PathBuf> {
 
     uri.to_file_path().map(|path| path.into_owned())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::uri_to_path;
+    use tower_lsp_server::ls_types::Uri;
+
+    #[test]
+    fn uri_to_path_accepts_only_file_uris() {
+        let file_path = std::env::current_dir()
+            .expect("test process should have a current directory")
+            .join("src/lib.rs");
+        let file_uri = Uri::from_file_path(&file_path).expect("test path should convert to URI");
+        let cases = [
+            (file_uri, Some(file_path)),
+            (
+                Uri::from_str("untitled:Scratch").expect("untitled URI should be valid"),
+                None,
+            ),
+            (
+                Uri::from_str("rust-analyzer://synthetic/lib.rs")
+                    .expect("custom URI should be valid"),
+                None,
+            ),
+        ];
+
+        for (uri, expected) in cases {
+            assert_eq!(uri_to_path(&uri), expected);
+        }
+    }
+}

--- a/crates/lsp/server/src/tests/engine_routing.rs
+++ b/crates/lsp/server/src/tests/engine_routing.rs
@@ -91,3 +91,40 @@ external file keeps active engine: active e0 /workspace
 "#,
     );
 }
+
+#[test]
+fn respects_workspace_folder_boundaries_during_discovery_and_spawn() {
+    check_routing(
+        RoutingFixture::new(MULTI_PROJECT_FIXTURE)
+            .workspace_folders(["workspace/project_a", "workspace/project_a/vendor"]),
+        &[
+            RoutingStep::discovery_workspace(
+                "project file discovers nearest configured folder",
+                "workspace/project_a/src/lib.rs",
+            ),
+            RoutingStep::discovery_workspace(
+                "nested file discovers most specific configured folder",
+                "workspace/project_a/vendor/member/src/lib.rs",
+            ),
+            RoutingStep::discovery_workspace(
+                "external file has no discovery folder",
+                "external/thin_vec/src/lib.rs",
+            ),
+            RoutingStep::workspace_root(
+                "resolved project root inside configured folder spawns engine",
+                "workspace/project_a",
+            ),
+            RoutingStep::workspace_root(
+                "resolved external root outside configured folders does not spawn",
+                "external",
+            ),
+        ],
+        r#"
+project file discovers nearest configured folder: /workspace/project_a
+nested file discovers most specific configured folder: /workspace/project_a/vendor
+external file has no discovery folder: none
+resolved project root inside configured folder spawns engine: spawn e0 /workspace/project_a
+resolved external root outside configured folders does not spawn: none
+"#,
+    );
+}

--- a/crates/lsp/server/src/tests/utils.rs
+++ b/crates/lsp/server/src/tests/utils.rs
@@ -56,6 +56,15 @@ impl RoutingFixture {
                     writeln!(rendered, "{title}: {}", self.render_workspace_route(&route))
                         .expect("routing snapshot should be writable");
                 }
+                RoutingStep::DiscoveryWorkspace { title, path } => {
+                    let workspace = self
+                        .routing
+                        .discovery_workspace_for(&self.path(path))
+                        .map(|path| self.render_path(path))
+                        .unwrap_or_else(|| "none".to_string());
+                    writeln!(rendered, "{title}: {workspace}")
+                        .expect("routing snapshot should be writable");
+                }
                 RoutingStep::OpenFile { title, path } => {
                     let active = self
                         .routing
@@ -157,6 +166,10 @@ pub(super) enum RoutingStep {
         title: &'static str,
         workspace_root: &'static str,
     },
+    DiscoveryWorkspace {
+        title: &'static str,
+        path: &'static str,
+    },
     OpenFile {
         title: &'static str,
         path: &'static str,
@@ -180,6 +193,10 @@ impl RoutingStep {
             title,
             workspace_root,
         }
+    }
+
+    pub(super) fn discovery_workspace(title: &'static str, path: &'static str) -> Self {
+        Self::DiscoveryWorkspace { title, path }
     }
 
     pub(super) fn open_file(title: &'static str, path: &'static str) -> Self {

--- a/editors/code/src/features/hover-actions-model.ts
+++ b/editors/code/src/features/hover-actions-model.ts
@@ -1,0 +1,192 @@
+/**
+ * Pure hover-action model helpers. VS Code objects are adapted at the edge in `hover-actions.ts`;
+ * this file keeps command-link generation and location filtering easy to unit-test.
+ */
+
+export interface SerializedLocation {
+  readonly uri: string;
+  readonly range: SerializedRange;
+}
+
+export interface SerializedRange {
+  readonly start: SerializedPosition;
+  readonly end: SerializedPosition;
+}
+
+export interface SerializedPosition {
+  readonly line: number;
+  readonly character: number;
+}
+
+export interface HoverAction {
+  readonly command: string;
+  readonly label: string;
+  readonly locations: readonly SerializedLocation[];
+}
+
+export interface HoverActionLinkLine {
+  readonly markdown: string;
+  readonly enabledCommands: readonly string[];
+}
+
+interface ProtocolLocationLike {
+  readonly uri: string;
+  readonly range: SerializedRange;
+}
+
+interface ProtocolLocationLinkLike {
+  readonly targetUri: string;
+  readonly targetRange: SerializedRange;
+  readonly targetSelectionRange?: SerializedRange;
+}
+
+export type ProtocolDefinitionLike =
+  | ProtocolLocationLike
+  | readonly (ProtocolLocationLike | ProtocolLocationLinkLike)[]
+  | null;
+
+export function hoverAction(
+  command: string,
+  locations: readonly SerializedLocation[],
+  singularLabel: string,
+  pluralNoun: string,
+): HoverAction {
+  const label = locations.length === 1 ? singularLabel : `${locations.length} ${pluralNoun}`;
+  return { command, label, locations };
+}
+
+export function hoverActionLinkLine(actions: readonly HoverAction[]): HoverActionLinkLine {
+  const links = actions.map(commandLink).join(" | ");
+  return {
+    markdown: `Go to ${links}`,
+    enabledCommands: actions.map((action) => action.command),
+  };
+}
+
+export function protocolDefinitionLocations(
+  definition: ProtocolDefinitionLike,
+): SerializedLocation[] {
+  if (definition === null) {
+    return [];
+  }
+
+  const values = Array.isArray(definition) ? definition : [definition];
+  return values.map((value) => {
+    if (isLocationLink(value)) {
+      return {
+        uri: value.targetUri,
+        range: value.targetSelectionRange ?? value.targetRange,
+      };
+    }
+
+    return {
+      uri: value.uri,
+      range: value.range,
+    };
+  });
+}
+
+export function uniqueLocations(locations: SerializedLocation[]): SerializedLocation[] {
+  const seen = new Set<string>();
+  const unique = [];
+
+  for (const location of locations) {
+    const key = JSON.stringify(location);
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    unique.push(location);
+  }
+
+  return unique;
+}
+
+export function locationsExcludingCurrentHover(
+  locations: SerializedLocation[],
+  documentUri: string,
+  hoverRange: SerializedRange | undefined,
+): SerializedLocation[] {
+  if (hoverRange === undefined) {
+    return locations;
+  }
+
+  // Type-definition providers often return the declaration itself when hovering a type
+  // declaration. Suppress that self-link so hover actions stay useful rather than decorative.
+  return locations.filter(
+    (location) => location.uri !== documentUri || !sameRange(location.range, hoverRange),
+  );
+}
+
+export function deserializeSerializedLocations(value: unknown): SerializedLocation[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((location) => {
+    const parsed = deserializeLocation(location);
+    return parsed === undefined ? [] : [parsed];
+  });
+}
+
+function commandLink(action: HoverAction): string {
+  const args = encodeURIComponent(JSON.stringify([action.locations]));
+  return `[${action.label}](command:${action.command}?${args})`;
+}
+
+function deserializeLocation(value: unknown): SerializedLocation | undefined {
+  if (!isRecord(value) || typeof value.uri !== "string" || !isRecord(value.range)) {
+    return undefined;
+  }
+
+  const range = deserializeRange(value.range);
+  if (range === undefined) {
+    return undefined;
+  }
+
+  return { uri: value.uri, range };
+}
+
+function deserializeRange(value: unknown): SerializedRange | undefined {
+  if (!isRecord(value) || !isRecord(value.start) || !isRecord(value.end)) {
+    return undefined;
+  }
+
+  const start = deserializePosition(value.start);
+  const end = deserializePosition(value.end);
+  if (start === undefined || end === undefined) {
+    return undefined;
+  }
+
+  return { start, end };
+}
+
+function deserializePosition(value: unknown): SerializedPosition | undefined {
+  if (!isRecord(value) || typeof value.line !== "number" || typeof value.character !== "number") {
+    return undefined;
+  }
+
+  return {
+    line: value.line,
+    character: value.character,
+  };
+}
+
+function sameRange(left: SerializedRange, right: SerializedRange): boolean {
+  return samePosition(left.start, right.start) && samePosition(left.end, right.end);
+}
+
+function samePosition(left: SerializedPosition, right: SerializedPosition): boolean {
+  return left.line === right.line && left.character === right.character;
+}
+
+function isLocationLink(
+  value: ProtocolLocationLike | ProtocolLocationLinkLike,
+): value is ProtocolLocationLinkLike {
+  return "targetUri" in value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/editors/code/src/features/hover-actions-model.ts
+++ b/editors/code/src/features/hover-actions-model.ts
@@ -119,58 +119,9 @@ export function locationsExcludingCurrentHover(
   );
 }
 
-export function deserializeSerializedLocations(value: unknown): SerializedLocation[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.flatMap((location) => {
-    const parsed = deserializeLocation(location);
-    return parsed === undefined ? [] : [parsed];
-  });
-}
-
 function commandLink(action: HoverAction): string {
   const args = encodeURIComponent(JSON.stringify([action.locations]));
   return `[${action.label}](command:${action.command}?${args})`;
-}
-
-function deserializeLocation(value: unknown): SerializedLocation | undefined {
-  if (!isRecord(value) || typeof value.uri !== "string" || !isRecord(value.range)) {
-    return undefined;
-  }
-
-  const range = deserializeRange(value.range);
-  if (range === undefined) {
-    return undefined;
-  }
-
-  return { uri: value.uri, range };
-}
-
-function deserializeRange(value: unknown): SerializedRange | undefined {
-  if (!isRecord(value) || !isRecord(value.start) || !isRecord(value.end)) {
-    return undefined;
-  }
-
-  const start = deserializePosition(value.start);
-  const end = deserializePosition(value.end);
-  if (start === undefined || end === undefined) {
-    return undefined;
-  }
-
-  return { start, end };
-}
-
-function deserializePosition(value: unknown): SerializedPosition | undefined {
-  if (!isRecord(value) || typeof value.line !== "number" || typeof value.character !== "number") {
-    return undefined;
-  }
-
-  return {
-    line: value.line,
-    character: value.character,
-  };
 }
 
 function sameRange(left: SerializedRange, right: SerializedRange): boolean {
@@ -185,8 +136,4 @@ function isLocationLink(
   value: ProtocolLocationLike | ProtocolLocationLinkLike,
 ): value is ProtocolLocationLinkLike {
   return "targetUri" in value;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }

--- a/editors/code/src/features/hover-actions.ts
+++ b/editors/code/src/features/hover-actions.ts
@@ -8,37 +8,24 @@ import * as vscode from "vscode";
 import {
   ImplementationRequest,
   TypeDefinitionRequest,
-  type Definition,
   type ImplementationParams,
   type LanguageClient,
   type LanguageClientOptions,
-  type Location as ProtocolLocation,
-  type LocationLink as ProtocolLocationLink,
   type TypeDefinitionParams,
 } from "vscode-languageclient/node";
 
 import { EXTENSION_COMMANDS } from "../commands";
-
-interface SerializedLocation {
-  readonly uri: string;
-  readonly range: SerializedRange;
-}
-
-interface SerializedRange {
-  readonly start: SerializedPosition;
-  readonly end: SerializedPosition;
-}
-
-interface SerializedPosition {
-  readonly line: number;
-  readonly character: number;
-}
-
-interface HoverAction {
-  readonly command: string;
-  readonly label: string;
-  readonly locations: readonly SerializedLocation[];
-}
+import {
+  deserializeSerializedLocations,
+  hoverAction,
+  hoverActionLinkLine,
+  locationsExcludingCurrentHover,
+  protocolDefinitionLocations,
+  uniqueLocations,
+  type HoverAction,
+  type SerializedLocation,
+  type SerializedRange,
+} from "./hover-actions-model";
 
 export function hoverMiddleware(
   clientProvider: () => LanguageClient | undefined,
@@ -67,13 +54,13 @@ export function hoverMiddleware(
         ]);
         const typeLocations = locationsExcludingCurrentHover(
           rawTypeLocations,
-          document.uri,
-          hover.range,
+          document.uri.toString(),
+          hoverRange(hover.range),
         );
         const implementationTargets = locationsExcludingCurrentHover(
           rawImplementationLocations,
-          document.uri,
-          hover.range,
+          document.uri.toString(),
+          hoverRange(hover.range),
         );
         if (token.isCancellationRequested) {
           return hover;
@@ -199,152 +186,38 @@ function appendHoverActions(hover: vscode.Hover, actions: readonly HoverAction[]
   return new vscode.Hover(contents, hover.range);
 }
 
-function hoverAction(
-  command: string,
-  locations: readonly SerializedLocation[],
-  singularLabel: string,
-  pluralNoun: string,
-): HoverAction {
-  const label = locations.length === 1 ? singularLabel : `${locations.length} ${pluralNoun}`;
-  return { command, label, locations };
-}
-
 function commandLinkLine(actions: readonly HoverAction[]): vscode.MarkdownString {
-  const links = actions.map(commandLink).join(" | ");
-  const line = new vscode.MarkdownString(`Go to ${links}`);
+  const linkLine = hoverActionLinkLine(actions);
+  const line = new vscode.MarkdownString(linkLine.markdown);
 
   // Only these locally generated command links are trusted. The server-rendered docs and signatures
   // keep VS Code's default untrusted Markdown behavior.
-  line.isTrusted = { enabledCommands: actions.map((action) => action.command) };
+  line.isTrusted = { enabledCommands: [...linkLine.enabledCommands] };
   return line;
 }
 
-function commandLink(action: HoverAction): string {
-  const args = encodeURIComponent(JSON.stringify([action.locations]));
-  return `[${action.label}](command:${action.command}?${args})`;
-}
-
-function protocolDefinitionLocations(
-  definition: Definition | ProtocolLocationLink[] | null,
-): SerializedLocation[] {
-  if (definition === null) {
-    return [];
-  }
-
-  const values = Array.isArray(definition) ? definition : [definition];
-  return values.map((value) => {
-    if (isLocationLink(value)) {
-      return {
-        uri: value.targetUri,
-        range: value.targetSelectionRange ?? value.targetRange,
-      };
-    }
-
-    return {
-      uri: value.uri,
-      range: value.range,
-    };
-  });
-}
-
-function uniqueLocations(locations: SerializedLocation[]): SerializedLocation[] {
-  const seen = new Set<string>();
-  const unique = [];
-
-  for (const location of locations) {
-    const key = JSON.stringify(location);
-    if (seen.has(key)) {
-      continue;
-    }
-
-    seen.add(key);
-    unique.push(location);
-  }
-
-  return unique;
-}
-
-function locationsExcludingCurrentHover(
-  locations: SerializedLocation[],
-  documentUri: vscode.Uri,
-  hoverRange: vscode.Range | undefined,
-): SerializedLocation[] {
-  if (hoverRange === undefined) {
-    return locations;
-  }
-
-  // Type-definition providers often return the declaration itself when hovering a type
-  // declaration. Suppress that self-link so hover actions stay useful rather than decorative.
-  return locations.filter(
-    (location) =>
-      location.uri !== documentUri.toString() ||
-      !sameRange(location.range, {
-        start: hoverRange.start,
-        end: hoverRange.end,
-      }),
+function deserializeLocations(value: unknown): vscode.Location[] {
+  return deserializeSerializedLocations(value).map(
+    (location) => new vscode.Location(vscode.Uri.parse(location.uri), range(location.range)),
   );
 }
 
-function sameRange(left: SerializedRange, right: SerializedRange): boolean {
-  return samePosition(left.start, right.start) && samePosition(left.end, right.end);
-}
-
-function samePosition(left: SerializedPosition, right: SerializedPosition): boolean {
-  return left.line === right.line && left.character === right.character;
-}
-
-function deserializeLocations(value: unknown): vscode.Location[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.flatMap((location) => {
-    const parsed = deserializeLocation(location);
-    return parsed === undefined ? [] : [parsed];
-  });
-}
-
-function deserializeLocation(value: unknown): vscode.Location | undefined {
-  if (!isRecord(value) || typeof value.uri !== "string" || !isRecord(value.range)) {
-    return undefined;
-  }
-
-  const range = deserializeRange(value.range);
+function hoverRange(range: vscode.Range | undefined): SerializedRange | undefined {
   if (range === undefined) {
     return undefined;
   }
 
-  return new vscode.Location(vscode.Uri.parse(value.uri), range);
+  return {
+    start: range.start,
+    end: range.end,
+  };
 }
 
-function deserializeRange(value: unknown): vscode.Range | undefined {
-  if (!isRecord(value) || !isRecord(value.start) || !isRecord(value.end)) {
-    return undefined;
-  }
-
-  const start = deserializePosition(value.start);
-  const end = deserializePosition(value.end);
-  if (start === undefined || end === undefined) {
-    return undefined;
-  }
-
-  return new vscode.Range(start, end);
-}
-
-function deserializePosition(value: unknown): vscode.Position | undefined {
-  if (!isRecord(value) || typeof value.line !== "number" || typeof value.character !== "number") {
-    return undefined;
-  }
-
-  return new vscode.Position(value.line, value.character);
-}
-
-function isLocationLink(
-  value: ProtocolLocation | ProtocolLocationLink,
-): value is ProtocolLocationLink {
-  return "targetUri" in value;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
+function range(range: SerializedRange): vscode.Range {
+  return new vscode.Range(
+    range.start.line,
+    range.start.character,
+    range.end.line,
+    range.end.character,
+  );
 }

--- a/editors/code/src/features/hover-actions.ts
+++ b/editors/code/src/features/hover-actions.ts
@@ -16,7 +16,6 @@ import {
 
 import { EXTENSION_COMMANDS } from "../commands";
 import {
-  deserializeSerializedLocations,
   hoverAction,
   hoverActionLinkLine,
   locationsExcludingCurrentHover,
@@ -114,25 +113,28 @@ function registerGoToLocationsCommand(
   logLabel: string,
   notFoundMessage: string,
 ): vscode.Disposable {
-  return vscode.commands.registerCommand(command, async (serializedLocations: unknown) => {
-    const locations = deserializeLocations(serializedLocations);
-    if (locations.length === 0) {
-      output.warn(`${logLabel} command ignored empty or malformed locations`);
-      return;
-    }
+  return vscode.commands.registerCommand(
+    command,
+    async (serializedLocations?: SerializedLocation[]) => {
+      const locations = toVsCodeLocations(serializedLocations);
+      if (locations.length === 0) {
+        output.warn(`${logLabel} command ignored empty locations`);
+        return;
+      }
 
-    const activeEditor = vscode.window.activeTextEditor;
-    const originUri = activeEditor?.document.uri ?? locations[0].uri;
-    const originPosition = activeEditor?.selection.active ?? locations[0].range.start;
-    await vscode.commands.executeCommand(
-      "editor.action.goToLocations",
-      originUri,
-      originPosition,
-      locations,
-      "peek",
-      notFoundMessage,
-    );
-  });
+      const activeEditor = vscode.window.activeTextEditor;
+      const originUri = activeEditor?.document.uri ?? locations[0].uri;
+      const originPosition = activeEditor?.selection.active ?? locations[0].range.start;
+      await vscode.commands.executeCommand(
+        "editor.action.goToLocations",
+        originUri,
+        originPosition,
+        locations,
+        "peek",
+        notFoundMessage,
+      );
+    },
+  );
 }
 
 async function typeDefinitionLocations(
@@ -196,8 +198,10 @@ function commandLinkLine(actions: readonly HoverAction[]): vscode.MarkdownString
   return line;
 }
 
-function deserializeLocations(value: unknown): vscode.Location[] {
-  return deserializeSerializedLocations(value).map(
+function toVsCodeLocations(
+  locations: readonly SerializedLocation[] | undefined,
+): vscode.Location[] {
+  return (locations ?? []).map(
     (location) => new vscode.Location(vscode.Uri.parse(location.uri), range(location.range)),
   );
 }

--- a/editors/code/src/status/client-status.ts
+++ b/editors/code/src/status/client-status.ts
@@ -12,7 +12,7 @@ import {
   type WorkDoneProgressReport,
 } from "vscode-languageclient/node";
 
-import { StatusView, statusText, type StatusDetails, type StatusSnapshot } from "./status-view";
+import { statusText, type StatusDetails, type StatusSnapshot } from "./status-model";
 
 const CARGO_DIAGNOSTICS_PROGRESS_TITLE = "Cargo diagnostics";
 
@@ -27,6 +27,17 @@ export interface ClientStatusSnapshot {
 }
 
 export type ActiveWorkspaceState = "indexing" | "ready" | "failed";
+
+export interface ClientStatusView {
+  starting(details: StatusDetails): void;
+  indexing(details?: StatusDetails): void;
+  ready(details?: StatusDetails): void;
+  stale(details?: StatusDetails): void;
+  diagnosticsRunning(command: string | undefined, details?: StatusDetails): void;
+  diagnosticsFailed(details?: StatusDetails): void;
+  stopped(reason: string, details?: StatusDetails): void;
+  failed(reason: string, details?: StatusDetails): void;
+}
 
 /**
  * Tracks client-facing state and decides which status-bar state should win.
@@ -51,7 +62,7 @@ export class ClientStatus {
   private readonly diagnosticsProgressTokens = new Set<ProgressToken>();
 
   public constructor(
-    private readonly view: StatusView,
+    private readonly view: ClientStatusView,
     private readonly shouldRender: () => boolean = () => true,
   ) {}
 

--- a/editors/code/src/status/status-model.ts
+++ b/editors/code/src/status/status-model.ts
@@ -1,0 +1,46 @@
+/**
+ * Plain status data and rendering helpers shared by the VS Code view and unit-testable state
+ * machine. This file intentionally has no `vscode` dependency.
+ */
+import * as path from "node:path";
+
+export interface StatusDetails {
+  readonly workspaceRoot?: string;
+  readonly activeWorkspaceRoot?: string;
+  readonly serverCommand?: string;
+  readonly serverSource?: string;
+}
+
+export type StatusState =
+  | "created"
+  | "starting"
+  | "indexing"
+  | "ready"
+  | "stale"
+  | "diagnostics-running"
+  | "diagnostics-failed"
+  | "stopped"
+  | "failed"
+  | "disposed";
+
+export interface StatusSnapshot {
+  readonly state: StatusState;
+  readonly text: string;
+  readonly details: StatusDetails;
+}
+
+export function statusText(baseText: string, details: StatusDetails | undefined): string {
+  const label = workspaceLabel(details);
+  return label === undefined ? baseText : `${baseText} [${label}]`;
+}
+
+function workspaceLabel(details: StatusDetails | undefined): string | undefined {
+  const root = details?.activeWorkspaceRoot;
+  if (root === undefined) {
+    return undefined;
+  }
+
+  const trimmed = root.replace(/[\\/]+$/, "");
+  const label = path.basename(trimmed);
+  return label.length > 0 ? label : trimmed;
+}

--- a/editors/code/src/status/status-view.ts
+++ b/editors/code/src/status/status-view.ts
@@ -4,35 +4,18 @@
  * This module knows how status states should look in VS Code: text, tooltip contents, background
  * color, command wiring, and plain snapshots for tests. It does not decide lifecycle state.
  */
-import * as path from "node:path";
 import * as vscode from "vscode";
 
 import { EXTENSION_COMMANDS } from "../commands";
+import {
+  statusText,
+  type StatusDetails,
+  type StatusSnapshot,
+  type StatusState,
+} from "./status-model";
 
-export interface StatusDetails {
-  readonly workspaceRoot?: string;
-  readonly activeWorkspaceRoot?: string;
-  readonly serverCommand?: string;
-  readonly serverSource?: string;
-}
-
-export type StatusState =
-  | "created"
-  | "starting"
-  | "indexing"
-  | "ready"
-  | "stale"
-  | "diagnostics-running"
-  | "diagnostics-failed"
-  | "stopped"
-  | "failed"
-  | "disposed";
-
-export interface StatusSnapshot {
-  readonly state: StatusState;
-  readonly text: string;
-  readonly details: StatusDetails;
-}
+export { statusText };
+export type { StatusDetails, StatusSnapshot, StatusState } from "./status-model";
 
 export class StatusView implements vscode.Disposable {
   private readonly item: vscode.StatusBarItem;
@@ -195,20 +178,4 @@ function appendCodeField(tooltip: vscode.MarkdownString, label: string, value: s
 
 function singleLine(value: string): string {
   return value.replace(/\s+/g, " ");
-}
-
-export function statusText(baseText: string, details: StatusDetails | undefined): string {
-  const label = workspaceLabel(details);
-  return label === undefined ? baseText : `${baseText} [${label}]`;
-}
-
-function workspaceLabel(details: StatusDetails | undefined): string | undefined {
-  const root = details?.activeWorkspaceRoot;
-  if (root === undefined) {
-    return undefined;
-  }
-
-  const trimmed = root.replace(/[\\/]+$/, "");
-  const label = path.basename(trimmed);
-  return label.length > 0 ? label : trimmed;
 }

--- a/editors/code/unit/client-status.test.ts
+++ b/editors/code/unit/client-status.test.ts
@@ -1,0 +1,105 @@
+import * as assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { ClientStatus, type ClientStatusView } from "../src/status/client-status";
+import type { StatusDetails } from "../src/status/status-model";
+
+const DETAILS: StatusDetails = {
+  workspaceRoot: "/workspace/window",
+  serverCommand: "rust-glancer lsp",
+  serverSource: "test",
+};
+
+describe("client status state precedence", () => {
+  it("lets engine state, dirty files, and diagnostics win in that order", () => {
+    const status = clientStatus();
+    status.starting(DETAILS);
+    status.ready(DETAILS);
+    status.handleWorkDoneProgress(
+      "cargo",
+      { kind: "begin", title: "Cargo diagnostics", message: "cargo check" },
+      false,
+    );
+
+    assert.equal(
+      render(status),
+      "diagnostics-running: $(sync~spin) Rust Glancer: cargo check running",
+    );
+
+    status.activeWorkspace("/workspace/project_a", "indexing", undefined, true);
+    assert.equal(render(status), "indexing: $(sync~spin) Rust Glancer: indexing [project_a]");
+
+    status.activeWorkspace("/workspace/project_a", "ready", undefined, true);
+    assert.equal(render(status), "stale: $(warning) Rust Glancer: stale until save [project_a]");
+
+    status.refresh(false);
+    assert.equal(
+      render(status),
+      "diagnostics-running: $(sync~spin) Rust Glancer: cargo check running [project_a]",
+    );
+
+    status.handleWorkDoneProgress("cargo", { kind: "end", message: "Failed" }, false);
+    assert.equal(
+      render(status),
+      "diagnostics-failed: $(error) Rust Glancer: cargo check failed [project_a]",
+    );
+  });
+
+  it("keeps active workspace failure above dirty and diagnostics state", () => {
+    const status = clientStatus();
+    status.starting(DETAILS);
+    status.ready(DETAILS);
+    status.handleWorkDoneProgress(
+      "cargo",
+      { kind: "begin", title: "Cargo diagnostics", message: "cargo check" },
+      false,
+    );
+
+    status.activeWorkspace("/workspace/project_b", "failed", "index failed", true);
+
+    assert.equal(render(status), "failed: $(error) Rust Glancer: failed [project_b]");
+    assert.equal(status.snapshot().diagnosticsRunning, true);
+    assert.equal(status.snapshot().failureReason, undefined);
+  });
+
+  it("preserves active workspace label across language-client ready transitions", () => {
+    const status = clientStatus();
+    status.starting(DETAILS);
+    status.ready(DETAILS);
+    status.activeWorkspace("/workspace/project_c", "ready", undefined, false);
+
+    status.ready({
+      ...DETAILS,
+      workspaceRoot: "/workspace/restarted-window",
+    });
+
+    assert.equal(render(status), "ready: $(check) Rust Glancer: ready [project_c]");
+    assert.deepEqual(status.snapshot().details, {
+      ...DETAILS,
+      workspaceRoot: "/workspace/restarted-window",
+      activeWorkspaceRoot: "/workspace/project_c",
+    });
+  });
+});
+
+function clientStatus(): ClientStatus {
+  return new ClientStatus(noopView(), () => false);
+}
+
+function render(status: ClientStatus): string {
+  const snapshot = status.snapshot().status;
+  return `${snapshot.state}: ${snapshot.text}`;
+}
+
+function noopView(): ClientStatusView {
+  return {
+    starting() {},
+    indexing() {},
+    ready() {},
+    stale() {},
+    diagnosticsRunning() {},
+    diagnosticsFailed() {},
+    stopped() {},
+    failed() {},
+  };
+}

--- a/editors/code/unit/hover-actions-model.test.ts
+++ b/editors/code/unit/hover-actions-model.test.ts
@@ -1,0 +1,129 @@
+import * as assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  deserializeSerializedLocations,
+  hoverAction,
+  hoverActionLinkLine,
+  locationsExcludingCurrentHover,
+  protocolDefinitionLocations,
+  uniqueLocations,
+  type SerializedLocation,
+} from "../src/features/hover-actions-model";
+import { EXTENSION_COMMANDS } from "../src/commands";
+
+describe("hover action model", () => {
+  it("normalizes protocol locations and removes duplicate targets", () => {
+    const declaration = location("file:///src/lib.rs", 1, 4, 1, 10);
+    const linkedSelection = location("file:///src/types.rs", 3, 8, 3, 14);
+
+    const actual = uniqueLocations(
+      protocolDefinitionLocations([
+        declaration,
+        declaration,
+        {
+          targetUri: "file:///src/types.rs",
+          targetRange: range(3, 0, 3, 20),
+          targetSelectionRange: linkedSelection.range,
+        },
+      ]),
+    );
+
+    assert.deepEqual(actual, [declaration, linkedSelection]);
+  });
+
+  it("filters hover self-links without hiding other locations", () => {
+    const self = location("file:///src/lib.rs", 1, 4, 1, 10);
+    const sameFileDifferentRange = location("file:///src/lib.rs", 2, 4, 2, 10);
+    const otherFile = location("file:///src/types.rs", 1, 4, 1, 10);
+
+    assert.deepEqual(
+      locationsExcludingCurrentHover(
+        [self, sameFileDifferentRange, otherFile],
+        "file:///src/lib.rs",
+        self.range,
+      ),
+      [sameFileDifferentRange, otherFile],
+    );
+  });
+
+  it("renders trusted command links with singular and plural labels", () => {
+    const typeTarget = location("file:///src/types.rs", 1, 0, 1, 6);
+    const implTargets = [
+      location("file:///src/lib.rs", 4, 0, 4, 8),
+      location("file:///src/lib.rs", 8, 0, 8, 8),
+    ];
+    const actions = [
+      hoverAction(EXTENSION_COMMANDS.goToTypeFromHover, [typeTarget], "type", "type definitions"),
+      hoverAction(
+        EXTENSION_COMMANDS.goToImplementationFromHover,
+        implTargets,
+        "implementation",
+        "implementations",
+      ),
+    ];
+
+    const actual = hoverActionLinkLine(actions);
+
+    assert.deepEqual(actual.enabledCommands, [
+      EXTENSION_COMMANDS.goToTypeFromHover,
+      EXTENSION_COMMANDS.goToImplementationFromHover,
+    ]);
+    assert.equal(
+      actual.markdown,
+      `Go to ${commandLink("type", EXTENSION_COMMANDS.goToTypeFromHover, [typeTarget])} | ${commandLink(
+        "2 implementations",
+        EXTENSION_COMMANDS.goToImplementationFromHover,
+        implTargets,
+      )}`,
+    );
+  });
+
+  it("deserializes only well-formed command locations", () => {
+    const valid = location("file:///src/lib.rs", 1, 4, 1, 10);
+
+    assert.deepEqual(
+      deserializeSerializedLocations([
+        valid,
+        { uri: 42, range: valid.range },
+        { uri: "file:///bad.rs", range: { start: { line: 1, character: 0 }, end: {} } },
+        "not a location",
+      ]),
+      [valid],
+    );
+  });
+});
+
+function commandLink(
+  label: string,
+  command: string,
+  locations: readonly SerializedLocation[],
+): string {
+  const args = encodeURIComponent(JSON.stringify([locations]));
+  return `[${label}](command:${command}?${args})`;
+}
+
+function location(
+  uri: string,
+  startLine: number,
+  startCharacter: number,
+  endLine: number,
+  endCharacter: number,
+): SerializedLocation {
+  return {
+    uri,
+    range: range(startLine, startCharacter, endLine, endCharacter),
+  };
+}
+
+function range(
+  startLine: number,
+  startCharacter: number,
+  endLine: number,
+  endCharacter: number,
+): SerializedLocation["range"] {
+  return {
+    start: { line: startLine, character: startCharacter },
+    end: { line: endLine, character: endCharacter },
+  };
+}

--- a/editors/code/unit/hover-actions-model.test.ts
+++ b/editors/code/unit/hover-actions-model.test.ts
@@ -2,7 +2,6 @@ import * as assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
-  deserializeSerializedLocations,
   hoverAction,
   hoverActionLinkLine,
   locationsExcludingCurrentHover,
@@ -76,20 +75,6 @@ describe("hover action model", () => {
         EXTENSION_COMMANDS.goToImplementationFromHover,
         implTargets,
       )}`,
-    );
-  });
-
-  it("deserializes only well-formed command locations", () => {
-    const valid = location("file:///src/lib.rs", 1, 4, 1, 10);
-
-    assert.deepEqual(
-      deserializeSerializedLocations([
-        valid,
-        { uri: 42, range: valid.range },
-        { uri: "file:///bad.rs", range: { start: { line: 1, character: 0 }, end: {} } },
-        "not a location",
-      ]),
-      [valid],
     );
   });
 });


### PR DESCRIPTION
The engine/ folder had significantly more tests than the rest of the project, so this PR kind of makes it a bit more even.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for LSP engine with query validation, dirty document handling, and rename operations.
  * Added unit tests for workspace routing, status management, and hover actions model.

* **Refactor**
  * Improved notification publisher architecture for better testing and extensibility.
  * Reorganized status display and hover action models for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->