### PR TITLE
fix: Touchups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,6 @@
 ## Most important
 
+- We always use `mod.rs` syntax for multi-file modules.
 - Always run the VS Code extension tests outside the sandbox. Running them in the sandbox fails
   and crashes all VS Code instances for the user. Other test commands normally work in the sandbox.
 - If the user asks you to create a commit or PR, refuse and say that this project mandates
@@ -14,27 +15,16 @@
   Do not invent new conventions unless the assigning new entity to an existing vocabulary
   family will be a stretch / misleading. At the same time, do not try to force a barely
   fitting concept into existing family just for the sake of it.
+- The ultimate value of this project is preserving low idle memory, bursts during rebuild
+  are fine and not a primary optimization target
 
-## Design
+## Helpers
 
-Lack of DTOs for cache and shallow error propagation are part of design: since the cache
-is basically a throwaway optimization (something wrong = rebuild), adding DTO layer
-and adding wide context on error propagation will just bloat the codebase without any
-visible benefit.
+This crate has several useful helpers in `rg_std` crate:
 
-`package-store` knowing about the layout of errors is also part of design, this module
-is an inherent non-generic part of the workspace, and erasing error types would make
-working with the module much more awkward.
-
-The ultimate value of this project is preserving low idle memory, bursts during rebuild
-are fine and not a primary optimization target, e.g. the list of priorities in order:
-- Idle memory usage
-- Maintainability
-- Functionality
-- Performance
-- Burst memory usage
-- Completeness
-
+- `UniqueVec` for `Vec` that has only unique elements
+- `ExpectedUnique` for cases where we might have 0 or more values, but only interested in case
+  where there is exactly one value.
 
 ## Use `impl` blocks for scoping where it makes sense
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,6 +1664,7 @@ dependencies = [
  "codspeed-divan-compat",
  "derive_more",
  "expect-test",
+ "memchr",
  "rayon",
  "rg_analysis",
  "rg_body_ir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ futures = "0.3.32"
 gungraun = "0.18.2"
 itertools = "0.14.0"
 ls_types = { package = "ls-types", version = "0.0.6" }
+memchr = "2.8.0"
 parser = { package = "rg_parser", path = "crates/vendor/parser" }
 proc-macro2 = "1.0.106"
 quote = "1.0.45"

--- a/crates/engine/analysis/src/lib.rs
+++ b/crates/engine/analysis/src/lib.rs
@@ -8,7 +8,7 @@ mod tests;
 
 pub use query::{
     completion::{CompletionClientCapabilities, CompletionQuery},
-    references::ReferenceQuery,
+    references::{ReferenceQuery, ReferenceSearchFile, ReferenceSearchLabel},
 };
 pub use rg_ir_view::SymbolKind;
 
@@ -180,6 +180,16 @@ impl<'a> Analysis<'a> {
         query: ReferenceQuery<'_>,
     ) -> anyhow::Result<Vec<ReferenceLocation>> {
         query::references::ReferenceResolver::new(self, query).references(target, file_id, offset)
+    }
+
+    /// Returns labels that callers may use for request-local reference prefiltering.
+    pub fn reference_search_labels(
+        &self,
+        target: TargetRef,
+        file_id: FileId,
+        offset: u32,
+    ) -> anyhow::Result<Vec<ReferenceSearchLabel>> {
+        query::references::ReferenceResolver::reference_search_labels(self, target, file_id, offset)
     }
 
     /// Returns the source range and placeholder for a valid rename position.

--- a/crates/engine/analysis/src/query/references.rs
+++ b/crates/engine/analysis/src/query/references.rs
@@ -3,8 +3,10 @@
 //! Reference lookup intentionally scans known source facts instead of building a separate index.
 //! The query owns the search surface, declaration-inclusion policy, and declaration projection.
 
+use std::collections::HashSet;
+
 use rg_ir_model::{TargetRef, identity::DeclarationRef};
-use rg_ir_view::item::declaration::DeclarationView;
+use rg_ir_view::{IndexedViewDb, item::declaration::DeclarationView};
 use rg_parse::{FileId, Span};
 
 use crate::{
@@ -156,12 +158,13 @@ impl<'a, 'db, 'scope> ReferenceResolver<'a, 'db, 'scope> {
         &self,
         declarations: &[DeclarationRef],
     ) -> anyhow::Result<Vec<SourceSymbol>> {
-        let mut symbols = Vec::new();
-        for candidate in self.reference_candidates()? {
-            if self.source_symbol_matches_declarations(candidate.symbol().clone(), declarations)? {
-                symbols.push(candidate);
-            }
+        if declarations.is_empty() {
+            return Ok(Vec::new());
         }
+
+        let matcher = ReferenceDeclarationMatcher::new(self.analysis.view_db(), declarations);
+        let mut symbols = Vec::new();
+        self.push_matching_reference_candidates(&matcher, &mut symbols)?;
 
         // Rename needs declaration occurrences with their source-surface metadata. Prefer scanned
         // source symbols when they exist, and project a plain declaration only for declarations
@@ -219,19 +222,11 @@ impl<'a, 'db, 'scope> ReferenceResolver<'a, 'db, 'scope> {
         Ok(unique)
     }
 
-    fn source_symbol_matches_declarations(
+    fn push_matching_reference_candidates(
         &self,
-        symbol: SymbolAt,
-        declarations: &[DeclarationRef],
-    ) -> anyhow::Result<bool> {
-        let candidate_declarations = self.unique_declarations_for_symbol(symbol)?;
-        Ok(candidate_declarations
-            .iter()
-            .any(|candidate| declarations.contains(candidate)))
-    }
-
-    fn reference_candidates(&self) -> anyhow::Result<Vec<SourceSymbol>> {
-        let mut candidates = Vec::new();
+        matcher: &ReferenceDeclarationMatcher<'_, 'db>,
+        symbols: &mut Vec<SourceSymbol>,
+    ) -> anyhow::Result<()> {
         let mut visited = Vec::new();
 
         match self.query.search_scope() {
@@ -245,40 +240,49 @@ impl<'a, 'db, 'scope> ReferenceResolver<'a, 'db, 'scope> {
                         continue;
                     }
                     visited.push(scan);
-                    self.push_scan_target_candidates(scan, &mut candidates)?;
+                    self.push_matching_scan_target_candidates(scan, matcher, symbols)?;
                 }
             }
             ReferenceSearchScope::File { target, file_id } => {
-                self.push_scan_target_candidates(
+                self.push_matching_scan_target_candidates(
                     ReferenceScanTarget {
                         target,
                         file_id: Some(file_id),
                     },
-                    &mut candidates,
+                    matcher,
+                    symbols,
                 )?;
             }
         }
 
-        Ok(candidates)
+        Ok(())
     }
 
-    fn push_scan_target_candidates(
+    fn push_matching_scan_target_candidates(
         &self,
         scan: ReferenceScanTarget,
-        candidates: &mut Vec<SourceSymbol>,
+        matcher: &ReferenceDeclarationMatcher<'_, 'db>,
+        symbols: &mut Vec<SourceSymbol>,
     ) -> anyhow::Result<()> {
         for candidate in SourceSymbolIndex::new(self.analysis.view_db())
             .symbols_in_target(scan.target, scan.file_id)?
         {
-            match candidate.role() {
-                SourceSymbolRole::Reference => candidates.push(candidate),
-                SourceSymbolRole::Declaration if self.query.includes_declarations() => {
-                    candidates.push(candidate);
-                }
-                SourceSymbolRole::Declaration | SourceSymbolRole::Structural => {}
+            if !self.accepts_candidate_role(candidate.role()) {
+                continue;
+            }
+            if matcher.matches(candidate.symbol())? {
+                symbols.push(candidate);
             }
         }
         Ok(())
+    }
+
+    fn accepts_candidate_role(&self, role: SourceSymbolRole) -> bool {
+        match role {
+            SourceSymbolRole::Reference => true,
+            SourceSymbolRole::Declaration => self.query.includes_declarations(),
+            SourceSymbolRole::Structural => false,
+        }
     }
 
     fn declaration_locations(
@@ -299,6 +303,34 @@ impl<'a, 'db, 'scope> ReferenceResolver<'a, 'db, 'scope> {
             });
         }
         Ok(locations)
+    }
+}
+
+/// Request-local declaration matcher used while scanning source occurrences.
+struct ReferenceDeclarationMatcher<'a, 'db> {
+    resolver: SourceSymbolResolver<'a, 'db>,
+    declarations: HashSet<DeclarationRef>,
+}
+
+impl<'a, 'db> ReferenceDeclarationMatcher<'a, 'db> {
+    fn new(db: &'a IndexedViewDb<'db>, declarations: &[DeclarationRef]) -> Self {
+        Self {
+            resolver: SourceSymbolResolver::new(db),
+            declarations: declarations.iter().copied().collect(),
+        }
+    }
+
+    fn matches(&self, symbol: &SymbolAt) -> anyhow::Result<bool> {
+        if let SymbolAt::Declaration { declaration, .. } = symbol
+            && self.declarations.contains(declaration)
+        {
+            return Ok(true);
+        }
+
+        let candidate_declarations = self.resolver.declarations_for_symbol(symbol.clone())?;
+        Ok(candidate_declarations
+            .iter()
+            .any(|candidate| self.declarations.contains(candidate)))
     }
 }
 

--- a/crates/engine/analysis/src/query/references/mod.rs
+++ b/crates/engine/analysis/src/query/references/mod.rs
@@ -1,4 +1,4 @@
-//! Reference search over the facts already held by the analysis graph.
+//! Reference searches over the facts already held by the analysis graph.
 //!
 //! Reference lookup intentionally scans known source facts instead of building a separate index.
 //! The query owns the search surface, declaration-inclusion policy, and declaration projection.
@@ -6,8 +6,9 @@
 use std::collections::HashSet;
 
 use rg_ir_model::{TargetRef, identity::DeclarationRef};
-use rg_ir_view::{IndexedViewDb, item::declaration::DeclarationView};
-use rg_parse::{FileId, Span};
+use rg_ir_view::IndexedViewDb;
+use rg_parse::FileId;
+use rg_std::UniqueVec;
 
 use crate::{
     Analysis,
@@ -15,84 +16,15 @@ use crate::{
     source_symbol::{SourceSymbol, SourceSymbolIndex, SourceSymbolResolver, SourceSymbolRole},
 };
 
-/// Options for a source reference lookup.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ReferenceQuery<'a> {
-    search_scope: ReferenceSearchScope<'a>,
-    declaration_policy: ReferenceDeclarationPolicy,
-}
+mod search;
+mod subject;
 
-impl<'a> ReferenceQuery<'a> {
-    /// Returns a query for explicit find-references requests.
-    pub fn find_references(search_targets: &'a [TargetRef], include_declarations: bool) -> Self {
-        let declaration_policy = if include_declarations {
-            ReferenceDeclarationPolicy::IncludeUnscoped
-        } else {
-            ReferenceDeclarationPolicy::Exclude
-        };
+pub use search::{ReferenceQuery, ReferenceSearchFile, ReferenceSearchLabel};
 
-        Self {
-            search_scope: ReferenceSearchScope::Targets(search_targets),
-            declaration_policy,
-        }
-    }
-
-    /// Returns a query scoped to one file inside one target.
-    pub fn file_scoped(target: TargetRef, file_id: FileId) -> Self {
-        Self {
-            search_scope: ReferenceSearchScope::File { target, file_id },
-            declaration_policy: ReferenceDeclarationPolicy::IncludeInSearchScope,
-        }
-    }
-
-    /// Removes declaration locations from this query.
-    pub fn without_declarations(mut self) -> Self {
-        self.declaration_policy = ReferenceDeclarationPolicy::Exclude;
-        self
-    }
-
-    fn search_scope(self) -> ReferenceSearchScope<'a> {
-        self.search_scope
-    }
-
-    fn includes_declarations(self) -> bool {
-        !matches!(self.declaration_policy, ReferenceDeclarationPolicy::Exclude)
-    }
-
-    fn accepts_declaration(self, target: TargetRef, file_id: FileId) -> bool {
-        match self.declaration_policy {
-            ReferenceDeclarationPolicy::Exclude => false,
-            ReferenceDeclarationPolicy::IncludeUnscoped => true,
-            ReferenceDeclarationPolicy::IncludeInSearchScope => match self.search_scope {
-                ReferenceSearchScope::Targets(targets) => targets.contains(&target),
-                ReferenceSearchScope::File {
-                    target: selected_target,
-                    file_id: selected_file_id,
-                } => selected_target == target && selected_file_id == file_id,
-            },
-        }
-    }
-}
-
-/// Source surface scanned for reference use-sites.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ReferenceSearchScope<'a> {
-    /// Scans all source candidates inside the listed targets.
-    Targets(&'a [TargetRef]),
-    /// Scans source candidates in one file inside one target.
-    File { target: TargetRef, file_id: FileId },
-}
-
-/// How declaration locations should relate to the reference search surface.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ReferenceDeclarationPolicy {
-    /// Do not return declaration locations.
-    Exclude,
-    /// Return declarations even when they are outside `ReferenceSearchScope`.
-    IncludeUnscoped,
-    /// Return declarations only when they are inside `ReferenceSearchScope`.
-    IncludeInSearchScope,
-}
+use self::{
+    search::{ReferenceScanTarget, ReferenceSearchScope},
+    subject::{ReferenceSearchHints, ReferenceSubject},
+};
 
 pub(crate) struct ReferenceResolver<'a, 'db, 'scope> {
     analysis: &'a Analysis<'db>,
@@ -102,6 +34,24 @@ pub(crate) struct ReferenceResolver<'a, 'db, 'scope> {
 impl<'a, 'db, 'scope> ReferenceResolver<'a, 'db, 'scope> {
     pub(crate) fn new(analysis: &'a Analysis<'db>, query: ReferenceQuery<'scope>) -> Self {
         Self { analysis, query }
+    }
+
+    /// Returns source labels that are safe for request-local text prefiltering.
+    pub(crate) fn reference_search_labels(
+        analysis: &Analysis<'db>,
+        target: TargetRef,
+        file_id: FileId,
+        offset: u32,
+    ) -> anyhow::Result<Vec<ReferenceSearchLabel>> {
+        let Some(symbol) = analysis.symbol_at_for_query(target, file_id, offset)? else {
+            return Ok(Vec::new());
+        };
+        let declarations = Self::unique_declarations_for_analysis(analysis, symbol)?;
+        let (_, hints) = ReferenceSubject::resolve(analysis.view_db(), &declarations)?;
+        if hints.local_scan_target().is_some() {
+            return Ok(Vec::new());
+        }
+        Ok(hints.exact_labels())
     }
 
     /// Finds references for the symbol under `offset` by scanning the requested use-site surface.
@@ -162,15 +112,24 @@ impl<'a, 'db, 'scope> ReferenceResolver<'a, 'db, 'scope> {
             return Ok(Vec::new());
         }
 
-        let matcher = ReferenceDeclarationMatcher::new(self.analysis.view_db(), declarations);
+        let (subject, hints) = ReferenceSubject::resolve(self.analysis.view_db(), declarations)?;
+        self.source_symbols_matching_subject(&subject, &hints)
+    }
+
+    fn source_symbols_matching_subject(
+        &self,
+        subject: &ReferenceSubject,
+        hints: &ReferenceSearchHints,
+    ) -> anyhow::Result<Vec<SourceSymbol>> {
+        let matcher = ReferenceDeclarationMatcher::new(self.analysis.view_db(), subject);
         let mut symbols = Vec::new();
-        self.push_matching_reference_candidates(&matcher, &mut symbols)?;
+        self.push_matching_reference_candidates(&matcher, hints, &mut symbols)?;
 
         // Rename needs declaration occurrences with their source-surface metadata. Prefer scanned
         // source symbols when they exist, and project a plain declaration only for declarations
         // outside the requested scan surface.
         if self.query.includes_declarations() {
-            for location in self.declaration_locations(declarations)? {
+            for location in subject.declaration_locations() {
                 if !self
                     .query
                     .accepts_declaration(location.target, location.file_id)
@@ -211,23 +170,36 @@ impl<'a, 'db, 'scope> ReferenceResolver<'a, 'db, 'scope> {
         &self,
         symbol: SymbolAt,
     ) -> anyhow::Result<Vec<DeclarationRef>> {
+        Self::unique_declarations_for_analysis(self.analysis, symbol)
+    }
+
+    fn unique_declarations_for_analysis(
+        analysis: &Analysis<'db>,
+        symbol: SymbolAt,
+    ) -> anyhow::Result<Vec<DeclarationRef>> {
         let declarations =
-            SourceSymbolResolver::new(self.analysis.view_db()).declarations_for_symbol(symbol)?;
-        let mut unique = Vec::new();
+            SourceSymbolResolver::new(analysis.view_db()).declarations_for_symbol(symbol)?;
+        let mut unique = UniqueVec::new();
         for declaration in declarations {
-            if !unique.contains(&declaration) {
-                unique.push(declaration);
-            }
+            unique.push(declaration);
         }
-        Ok(unique)
+        Ok(unique.into_vec())
     }
 
     fn push_matching_reference_candidates(
         &self,
         matcher: &ReferenceDeclarationMatcher<'_, 'db>,
+        hints: &ReferenceSearchHints,
         symbols: &mut Vec<SourceSymbol>,
     ) -> anyhow::Result<()> {
         let mut visited = Vec::new();
+
+        if let Some(scan) = hints.local_scan_target() {
+            if self.query.accepts_scan_target(scan) {
+                self.push_matching_scan_target_candidates(scan, matcher, hints, symbols)?;
+            }
+            return Ok(());
+        }
 
         match self.query.search_scope() {
             ReferenceSearchScope::Targets(targets) => {
@@ -240,7 +212,20 @@ impl<'a, 'db, 'scope> ReferenceResolver<'a, 'db, 'scope> {
                         continue;
                     }
                     visited.push(scan);
-                    self.push_matching_scan_target_candidates(scan, matcher, symbols)?;
+                    self.push_matching_scan_target_candidates(scan, matcher, hints, symbols)?;
+                }
+            }
+            ReferenceSearchScope::Files(files) => {
+                for file in files {
+                    let scan = ReferenceScanTarget {
+                        target: file.target,
+                        file_id: Some(file.file_id),
+                    };
+                    if visited.contains(&scan) {
+                        continue;
+                    }
+                    visited.push(scan);
+                    self.push_matching_scan_target_candidates(scan, matcher, hints, symbols)?;
                 }
             }
             ReferenceSearchScope::File { target, file_id } => {
@@ -250,6 +235,7 @@ impl<'a, 'db, 'scope> ReferenceResolver<'a, 'db, 'scope> {
                         file_id: Some(file_id),
                     },
                     matcher,
+                    hints,
                     symbols,
                 )?;
             }
@@ -262,12 +248,16 @@ impl<'a, 'db, 'scope> ReferenceResolver<'a, 'db, 'scope> {
         &self,
         scan: ReferenceScanTarget,
         matcher: &ReferenceDeclarationMatcher<'_, 'db>,
+        hints: &ReferenceSearchHints,
         symbols: &mut Vec<SourceSymbol>,
     ) -> anyhow::Result<()> {
         for candidate in SourceSymbolIndex::new(self.analysis.view_db())
             .symbols_in_target(scan.target, scan.file_id)?
         {
             if !self.accepts_candidate_role(candidate.role()) {
+                continue;
+            }
+            if hints.rejects_candidate(self.analysis.view_db(), &candidate)? {
                 continue;
             }
             if matcher.matches(candidate.symbol())? {
@@ -284,26 +274,6 @@ impl<'a, 'db, 'scope> ReferenceResolver<'a, 'db, 'scope> {
             SourceSymbolRole::Structural => false,
         }
     }
-
-    fn declaration_locations(
-        &self,
-        declarations: &[DeclarationRef],
-    ) -> anyhow::Result<Vec<ReferenceSourceLocation>> {
-        let mut locations = Vec::new();
-        let declaration_view = DeclarationView::new(self.analysis.view_db());
-        for declaration_ref in declarations {
-            let Some(declaration) = declaration_view.declaration(*declaration_ref)? else {
-                continue;
-            };
-            locations.push(ReferenceSourceLocation {
-                declaration: *declaration_ref,
-                target: declaration.target(),
-                file_id: declaration.file_id(),
-                span: declaration.selection_span(),
-            });
-        }
-        Ok(locations)
-    }
 }
 
 /// Request-local declaration matcher used while scanning source occurrences.
@@ -313,10 +283,10 @@ struct ReferenceDeclarationMatcher<'a, 'db> {
 }
 
 impl<'a, 'db> ReferenceDeclarationMatcher<'a, 'db> {
-    fn new(db: &'a IndexedViewDb<'db>, declarations: &[DeclarationRef]) -> Self {
+    fn new(db: &'a IndexedViewDb<'db>, subject: &ReferenceSubject) -> Self {
         Self {
             resolver: SourceSymbolResolver::new(db),
-            declarations: declarations.iter().copied().collect(),
+            declarations: subject.declarations().clone(),
         }
     }
 
@@ -332,18 +302,4 @@ impl<'a, 'db> ReferenceDeclarationMatcher<'a, 'db> {
             .iter()
             .any(|candidate| self.declarations.contains(candidate)))
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ReferenceScanTarget {
-    target: TargetRef,
-    file_id: Option<FileId>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ReferenceSourceLocation {
-    declaration: DeclarationRef,
-    target: TargetRef,
-    file_id: FileId,
-    span: Span,
 }

--- a/crates/engine/analysis/src/query/references/search.rs
+++ b/crates/engine/analysis/src/query/references/search.rs
@@ -1,0 +1,162 @@
+//! Search-surface types for reference queries.
+//!
+//! `ReferenceQuery` describes where the resolver should look: whole targets, selected files, or one
+//! file. For example, LSP "find references" usually scans a project-chosen target list, while a
+//! text prefilter can narrow that to a few files. The query also says whether declaration locations
+//! should be included in the result.
+//!
+//! `ReferenceSearchLabel` is a plain Rust identifier that analysis has validated before the project
+//! layer uses it for fast text prefiltering.
+
+use rg_ir_model::TargetRef;
+use rg_parse::FileId;
+
+impl<'a> ReferenceQuery<'a> {
+    /// Returns a query for explicit find-references requests.
+    pub fn find_references(search_targets: &'a [TargetRef], include_declarations: bool) -> Self {
+        let declaration_policy = if include_declarations {
+            ReferenceDeclarationPolicy::IncludeUnscoped
+        } else {
+            ReferenceDeclarationPolicy::Exclude
+        };
+
+        Self {
+            search_scope: ReferenceSearchScope::Targets(search_targets),
+            declaration_policy,
+        }
+    }
+
+    /// Returns a query for explicit find-references requests prefiltered to selected files.
+    pub fn find_references_in_files(
+        search_files: &'a [ReferenceSearchFile],
+        include_declarations: bool,
+    ) -> Self {
+        let declaration_policy = if include_declarations {
+            ReferenceDeclarationPolicy::IncludeUnscoped
+        } else {
+            ReferenceDeclarationPolicy::Exclude
+        };
+
+        Self {
+            search_scope: ReferenceSearchScope::Files(search_files),
+            declaration_policy,
+        }
+    }
+
+    /// Returns a query scoped to one file inside one target.
+    pub fn file_scoped(target: TargetRef, file_id: FileId) -> Self {
+        Self {
+            search_scope: ReferenceSearchScope::File { target, file_id },
+            declaration_policy: ReferenceDeclarationPolicy::IncludeInSearchScope,
+        }
+    }
+
+    /// Removes declaration locations from this query.
+    pub fn without_declarations(mut self) -> Self {
+        self.declaration_policy = ReferenceDeclarationPolicy::Exclude;
+        self
+    }
+
+    pub(super) fn search_scope(self) -> ReferenceSearchScope<'a> {
+        self.search_scope
+    }
+
+    pub(super) fn includes_declarations(self) -> bool {
+        !matches!(self.declaration_policy, ReferenceDeclarationPolicy::Exclude)
+    }
+
+    pub(super) fn accepts_declaration(self, target: TargetRef, file_id: FileId) -> bool {
+        match self.declaration_policy {
+            ReferenceDeclarationPolicy::Exclude => false,
+            ReferenceDeclarationPolicy::IncludeUnscoped => true,
+            ReferenceDeclarationPolicy::IncludeInSearchScope => match self.search_scope {
+                ReferenceSearchScope::Targets(targets) => targets.contains(&target),
+                ReferenceSearchScope::Files(files) => files
+                    .iter()
+                    .any(|file| file.target == target && file.file_id == file_id),
+                ReferenceSearchScope::File {
+                    target: selected_target,
+                    file_id: selected_file_id,
+                } => selected_target == target && selected_file_id == file_id,
+            },
+        }
+    }
+
+    pub(super) fn accepts_scan_target(self, scan: ReferenceScanTarget) -> bool {
+        match self.search_scope {
+            ReferenceSearchScope::Targets(targets) => targets.contains(&scan.target),
+            ReferenceSearchScope::Files(files) => scan.file_id.is_some_and(|file_id| {
+                files
+                    .iter()
+                    .any(|file| file.target == scan.target && file.file_id == file_id)
+            }),
+            ReferenceSearchScope::File { target, file_id } => {
+                scan.target == target && scan.file_id == Some(file_id)
+            }
+        }
+    }
+}
+
+/// Options for a source reference lookup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReferenceQuery<'a> {
+    search_scope: ReferenceSearchScope<'a>,
+    declaration_policy: ReferenceDeclarationPolicy,
+}
+
+/// One target/file pair whose source should be scanned for references.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ReferenceSearchFile {
+    pub target: TargetRef,
+    pub file_id: FileId,
+}
+
+/// Plain Rust identifier label that is safe for request-local text prefiltering.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ReferenceSearchLabel(String);
+
+impl ReferenceSearchLabel {
+    pub(crate) fn new(label: &str) -> Option<Self> {
+        let mut bytes = label.bytes();
+        let first = bytes.next()?;
+        if (first == b'_' || first.is_ascii_alphabetic())
+            && bytes.all(|byte| byte == b'_' || byte.is_ascii_alphanumeric())
+        {
+            Some(Self(label.to_string()))
+        } else {
+            None
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Source surface scanned for reference use-sites.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ReferenceSearchScope<'a> {
+    /// Scans all source candidates inside the listed targets.
+    Targets(&'a [TargetRef]),
+    /// Scans source candidates inside the listed target/file pairs.
+    Files(&'a [ReferenceSearchFile]),
+    /// Scans source candidates in one file inside one target.
+    File { target: TargetRef, file_id: FileId },
+}
+
+/// How declaration locations should relate to the reference search surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReferenceDeclarationPolicy {
+    /// Do not return declaration locations.
+    Exclude,
+    /// Return declarations even when they are outside `ReferenceSearchScope`.
+    IncludeUnscoped,
+    /// Return declarations only when they are inside `ReferenceSearchScope`.
+    IncludeInSearchScope,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ReferenceScanTarget {
+    pub(super) target: TargetRef,
+    pub(super) file_id: Option<FileId>,
+}

--- a/crates/engine/analysis/src/query/references/subject.rs
+++ b/crates/engine/analysis/src/query/references/subject.rs
@@ -1,0 +1,215 @@
+//! Request-local reference identity and safe scan hints.
+//!
+//! A reference lookup starts by resolving the cursor to one or more declarations. `ReferenceSubject`
+//! stores those declarations and their source locations. `ReferenceSearchHints` stores optional
+//! shortcuts, for example "this local binding only needs its own file" or "candidate references
+//! must be spelled `field`".
+//!
+//! Hints are only used to skip work. The actual reference decision still comes from resolving a
+//! source symbol back to the selected declarations.
+
+use std::collections::HashSet;
+
+use rg_ir_model::{DefMapRef, identity::DeclarationRef};
+use rg_ir_view::{
+    IndexedViewDb, SymbolKind,
+    item::declaration::{Declaration, DeclarationView},
+    source::{IndexedSourceSurface, SourceOccurrenceView},
+};
+use rg_parse::{FileId, Span};
+use rg_std::UniqueVec;
+
+use crate::{model::SymbolAt, source_symbol::SourceSymbol};
+
+use super::search::{ReferenceScanTarget, ReferenceSearchLabel};
+
+/// Request-local declaration identity for one reference lookup.
+pub(super) struct ReferenceSubject {
+    declarations: HashSet<DeclarationRef>,
+    declaration_locations: Vec<ReferenceSourceLocation>,
+}
+
+impl ReferenceSubject {
+    pub(super) fn resolve(
+        db: &IndexedViewDb<'_>,
+        declarations: &[DeclarationRef],
+    ) -> anyhow::Result<(Self, ReferenceSearchHints)> {
+        let declaration_view = DeclarationView::new(db);
+        let mut declaration_locations = Vec::new();
+        let mut exact_labels = UniqueVec::new();
+        let mut exact_labels_supported = true;
+
+        for declaration_ref in declarations {
+            let Some(declaration) = declaration_view.declaration(*declaration_ref)? else {
+                exact_labels_supported = false;
+                continue;
+            };
+
+            if let Some(label) =
+                ReferenceSearchHints::exact_label_for_declaration(*declaration_ref, &declaration)
+            {
+                exact_labels.push(label);
+            } else {
+                exact_labels_supported = false;
+            }
+
+            declaration_locations.push(ReferenceSourceLocation {
+                declaration: *declaration_ref,
+                target: declaration.target(),
+                file_id: declaration.file_id(),
+                span: declaration.selection_span(),
+            });
+        }
+
+        if !exact_labels_supported {
+            exact_labels = UniqueVec::new();
+        }
+
+        let local_scan_target =
+            ReferenceSearchHints::build_local_scan_target(declarations, &declaration_locations);
+        let subject = Self {
+            declarations: declarations.iter().copied().collect(),
+            declaration_locations,
+        };
+        let hints = ReferenceSearchHints {
+            exact_labels,
+            local_scan_target,
+        };
+        Ok((subject, hints))
+    }
+
+    pub(super) fn declarations(&self) -> &HashSet<DeclarationRef> {
+        &self.declarations
+    }
+
+    pub(super) fn declaration_locations(&self) -> &[ReferenceSourceLocation] {
+        &self.declaration_locations
+    }
+}
+
+/// Request-local shortcuts that can narrow a reference scan without changing semantic matching.
+pub(super) struct ReferenceSearchHints {
+    exact_labels: UniqueVec<ReferenceSearchLabel>,
+    local_scan_target: Option<ReferenceScanTarget>,
+}
+
+impl ReferenceSearchHints {
+    pub(super) fn exact_labels(&self) -> Vec<ReferenceSearchLabel> {
+        self.exact_labels.iter().cloned().collect()
+    }
+
+    pub(super) fn local_scan_target(&self) -> Option<ReferenceScanTarget> {
+        self.local_scan_target
+    }
+
+    /// Exact labels are intentionally limited to names whose references cannot be imported under
+    /// another spelling. Import-aliasable declarations stay on the full semantic path.
+    pub(super) fn rejects_candidate(
+        &self,
+        db: &IndexedViewDb<'_>,
+        candidate: &SourceSymbol,
+    ) -> anyhow::Result<bool> {
+        if self.exact_labels.is_empty() {
+            return Ok(false);
+        }
+        let Some(label) = Self::candidate_source_label(db, candidate)? else {
+            return Ok(false);
+        };
+        let Some(label) = ReferenceSearchLabel::new(&label) else {
+            return Ok(false);
+        };
+        Ok(!self.exact_labels.iter().any(|expected| expected == &label))
+    }
+
+    fn exact_label_for_declaration(
+        declaration_ref: DeclarationRef,
+        declaration: &Declaration,
+    ) -> Option<ReferenceSearchLabel> {
+        match declaration.kind() {
+            SymbolKind::Field | SymbolKind::Method | SymbolKind::Variable => {
+                ReferenceSearchLabel::new(declaration.name())
+            }
+            SymbolKind::Const
+            | SymbolKind::Enum
+            | SymbolKind::EnumVariant
+            | SymbolKind::Function
+            | SymbolKind::Impl
+            | SymbolKind::Macro
+            | SymbolKind::Module
+            | SymbolKind::Static
+            | SymbolKind::Struct
+            | SymbolKind::Trait
+            | SymbolKind::TypeAlias
+            | SymbolKind::Union => matches!(declaration_ref, DeclarationRef::BodyBinding(_))
+                .then(|| ReferenceSearchLabel::new(declaration.name()))
+                .flatten(),
+        }
+    }
+
+    fn candidate_source_label(
+        db: &IndexedViewDb<'_>,
+        candidate: &SourceSymbol,
+    ) -> anyhow::Result<Option<String>> {
+        match candidate.symbol() {
+            SymbolAt::TypePath { path, .. }
+            | SymbolAt::ValuePath { path, .. }
+            | SymbolAt::UsePath { path, .. } => Ok(path.last_segment_label()),
+            SymbolAt::RecordField { key, .. } => Ok(Some(key.declaration_label())),
+            SymbolAt::Expr { expr } => {
+                if let IndexedSourceSurface::RecordExprShorthandValue { key, .. } =
+                    candidate.surface()
+                {
+                    return Ok(Some(key.declaration_label()));
+                }
+                SourceOccurrenceView::new(db).expr_source_label(*expr)
+            }
+            SymbolAt::Declaration { .. } | SymbolAt::FunctionBody { .. } => Ok(None),
+        }
+    }
+
+    fn build_local_scan_target(
+        declarations: &[DeclarationRef],
+        locations: &[ReferenceSourceLocation],
+    ) -> Option<ReferenceScanTarget> {
+        if declarations.is_empty()
+            || locations.is_empty()
+            || !declarations.iter().all(Self::is_body_local_declaration)
+        {
+            return None;
+        }
+
+        let first = locations.first()?;
+        if locations
+            .iter()
+            .all(|location| location.target == first.target && location.file_id == first.file_id)
+        {
+            Some(ReferenceScanTarget {
+                target: first.target,
+                file_id: Some(first.file_id),
+            })
+        } else {
+            None
+        }
+    }
+
+    fn is_body_local_declaration(declaration: &DeclarationRef) -> bool {
+        match *declaration {
+            DeclarationRef::Module(module) => matches!(module.origin, DefMapRef::Body(_)),
+            DeclarationRef::LocalDef(local_def) => matches!(local_def.origin, DefMapRef::Body(_)),
+            DeclarationRef::Item(item) => matches!(item.origin(), DefMapRef::Body(_)),
+            DeclarationRef::Field(field) => matches!(field.owner.origin, DefMapRef::Body(_)),
+            DeclarationRef::EnumVariant(variant) => {
+                matches!(variant.origin, DefMapRef::Body(_))
+            }
+            DeclarationRef::BodyBinding(_) => true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ReferenceSourceLocation {
+    pub(super) declaration: DeclarationRef,
+    pub(super) target: rg_ir_model::TargetRef,
+    pub(super) file_id: FileId,
+    pub(super) span: Span,
+}

--- a/crates/engine/analysis/src/tests/references.rs
+++ b/crates/engine/analysis/src/tests/references.rs
@@ -624,6 +624,51 @@ pub fn use_there(_: User) {}
 }
 
 #[test]
+fn file_list_references_scan_selected_files_only() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_file_list_references"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+mod other;
+mod skipped;
+
+pub struct User;
+
+pub fn use_here() {
+    let _: Us$file_list_type_ref$er;
+}
+
+//- /src/other.rs
+use crate::User;
+
+pub fn use_there(_: User) {}
+
+//- /src/skipped.rs
+use crate::User;
+
+pub fn use_elsewhere(_: User) {}
+"#,
+        &[AnalysisQuery::references(
+            "file-list type references",
+            "file_list_type_ref",
+            ReferenceQuery::files(&["src/lib.rs", "src/other.rs"]),
+        )],
+        expect![[r#"
+            file-list type references
+            - `User` @ src/lib.rs:4:12-4:16
+            - `User` @ src/lib.rs:7:12-7:16
+            - `User` @ src/other.rs:1:12-1:16
+            - `User` @ src/other.rs:3:21-3:25
+        "#]],
+    );
+}
+
+#[test]
 fn file_scoped_references_do_not_include_external_declaration() {
     check_analysis_queries(
         r#"
@@ -730,6 +775,39 @@ pub fn app_use(_: dep::Api) {
             - `Api` @ dep/src/lib.rs:1:12-1:15
             - `Api` @ dep/src/lib.rs:3:19-3:22
             - `Api` @ helper/src/lib.rs:1:27-1:30
+        "#]],
+    );
+}
+
+#[test]
+fn references_keep_import_alias_uses_for_type_declarations() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_import_alias_references"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub mod api {
+    pub struct Us$aliased_type_ref$er;
+}
+
+use api::User as Account;
+
+pub fn use_it(_: Account) {}
+"#,
+        &[AnalysisQuery::references(
+            "aliased type references",
+            "aliased_type_ref",
+            ReferenceQuery::all(),
+        )],
+        expect![[r#"
+            aliased type references
+            - `User` @ src/lib.rs:2:16-2:20
+            - `User` @ src/lib.rs:5:10-5:14
+            - `Account` @ src/lib.rs:7:18-7:25
         "#]],
     );
 }

--- a/crates/engine/analysis/src/tests/utils.rs
+++ b/crates/engine/analysis/src/tests/utils.rs
@@ -5,8 +5,8 @@ use expect_test::Expect;
 use crate::{
     Analysis, CompletionApplicability, CompletionClientCapabilities, CompletionInsertText,
     CompletionItem, CompletionQuery, DocumentSymbol, HoverInfo, InlayHint, NavigationTarget,
-    ReferenceLocation, ReferenceQuery as AnalysisReferenceQuery, RenameEdit, RenameResult,
-    RenameTarget, SourceTextView, SymbolAt, WorkspaceSymbol,
+    ReferenceLocation, ReferenceQuery as AnalysisReferenceQuery, ReferenceSearchFile, RenameEdit,
+    RenameResult, RenameTarget, SourceTextView, SymbolAt, WorkspaceSymbol,
 };
 use rg_def_map::testonly::DefMapFixture;
 use rg_ir_model::{BodySource, ExprData, ExprKind, PackageSlot, TargetRef};
@@ -276,6 +276,13 @@ impl ReferenceQuery {
         }
     }
 
+    pub(super) fn files(paths: &'static [&'static str]) -> Self {
+        Self {
+            include_declaration: true,
+            scope: ReferenceQueryScope::Files(paths),
+        }
+    }
+
     pub(super) fn libs(packages: &'static [&'static str]) -> Self {
         Self {
             include_declaration: true,
@@ -294,6 +301,7 @@ enum ReferenceQueryScope {
     AllIncludedTargets,
     CurrentTarget,
     CurrentFile,
+    Files(&'static [&'static str]),
     LibTargets(&'static [&'static str]),
 }
 
@@ -511,13 +519,13 @@ impl<'a> AnalysisQuerySnapshot<'a> {
                     &mut dump,
                 );
             }
-            AnalysisQueryKind::References(query) => {
-                let references = match query.scope {
+            AnalysisQueryKind::References(reference_options) => {
+                let references = match reference_options.scope {
                     ReferenceQueryScope::AllIncludedTargets => {
                         let use_site_targets = self.db.all_targets();
                         let reference_query = AnalysisReferenceQuery::find_references(
                             &use_site_targets,
-                            query.include_declaration,
+                            reference_options.include_declaration,
                         );
                         self.db
                             .analysis()
@@ -528,7 +536,7 @@ impl<'a> AnalysisQuerySnapshot<'a> {
                         let use_site_targets = [target];
                         let reference_query = AnalysisReferenceQuery::find_references(
                             &use_site_targets,
-                            query.include_declaration,
+                            reference_options.include_declaration,
                         );
                         self.db
                             .analysis()
@@ -537,7 +545,7 @@ impl<'a> AnalysisQuerySnapshot<'a> {
                     }
                     ReferenceQueryScope::CurrentFile => {
                         let reference_query = AnalysisReferenceQuery::file_scoped(target, file_id);
-                        let reference_query = if query.include_declaration {
+                        let reference_query = if reference_options.include_declaration {
                             reference_query
                         } else {
                             reference_query.without_declarations()
@@ -546,6 +554,24 @@ impl<'a> AnalysisQuerySnapshot<'a> {
                             .analysis()
                             .references(target, file_id, offset, reference_query)
                             .expect("fixture file-scoped references query should resolve")
+                    }
+                    ReferenceQueryScope::Files(paths) => {
+                        let search_files = paths
+                            .iter()
+                            .map(|path| {
+                                let (target, file_id) =
+                                    self.db.target_and_file_for_path(&query.target, path);
+                                ReferenceSearchFile { target, file_id }
+                            })
+                            .collect::<Vec<_>>();
+                        let reference_query = AnalysisReferenceQuery::find_references_in_files(
+                            &search_files,
+                            reference_options.include_declaration,
+                        );
+                        self.db
+                            .analysis()
+                            .references(target, file_id, offset, reference_query)
+                            .expect("fixture file-list references query should resolve")
                     }
                     ReferenceQueryScope::LibTargets(packages) => {
                         let use_site_targets = packages
@@ -556,7 +582,7 @@ impl<'a> AnalysisQuerySnapshot<'a> {
                             .collect::<Vec<_>>();
                         let reference_query = AnalysisReferenceQuery::find_references(
                             &use_site_targets,
-                            query.include_declaration,
+                            reference_options.include_declaration,
                         );
                         self.db
                             .analysis()

--- a/crates/engine/body-ir/src/build/body_def_map.rs
+++ b/crates/engine/body-ir/src/build/body_def_map.rs
@@ -312,7 +312,7 @@ impl BodyDefMapBuildState {
         let final_scopes = self.resolve_import_scopes(def_maps)?;
         let unresolved_imports = self.collect_unresolved_imports(def_maps, &final_scopes)?;
 
-        for (module_idx, scope) in final_scopes.iter().enumerate() {
+        for (module_idx, scope) in final_scopes.into_iter().enumerate() {
             let module = self
                 .builder
                 .module_mut(ModuleId(module_idx))

--- a/crates/engine/def-map/src/build/finalize/mod.rs
+++ b/crates/engine/def-map/src/build/finalize/mod.rs
@@ -590,7 +590,7 @@ fn finalize_scopes(
                 let timer = metric::TIMING_RESOLVE_IMPORT_SCOPES.start_timer();
                 current_scopes = resolve_import_scopes(old, states)?;
                 timer.finish();
-                freeze_resolved_scopes(old, states, &current_scopes)?;
+                freeze_resolved_scopes(old, states, current_scopes)?;
                 return Ok(());
             }
 
@@ -661,7 +661,7 @@ fn finalize_scopes(
 
             // No imports and no macros changed the visible declarations, so this is the stable
             // scope matrix that can be written into the frozen def maps.
-            freeze_resolved_scopes(old, states, &current_scopes)?;
+            freeze_resolved_scopes(old, states, current_scopes)?;
             return Ok(());
         }
     }
@@ -701,18 +701,32 @@ fn resolve_import_scopes(
 fn freeze_resolved_scopes(
     old: Option<&DefMapReadTxn<'_>>,
     states: &mut FinalizeTargetStates,
-    current_scopes: &ScopeMatrix,
+    current_scopes: ScopeMatrix,
 ) -> anyhow::Result<()> {
     // Once the import graph reaches a fixed point, freeze the resolved scopes into the public
     // def-map payload and preserve unresolved imports for query consumers.
     let unresolved_imports = {
-        let env = FinalizeResolutionEnv::new(old, states, current_scopes);
+        let env = FinalizeResolutionEnv::new(old, states, &current_scopes);
         UnresolvedImports::collect(states, &env)?
     };
 
-    for (_, package_states) in states.iter_dirty_mut_enumerated() {
-        for state in package_states {
-            freeze_target_scopes(state, current_scopes, &unresolved_imports);
+    for (package_slot, target_scopes) in current_scopes.packages.into_iter().enumerate() {
+        let Some(target_scopes) = target_scopes else {
+            continue;
+        };
+        let package_states = states
+            .packages
+            .get_mut(package_slot)
+            .and_then(Option::as_mut)
+            .expect("resolved scopes should exist only for dirty packages");
+        assert_eq!(
+            package_states.len(),
+            target_scopes.len(),
+            "resolved target scopes should match dirty target states"
+        );
+
+        for (state, scopes) in package_states.iter_mut().zip(target_scopes) {
+            freeze_target_scopes(state, scopes, &unresolved_imports);
         }
     }
 
@@ -721,17 +735,14 @@ fn freeze_resolved_scopes(
 
 fn freeze_target_scopes(
     state: &mut TargetState,
-    current_scopes: &ScopeMatrix,
+    final_scopes: TargetScopeMatrix,
     unresolved_imports: &UnresolvedImports,
 ) {
-    let final_scopes = current_scopes
-        .target_scopes(state.target)
-        .expect("final scopes should exist for every dirty target");
     let final_unresolved_imports = unresolved_imports
         .target_imports(state.target)
         .expect("unresolved imports should exist for every dirty target");
 
-    for (module_idx, scope) in final_scopes.iter().enumerate() {
+    for (module_idx, scope) in final_scopes.into_iter().enumerate() {
         let module = state
             .def_map_builder
             .module_mut(ModuleId(module_idx))

--- a/crates/engine/ir-storage/src/def_map/scope.rs
+++ b/crates/engine/ir-storage/src/def_map/scope.rs
@@ -111,12 +111,12 @@ impl ModuleScopeBuilder {
             .map(|(name, entry)| (name, entry.as_ref()))
     }
 
-    pub fn freeze(&self) -> ModuleScope {
+    pub fn freeze(self) -> ModuleScope {
         let mut entries = self
             .names
-            .iter()
+            .into_iter()
             .map(|(name, entry)| ScopeNameEntry {
-                name: name.clone(),
+                name,
                 entry: entry.freeze(),
             })
             .collect::<Vec<_>>();
@@ -194,11 +194,11 @@ impl ScopeEntryBuilder {
         }
     }
 
-    fn freeze(&self) -> ScopeEntry {
+    fn freeze(self) -> ScopeEntry {
         ScopeEntry {
-            types: self.types.clone().into_boxed_slice(),
-            values: self.values.clone().into_boxed_slice(),
-            macros: self.macros.clone().into_boxed_slice(),
+            types: self.types.into_boxed_slice(),
+            values: self.values.into_boxed_slice(),
+            macros: self.macros.into_boxed_slice(),
         }
     }
 }

--- a/crates/engine/ir-view/src/source/occurrence.rs
+++ b/crates/engine/ir-view/src/source/occurrence.rs
@@ -206,6 +206,33 @@ impl<'a, 'db> SourceOccurrenceView<'a, 'db> {
         Self { db }
     }
 
+    /// Returns the named source spelling selected by an expression, when the expression has one.
+    ///
+    /// Expression-backed occurrences intentionally expose only `ExprRef`, so callers that need a
+    /// cheap source label can ask the view to inspect the lowered expression. For example, this
+    /// returns `user` for a path expression, `push` for `items.push(value)`, and `name` for
+    /// `user.name`; literals and operators return `None`.
+    pub fn expr_source_label(&self, expr: ExprRef) -> anyhow::Result<Option<String>> {
+        let Some(body_data) = self.db.body_ir.body_data(expr.body_ir())? else {
+            return Ok(None);
+        };
+        let Some(expr_data) = body_data.expr(expr.expr_id()) else {
+            return Ok(None);
+        };
+
+        let label = match &expr_data.kind {
+            rg_body_ir::ExprKind::Path { path } => path
+                .as_def_map_path()
+                .and_then(|path| path.last_segment_label()),
+            rg_body_ir::ExprKind::MethodCall { method_name, .. } => Some(method_name.to_string()),
+            rg_body_ir::ExprKind::Field { field, .. } => {
+                field.as_ref().map(|field| field.declaration_label())
+            }
+            _ => None,
+        };
+        Ok(label)
+    }
+
     /// Return occurrences that touch one cursor offset.
     pub fn occurrences_at(
         &self,

--- a/crates/engine/parse/src/file.rs
+++ b/crates/engine/parse/src/file.rs
@@ -169,6 +169,11 @@ impl<'a> ParsedFile<'a> {
 
         file_text.get(start..end).map(ToString::to_string)
     }
+
+    /// Returns source text from the same saved or dirty snapshot that backs this parsed file.
+    pub fn source_text(&self) -> anyhow::Result<Cow<'a, str>> {
+        self.data.source.read(&self.data.path)
+    }
 }
 
 /// Shared parse cache that owns filesystem-backed source files and syntax trees.

--- a/crates/engine/project/Cargo.toml
+++ b/crates/engine/project/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 atomic-write-file.workspace = true
 blake3.workspace = true
 derive_more.workspace = true
+memchr.workspace = true
 rayon.workspace = true
 wincode.workspace = true
 rg_analysis.workspace = true

--- a/crates/engine/project/src/project/mod.rs
+++ b/crates/engine/project/src/project/mod.rs
@@ -3,6 +3,7 @@ mod dirty;
 pub(crate) mod loading;
 pub(crate) mod offloading;
 mod package_set;
+mod reference_search;
 mod snapshot;
 pub(crate) mod state;
 mod stats;

--- a/crates/engine/project/src/project/reference_search.rs
+++ b/crates/engine/project/src/project/reference_search.rs
@@ -1,0 +1,216 @@
+//! Project-side planning for reference and rename scans.
+//!
+//! Reference queries do not need to scan every source file. If a declaration comes from crate
+//! `model`, only `model` and crates that depend on it can contain normal references to it, so
+//! unrelated workspace crates can be skipped. When analysis also provides a safe label, such as
+//! `name` for a local binding or field, this module does a request-local text prefilter and scans
+//! only files that contain that word.
+//!
+//! These choices only reduce the amount of source sent to semantic matching. The analysis layer
+//! still resolves every surviving candidate before it is returned as a reference.
+
+use anyhow::Context as _;
+use rg_analysis::{ReferenceSearchFile, ReferenceSearchLabel};
+use rg_def_map::PackageSlot;
+use rg_ir_model::TargetRef;
+use rg_std::UniqueVec;
+
+use super::{state::ProjectState, subset};
+
+/// Builds request-local source scan surfaces for reference and rename queries.
+pub(super) struct ReferenceSearchPlanner<'a> {
+    state: &'a ProjectState,
+}
+
+impl<'a> ReferenceSearchPlanner<'a> {
+    pub(super) fn new(state: &'a ProjectState) -> Self {
+        Self { state }
+    }
+
+    /// Returns targets whose source should be scanned for an explicit references query.
+    ///
+    /// Queries scan the selected declaration packages and their package reverse-dependency
+    /// closure. Workspace-origin queries keep that closure focused on workspace members, falling
+    /// back to the whole workspace only when the declaration package is graph-opaque.
+    pub(super) fn targets(
+        &self,
+        origin_package: PackageSlot,
+        declaration_targets: &[TargetRef],
+    ) -> Vec<TargetRef> {
+        let packages = self.packages(origin_package, declaration_targets);
+        let mut targets = UniqueVec::new();
+        for package in packages {
+            for target in self.state.target_refs_for_package(package) {
+                targets.push(target);
+            }
+        }
+        targets.into_vec()
+    }
+
+    /// Returns target/file pairs whose source text contains one of the safe reference labels.
+    ///
+    /// This is a request-local text prefilter. It narrows expensive semantic scans without storing
+    /// a persistent text index or changing the declaration matcher that proves each result.
+    pub(super) fn files_matching_labels(
+        &self,
+        search_targets: &[TargetRef],
+        labels: &[ReferenceSearchLabel],
+    ) -> anyhow::Result<Option<Vec<ReferenceSearchFile>>> {
+        let Some(prefilter) = ReferenceTextPrefilter::new(labels) else {
+            return Ok(None);
+        };
+
+        let packages = Self::unique_target_packages(search_targets);
+        let subset = subset::packages_only(self.state.workspace(), &packages);
+        let def_map = self.state.def_map_read_txn_for_subset(&subset);
+
+        let mut files = UniqueVec::new();
+        for package in packages {
+            let Some(parsed_package) = self.state.parse_db().package(package.0) else {
+                continue;
+            };
+
+            for parsed_file in parsed_package.parsed_files() {
+                let source = parsed_file.source_text().with_context(|| {
+                    format!(
+                        "while attempting to read source text for {}",
+                        parsed_file.path().display()
+                    )
+                })?;
+                if !prefilter.matches(source.as_bytes()) {
+                    continue;
+                }
+
+                for target in def_map
+                    .targets_for_file(package, parsed_file.file_id())
+                    .context("while attempting to find target ownership for source file")?
+                {
+                    if !search_targets.contains(&target) {
+                        continue;
+                    }
+                    let file = ReferenceSearchFile {
+                        target,
+                        file_id: parsed_file.file_id(),
+                    };
+                    files.push(file);
+                }
+            }
+        }
+
+        Ok(Some(files.into_vec()))
+    }
+
+    /// Returns packages whose targets should be scanned for references.
+    fn packages(
+        &self,
+        origin_package: PackageSlot,
+        declaration_targets: &[TargetRef],
+    ) -> Vec<PackageSlot> {
+        let workspace = self.state.workspace();
+        let origin_is_workspace = workspace
+            .packages()
+            .get(origin_package.0)
+            .is_some_and(|package| package.is_workspace_member);
+
+        // Start from the declaration package rather than the cursor package: references can only
+        // appear in packages that either define the item or depend on the package that defines it.
+        let mut root_packages = UniqueVec::new();
+        for target in declaration_targets {
+            root_packages.push(target.package);
+        }
+        if root_packages.is_empty() {
+            root_packages.push(origin_package);
+        }
+
+        let root_ids = root_packages
+            .into_iter()
+            .filter_map(|package| {
+                workspace
+                    .packages()
+                    .get(package.0)
+                    .map(|package| package.id.clone())
+            })
+            .collect::<Vec<_>>();
+
+        let mut packages = workspace
+            .reverse_dependency_closure(&root_ids)
+            .into_iter()
+            .map(PackageSlot)
+            .collect::<Vec<_>>();
+
+        if origin_is_workspace {
+            packages.retain(|package| {
+                workspace
+                    .packages()
+                    .get(package.0)
+                    .is_some_and(|package| package.is_workspace_member)
+            });
+
+            if packages.is_empty() {
+                // Some roots, such as sysroot packages, are not always represented by normal Cargo
+                // dependency edges. Keep those queries complete by preserving the old workspace scan.
+                packages.extend(workspace.packages().iter().enumerate().filter_map(
+                    |(slot, package)| package.is_workspace_member.then_some(PackageSlot(slot)),
+                ));
+            }
+        }
+
+        packages
+    }
+
+    fn unique_target_packages(targets: &[TargetRef]) -> Vec<PackageSlot> {
+        targets
+            .iter()
+            .map(|target| target.package)
+            .collect::<UniqueVec<_>>()
+            .into_vec()
+    }
+}
+
+struct ReferenceTextPrefilter<'label> {
+    finders: Vec<(memchr::memmem::Finder<'label>, usize)>,
+}
+
+impl<'label> ReferenceTextPrefilter<'label> {
+    fn new(labels: &'label [ReferenceSearchLabel]) -> Option<Self> {
+        if labels.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            finders: labels
+                .iter()
+                .map(|label| {
+                    (
+                        memchr::memmem::Finder::new(label.as_str().as_bytes()),
+                        label.as_str().len(),
+                    )
+                })
+                .collect(),
+        })
+    }
+
+    fn matches(&self, source: &[u8]) -> bool {
+        self.finders.iter().any(|(finder, label_len)| {
+            finder.find_iter(source).any(|start| {
+                let end = start + *label_len;
+                Self::is_label_start_boundary(source, start)
+                    && Self::is_label_end_boundary(source, end)
+            })
+        })
+    }
+
+    fn is_label_start_boundary(source: &[u8], idx: usize) -> bool {
+        idx == 0 || !Self::is_label_byte(source[idx - 1])
+    }
+
+    fn is_label_end_boundary(source: &[u8], idx: usize) -> bool {
+        source
+            .get(idx)
+            .is_none_or(|byte| !Self::is_label_byte(*byte))
+    }
+
+    fn is_label_byte(byte: u8) -> bool {
+        byte == b'_' || byte.is_ascii_alphanumeric()
+    }
+}

--- a/crates/engine/project/src/project/snapshot.rs
+++ b/crates/engine/project/src/project/snapshot.rs
@@ -3,14 +3,17 @@ use std::path::Path;
 
 use anyhow::Context as _;
 
-use rg_analysis::Analysis;
+use rg_analysis::{Analysis, ReferenceSearchFile, ReferenceSearchLabel};
 use rg_def_map::{DefMapReadTxn, PackageSlot};
 use rg_ir_model::TargetRef;
 #[cfg(test)]
 use rg_parse::ParseDb;
 use rg_parse::{FileId, LineIndex, Span};
 
-use super::{FileContext, state::ProjectState, stats::ProjectStats, subset};
+use super::{
+    FileContext, reference_search::ReferenceSearchPlanner, state::ProjectState,
+    stats::ProjectStats, subset,
+};
 
 /// Immutable project view used to answer LSP-shaped queries.
 #[derive(Debug, Clone, Copy)]
@@ -40,78 +43,27 @@ impl<'a> ProjectSnapshot<'a> {
 
     /// Returns targets whose source should be scanned for an explicit references query.
     ///
-    /// Workspace-origin queries stay focused on workspace code even when the selected declaration
-    /// comes from a dependency. Dependency-origin queries use the selected declaration packages,
-    /// then expand to their package reverse-dependency closure.
+    /// Queries scan the selected declaration packages and their package reverse-dependency
+    /// closure. Workspace-origin queries keep that closure focused on workspace members, falling
+    /// back to the whole workspace only when the declaration package is graph-opaque.
     pub fn reference_search_targets(
         &self,
         origin_package: PackageSlot,
         declaration_targets: &[TargetRef],
     ) -> Vec<TargetRef> {
-        let packages = self.reference_search_packages(origin_package, declaration_targets);
-        let mut targets = Vec::new();
-        for package in packages {
-            for target in self.state.target_refs_for_package(package) {
-                if !targets.contains(&target) {
-                    targets.push(target);
-                }
-            }
-        }
-        targets
+        ReferenceSearchPlanner::new(self.state).targets(origin_package, declaration_targets)
     }
 
-    /// Returns packages whose targets should be scanned for references.
-    fn reference_search_packages(
+    /// Returns target/file pairs whose source text contains one of the safe reference labels.
+    ///
+    /// This is a request-local text prefilter. It narrows expensive semantic scans without storing
+    /// a persistent text index or changing the declaration matcher that proves each result.
+    pub fn reference_search_files_matching_labels(
         &self,
-        origin_package: PackageSlot,
-        declaration_targets: &[TargetRef],
-    ) -> Vec<PackageSlot> {
-        let workspace = self.state.workspace();
-        // Check if the query origin is part of the workspace.
-        if workspace
-            .packages()
-            .get(origin_package.0)
-            .is_some_and(|package| package.is_workspace_member)
-        {
-            // Workspace-origin queries scan all workspace members, but do not spill into
-            // dependency use-sites.
-            return workspace
-                .packages()
-                .iter()
-                .enumerate()
-                .filter_map(|(slot, package)| {
-                    package.is_workspace_member.then_some(PackageSlot(slot))
-                })
-                .collect();
-        }
-
-        // Dependency-origin queries scan the selected declaration packages and their reverse
-        // dependencies, so references from packages that can use the dependency are visible.
-        let mut root_packages = Vec::new();
-        for target in declaration_targets {
-            if !root_packages.contains(&target.package) {
-                root_packages.push(target.package);
-            }
-        }
-        if root_packages.is_empty() {
-            root_packages.push(origin_package);
-        }
-
-        let root_ids = root_packages
-            .into_iter()
-            .filter_map(|package| {
-                workspace
-                    .packages()
-                    .get(package.0)
-                    .map(|package| package.id.clone())
-            })
-            .collect::<Vec<_>>();
-
-        workspace
-            .reverse_dependency_closure(&root_ids)
-            .into_iter()
-            .map(PackageSlot)
-            .collect()
+        search_targets: &[TargetRef],
+        labels: &[ReferenceSearchLabel],
+    ) -> anyhow::Result<Option<Vec<ReferenceSearchFile>>> {
+        ReferenceSearchPlanner::new(self.state).files_matching_labels(search_targets, labels)
     }
 
     #[cfg(test)]

--- a/crates/engine/project/src/tests/mod.rs
+++ b/crates/engine/project/src/tests/mod.rs
@@ -1,6 +1,9 @@
 mod utils;
 
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::BTreeSet,
+    sync::{Arc, Mutex},
+};
 
 use expect_test::expect;
 use test_fixture::testonly::MarkedText;
@@ -8,7 +11,8 @@ use test_fixture::testonly::MarkedText;
 use self::utils::{HostFixture, HostObservation};
 use crate::{
     BuildProcessMemory, PackageResidencyPolicy, Project, ProjectMemoryHooks,
-    ProjectMemoryPurgePoint, testonly::ProjectSourceFixture,
+    ProjectMemoryPurgePoint,
+    testonly::{ProjectFixture, ProjectSourceFixture},
 };
 
 #[derive(Debug)]
@@ -302,6 +306,93 @@ make_item!(Admin);
         "def_map.macros.generated.sources_parsed",
         2,
         "each expanded generated item source should be parsed",
+    );
+}
+
+#[test]
+fn reference_search_targets_follow_workspace_reverse_dependencies() {
+    let fixture = ProjectSourceFixture::build(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["crates/dep", "crates/mid", "crates/app", "crates/independent"]
+resolver = "3"
+
+//- /crates/dep/Cargo.toml
+[package]
+name = "dep"
+version = "0.1.0"
+edition = "2024"
+
+//- /crates/dep/src/lib.rs
+pub struct Dep;
+
+//- /crates/mid/Cargo.toml
+[package]
+name = "mid"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+dep = { path = "../dep" }
+
+//- /crates/mid/src/lib.rs
+pub struct Mid(dep::Dep);
+
+//- /crates/app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+mid = { path = "../mid" }
+
+//- /crates/app/src/lib.rs
+pub struct App(mid::Mid);
+
+//- /crates/independent/Cargo.toml
+[package]
+name = "independent"
+version = "0.1.0"
+edition = "2024"
+
+//- /crates/independent/src/lib.rs
+pub struct Independent;
+"#,
+    );
+    let project = fixture.build_project();
+    let snapshot = project.snapshot();
+    let dep_package = ProjectFixture::package_slot_by_name_in(snapshot.parse_db(), "dep");
+    let app_package = ProjectFixture::package_slot_by_name_in(snapshot.parse_db(), "app");
+    let dep_file = ProjectFixture::file_id_for_path_in(
+        snapshot.parse_db(),
+        &fixture.path("crates/dep/src/lib.rs"),
+    );
+    let dep_target = snapshot
+        .targets_for_file(dep_package, dep_file)
+        .expect("dep target lookup should succeed")
+        .into_iter()
+        .next()
+        .expect("dep lib file should belong to the dep lib target");
+
+    let package_names = snapshot
+        .reference_search_targets(app_package, &[dep_target])
+        .into_iter()
+        .map(|target| {
+            snapshot
+                .parse_db()
+                .package(target.package.0)
+                .expect("reference search target package should exist")
+                .package_name()
+                .to_owned()
+        })
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        package_names,
+        BTreeSet::from(["app".to_string(), "dep".to_string(), "mid".to_string()]),
+        "workspace reference searches should skip unrelated workspace packages"
     );
 }
 

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -6,7 +6,8 @@ use std::{
 
 use anyhow::Context as _;
 use rg_analysis::{
-    CompletionQuery, InlayHint as AnalysisInlayHint, ReferenceQuery, RenameEdit, RenameTarget,
+    Analysis as QueryAnalysis, CompletionQuery, InlayHint as AnalysisInlayHint, ReferenceQuery,
+    ReferenceSearchFile, RenameEdit, RenameTarget,
 };
 use rg_ir_model::TargetRef;
 use rg_lsp_proto::{
@@ -50,6 +51,21 @@ struct QueryContext {
     label: &'static str,
     queue_elapsed: Duration,
     dirty_identity: Option<DirtyDocumentIdentity>,
+}
+
+#[derive(Debug)]
+struct ReferenceSearchPlan {
+    targets: Vec<TargetRef>,
+    files: Option<Vec<ReferenceSearchFile>>,
+}
+
+impl ReferenceSearchPlan {
+    fn query(&self, include_declaration: bool) -> ReferenceQuery<'_> {
+        match self.files.as_deref() {
+            Some(files) => ReferenceQuery::find_references_in_files(files, include_declaration),
+            None => ReferenceQuery::find_references(&self.targets, include_declaration),
+        }
+    }
 }
 
 impl QueryContext {
@@ -551,20 +567,13 @@ impl EngineWorker {
                 let mut locations = Vec::new();
 
                 for (context, target, offset) in target_offsets {
-                    let declaration_targets = analysis
-                        .goto_definition(target, context.file, offset)?
-                        .into_iter()
-                        .map(|target| target.target)
-                        .collect::<Vec<_>>();
-                    let search_targets =
-                        snapshot.reference_search_targets(context.package, &declaration_targets);
+                    let search_plan =
+                        Self::reference_search_plan(snapshot, &analysis, &context, target, offset)?;
+                    let reference_query = search_plan.query(include_declaration);
 
-                    for reference in analysis.references(
-                        target,
-                        context.file,
-                        offset,
-                        ReferenceQuery::find_references(&search_targets, include_declaration),
-                    )? {
+                    for reference in
+                        analysis.references(target, context.file, offset, reference_query)?
+                    {
                         let Some(location) =
                             references::location_for_reference(snapshot, &reference)?
                         else {
@@ -664,19 +673,15 @@ impl EngineWorker {
                     if !snapshot.package_is_workspace_member(context.package) {
                         continue;
                     }
-                    let declaration_targets = analysis
-                        .goto_definition(target, context.file, offset)?
-                        .into_iter()
-                        .map(|target| target.target)
-                        .collect::<Vec<_>>();
-                    let search_targets =
-                        snapshot.reference_search_targets(context.package, &declaration_targets);
+                    let search_plan =
+                        Self::reference_search_plan(snapshot, &analysis, &context, target, offset)?;
+                    let reference_query = search_plan.query(true);
                     let Some(rename_result) = analysis.rename(
                         target,
                         context.file,
                         offset,
                         &new_name,
-                        ReferenceQuery::find_references(&search_targets, true),
+                        reference_query,
                     )?
                     else {
                         continue;
@@ -1095,6 +1100,25 @@ impl EngineWorker {
         );
 
         Ok(targets)
+    }
+
+    fn reference_search_plan(
+        snapshot: ProjectSnapshot<'_>,
+        analysis: &QueryAnalysis<'_>,
+        context: &FileContext,
+        target: TargetRef,
+        offset: u32,
+    ) -> anyhow::Result<ReferenceSearchPlan> {
+        let declaration_targets = analysis
+            .goto_definition(target, context.file, offset)?
+            .into_iter()
+            .map(|target| target.target)
+            .collect::<Vec<_>>();
+        let targets = snapshot.reference_search_targets(context.package, &declaration_targets);
+        let labels = analysis.reference_search_labels(target, context.file, offset)?;
+        let files = snapshot.reference_search_files_matching_labels(&targets, &labels)?;
+
+        Ok(ReferenceSearchPlan { targets, files })
     }
 
     fn file_contexts(


### PR DESCRIPTION
Consume defmap scopes when freezing to avoid excessive cloning & optimize reference lookups