### PR TITLE
fix: Fix slow LSP tests

### DIFF
--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -13,6 +13,7 @@ use rg_lsp_proto::{
     AnalysisConfig, CargoMetadataTarget as ProtoCargoMetadataTarget, CompletionClientCapabilities,
     IndexingPerformancePreference as ProtoIndexingPerformancePreference,
     PackageResidencyPolicy as ProtoPackageResidencyPolicy,
+    SysrootDiscovery as ProtoSysrootDiscovery,
 };
 use rg_parse::TextSpan;
 use rg_project::{
@@ -408,7 +409,10 @@ impl EngineWorker {
         let workspace = WorkspaceMetadata::lower(metadata.metadata, metadata.target_cfg)
             .context("while attempting to normalize Cargo metadata")?;
         let workspace_root = workspace.workspace_root().to_path_buf();
-        let sysroot = SysrootSources::discover(workspace.workspace_root());
+        let sysroot = match analysis.sysroot_discovery {
+            ProtoSysrootDiscovery::Auto => SysrootSources::discover(workspace.workspace_root()),
+            ProtoSysrootDiscovery::Disabled => None,
+        };
         match &sysroot {
             Some(sysroot) => {
                 tracing::info!(

--- a/crates/lsp/engine/src/tests/utils.rs
+++ b/crates/lsp/engine/src/tests/utils.rs
@@ -10,7 +10,8 @@ use ls_types::{
     Range, WorkspaceEdit,
 };
 use rg_lsp_proto::{
-    CompletionClientCapabilities, EngineConfig, EngineService, ServiceNotification,
+    AnalysisConfig, CompletionClientCapabilities, EngineConfig, EngineService, ServiceNotification,
+    SysrootDiscovery,
 };
 use rg_parse::LineIndex;
 use tarpc::context;
@@ -58,10 +59,22 @@ impl LspEngineFixture {
             .initialize(
                 context::current(),
                 self.fixture.path(""),
-                EngineConfig::default(),
+                Self::engine_config(),
             )
             .await
             .expect("fixture LSP engine should initialize");
+    }
+
+    fn engine_config() -> EngineConfig {
+        // These flow tests exercise fixture-local LSP behavior. Real rust-src indexing is covered
+        // by lower-level sysroot tests and would dominate every tiny protocol fixture.
+        EngineConfig {
+            analysis: AnalysisConfig {
+                sysroot_discovery: SysrootDiscovery::Disabled,
+                ..AnalysisConfig::default()
+            },
+            ..EngineConfig::default()
+        }
     }
 
     pub(super) async fn check(&self, queries: &[LspQuery], expect: Expect) {

--- a/crates/lsp/proto/src/analysis_config.rs
+++ b/crates/lsp/proto/src/analysis_config.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 pub struct AnalysisConfig {
     pub package_residency_policy: PackageResidencyPolicy,
     pub cargo_metadata_config: CargoMetadataConfig,
+    #[serde(default)]
+    pub sysroot_discovery: SysrootDiscovery,
     pub indexing_preference: IndexingPerformancePreference,
 }
 
@@ -115,6 +117,34 @@ pub enum CargoMetadataTarget {
     Triple(String),
 }
 
+/// Protocol-level standard-library source discovery requested by an LSP client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub enum SysrootDiscovery {
+    #[default]
+    Auto,
+    Disabled,
+}
+
+impl SysrootDiscovery {
+    /// Stable kebab-case name accepted in LSP initialization options.
+    pub fn config_name(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Disabled => "disabled",
+        }
+    }
+
+    /// Parses the public names accepted by frontends.
+    pub fn from_config_name(value: &str) -> Option<Self> {
+        let normalized = value.trim().replace('_', "-").to_ascii_lowercase();
+        match normalized.as_str() {
+            "auto" => Some(Self::Auto),
+            "disabled" => Some(Self::Disabled),
+            _ => None,
+        }
+    }
+}
+
 impl AnalysisConfig {
     pub fn from_initialization_options(options: Option<&LSPAny>) -> anyhow::Result<Self> {
         let default = Self::default();
@@ -140,6 +170,22 @@ impl AnalysisConfig {
             .and_then(LSPAny::as_str)
             .map(|target| CargoMetadataConfig::default().target_triple(target))
             .unwrap_or_else(|| default.cargo_metadata_config.clone());
+        let sysroot_discovery = match options.and_then(LSPAny::as_object).and_then(|options| {
+            options
+                .get("sysroot")
+                .and_then(LSPAny::as_object)
+                .and_then(|sysroot| sysroot.get("discovery"))
+        }) {
+            Some(value) => {
+                let value = value.as_str().ok_or_else(|| {
+                    anyhow::anyhow!("rust-glancer sysroot.discovery must be a string")
+                })?;
+                SysrootDiscovery::from_config_name(value).ok_or_else(|| {
+                    anyhow::anyhow!("rust-glancer sysroot.discovery must be one of: auto, disabled")
+                })?
+            }
+            None => default.sysroot_discovery,
+        };
         let indexing_preference = match options.and_then(LSPAny::as_object).and_then(|options| {
             options
                 .get("indexing")
@@ -162,6 +208,7 @@ impl AnalysisConfig {
         Ok(Self {
             package_residency_policy,
             cargo_metadata_config,
+            sysroot_discovery,
             indexing_preference,
         })
     }
@@ -174,6 +221,7 @@ impl Default for AnalysisConfig {
             // fast initial indexing unless a client explicitly asks to lower peak memory.
             package_residency_policy: PackageResidencyPolicy::WorkspaceAndPathDepsResident,
             cargo_metadata_config: CargoMetadataConfig::default(),
+            sysroot_discovery: SysrootDiscovery::default(),
             indexing_preference: IndexingPerformancePreference::default(),
         }
     }
@@ -185,6 +233,7 @@ mod tests {
 
     use super::{
         AnalysisConfig, CargoMetadataTarget, IndexingPerformancePreference, PackageResidencyPolicy,
+        SysrootDiscovery,
     };
 
     #[test]
@@ -200,6 +249,7 @@ mod tests {
             config.cargo_metadata_config.target(),
             &CargoMetadataTarget::Auto
         );
+        assert_eq!(config.sysroot_discovery, SysrootDiscovery::Auto);
         assert_eq!(
             config.indexing_preference,
             IndexingPerformancePreference::FasterBuilds,
@@ -242,6 +292,19 @@ mod tests {
             config.cargo_metadata_config.target(),
             &CargoMetadataTarget::Triple("x86_64-unknown-linux-gnu".to_string()),
         );
+    }
+
+    #[test]
+    fn parses_sysroot_discovery() {
+        let options = object([(
+            "sysroot",
+            object([("discovery", LSPAny::String("disabled".to_string()))]),
+        )]);
+
+        let config = AnalysisConfig::from_initialization_options(Some(&options))
+            .expect("analysis config should parse");
+
+        assert_eq!(config.sysroot_discovery, SysrootDiscovery::Disabled);
     }
 
     #[test]

--- a/crates/lsp/proto/src/engine_config.rs
+++ b/crates/lsp/proto/src/engine_config.rs
@@ -23,7 +23,10 @@ impl EngineConfig {
 mod tests {
     use ls_types::LSPAny;
 
-    use crate::{CargoMetadataTarget, IndexingPerformancePreference, PackageResidencyPolicy};
+    use crate::{
+        CargoMetadataTarget, IndexingPerformancePreference, PackageResidencyPolicy,
+        SysrootDiscovery,
+    };
 
     use super::EngineConfig;
 
@@ -52,6 +55,10 @@ mod tests {
                 )]),
             ),
             (
+                "sysroot",
+                object([("discovery", LSPAny::String("disabled".to_string()))]),
+            ),
+            (
                 "diagnostics",
                 object([
                     ("onStartup", LSPAny::Bool(true)),
@@ -74,6 +81,10 @@ mod tests {
         assert_eq!(
             config.analysis.indexing_preference,
             IndexingPerformancePreference::FasterBuilds,
+        );
+        assert_eq!(
+            config.analysis.sysroot_discovery,
+            SysrootDiscovery::Disabled
         );
         assert!(config.diagnostics.on_startup);
         assert_eq!(config.diagnostics.command, "clippy");

--- a/crates/lsp/proto/src/lib.rs
+++ b/crates/lsp/proto/src/lib.rs
@@ -17,7 +17,7 @@ mod service;
 pub use self::{
     analysis_config::{
         AnalysisConfig, CargoMetadataConfig, CargoMetadataTarget, IndexingPerformancePreference,
-        PackageResidencyPolicy,
+        PackageResidencyPolicy, SysrootDiscovery,
     },
     client_capabilities::ClientCapabilities,
     completion::CompletionClientCapabilities,


### PR DESCRIPTION
## Summary
- Add `sysroot.discovery` to analysis configuration with `auto` and `disabled` modes.
- Thread the new setting through protocol parsing, public exports, and engine startup.
- Disable sysroot discovery in LSP fixture tests to keep protocol flows focused and lightweight.

## Testing
- Added protocol-level tests for parsing `sysroot.discovery` and propagating it through `EngineConfig`.
- Updated LSP fixture setup to use sysroot discovery disabled for flow tests.
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `sysroot_discovery` configuration option to control automatic sysroot source discovery during initialization. Users can set this option to `Auto` to discover sources from the workspace (default), or `Disabled` to skip discovery entirely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->