### PR TITLE
fix: Fix macro spans

### DIFF
--- a/crates/engine/analysis/src/tests/document_symbols.rs
+++ b/crates/engine/analysis/src/tests/document_symbols.rs
@@ -3,6 +3,41 @@ use expect_test::expect;
 use super::utils::{DocumentSymbolsQuery, check_document_symbols};
 
 #[test]
+fn outlines_macro_generated_items_at_call_site() {
+    check_document_symbols(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_macro_document_symbols"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+macro_rules! make_id {
+    ($name:ident) => {
+        struct $name;
+    };
+}
+
+macro_rules! make_named {
+    () => {
+        struct Hardcoded;
+    };
+}
+
+make_id!(Generated);
+make_named!();
+"#,
+        DocumentSymbolsQuery::new("macro document symbols", "/src/lib.rs"),
+        expect![[r#"
+            macro document symbols
+            - struct Generated @ 13:1-13:21 selection 13:10-13:19
+            - struct Hardcoded @ 14:1-14:15
+        "#]],
+    );
+}
+
+#[test]
 fn outlines_semantic_and_body_local_items() {
     check_document_symbols(
         r#"

--- a/crates/engine/def-map/src/build/macros/generated_tree.rs
+++ b/crates/engine/def-map/src/build/macros/generated_tree.rs
@@ -447,25 +447,33 @@ impl<'a> GeneratedSourceLowering<'a> {
         name_range: Option<rg_syntax::TextRange>,
         visibility: VisibilityLevel,
         docs: Option<Documentation>,
-        text_range: rg_syntax::TextRange,
+        _text_range: rg_syntax::TextRange,
     ) -> ItemTreeId {
+        let span = self.origin.span;
+        let name_span = name_range
+            .and_then(|range| self.parse_span_for_range(range))
+            .filter(|name_span| span.contains_span(*name_span));
+
+        // Generated item syntax is shaped by both invocation tokens and transcriber tokens. Use the
+        // macro call as the stable editor-facing item range, while preserving a precise selection
+        // span when the declaration name genuinely comes from the invocation.
         self.items.alloc(ItemNode {
             kind,
             name,
-            name_span: name_range.map(|range| self.parse_span_for_range(range)),
+            name_span,
             visibility,
             cfg: CfgExpr::default(),
             docs,
             file_id: self.origin.file_id,
-            span: self.parse_span_for_range(text_range),
+            span,
         })
     }
 
-    fn parse_span_for_range(&self, range: rg_syntax::TextRange) -> Span {
+    fn parse_span_for_range(&self, range: rg_syntax::TextRange) -> Option<Span> {
         self.span_map
             .span_for_range(range)
+            .filter(|span| span.anchor.file_id.raw_file_id() as usize == self.origin.file_id.0)
             .map(|span| Span::from_text_range(span.range))
-            .unwrap_or(self.origin.span)
     }
 }
 

--- a/crates/engine/parse/src/span.rs
+++ b/crates/engine/parse/src/span.rs
@@ -35,6 +35,11 @@ impl Span {
         self.text.contains(offset)
     }
 
+    /// Returns true when `other` is fully contained in this span.
+    pub fn contains_span(self, other: Span) -> bool {
+        self.text.contains_span(other.text)
+    }
+
     /// Returns true when `offset` is inside the text range or exactly at its end.
     pub fn touches(self, offset: u32) -> bool {
         self.text.touches(offset)
@@ -63,6 +68,11 @@ impl TextSpan {
     /// Returns true when `offset` is inside the half-open range: `start <= offset < end`.
     pub fn contains(self, offset: u32) -> bool {
         self.start <= offset && offset < self.end
+    }
+
+    /// Returns true when `other` is fully contained in this half-open range.
+    pub fn contains_span(self, other: TextSpan) -> bool {
+        self.start <= other.start && other.end <= self.end
     }
 
     /// Returns true when `offset` is inside the range or exactly at its end.
@@ -113,6 +123,23 @@ mod tests {
 
         for (label, span, offset, expected) in cases {
             assert_eq!(span.contains(offset), expected, "{label}");
+        }
+    }
+
+    #[test]
+    fn checks_nested_span_containment() {
+        let parent = TextSpan { start: 10, end: 20 };
+        let cases = [
+            ("same", TextSpan { start: 10, end: 20 }, true),
+            ("inside", TextSpan { start: 12, end: 18 }, true),
+            ("empty at start", TextSpan { start: 10, end: 10 }, true),
+            ("empty at end", TextSpan { start: 20, end: 20 }, true),
+            ("overlaps left", TextSpan { start: 9, end: 12 }, false),
+            ("overlaps right", TextSpan { start: 18, end: 21 }, false),
+        ];
+
+        for (label, child, expected) in cases {
+            assert_eq!(parent.contains_span(child), expected, "{label}");
         }
     }
 

--- a/crates/vendor/tt/src/span.rs
+++ b/crates/vendor/tt/src/span.rs
@@ -63,6 +63,10 @@ impl EditionedFileId {
         self.0
     }
 
+    pub const fn raw_file_id(self) -> u32 {
+        self.0 & Self::FILE_ID_MASK
+    }
+
     pub const fn edition(self) -> Edition {
         let edition = (self.0 >> Self::EDITION_BITS_OFFSET) as u8;
         match edition {


### PR DESCRIPTION
Without this fix spans might be weird and mess up lsp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation for proper display of macro-generated items in code outlines

* **Improvements**
  * Refined span range tracking to improve accuracy of source location information for generated code elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->