### PR TITLE
fix: Purge memory on read-only queries

### DIFF
--- a/crates/engine/project/src/project/mod.rs
+++ b/crates/engine/project/src/project/mod.rs
@@ -20,7 +20,10 @@ use rg_parse::FileId;
 use rg_workspace::WorkspaceMetadata;
 
 use self::state::ProjectState;
-use crate::{indexing::IndexingPerformancePreference, residency::PackageResidencyPlan};
+use crate::{
+    indexing::IndexingPerformancePreference,
+    residency::{PackageResidency, PackageResidencyPlan},
+};
 use rg_std::MemorySize;
 
 pub use self::{
@@ -114,6 +117,28 @@ impl Project {
         changes: impl IntoIterator<Item = DirtyFileChange>,
     ) -> anyhow::Result<Option<Project>> {
         dirty::build_overlay(self, changes)
+    }
+
+    /// Drops state that read-only queries may lazily reconstruct from durable backing data.
+    ///
+    /// Query transactions own their offloaded package payloads, so those die with the request.
+    /// Source-coordinate conversion is different: it repopulates line-index cells inside the
+    /// project itself, and the owner has to reset those cells after the request settles.
+    pub fn release_query_memory(&mut self) {
+        let offloadable_packages = self
+            .state
+            .package_residency
+            .packages()
+            .iter()
+            .enumerate()
+            .filter_map(|(package_idx, residency)| {
+                (*residency == PackageResidency::Offloadable).then_some(package_idx)
+            })
+            .collect::<Vec<_>>();
+
+        self.state
+            .parse
+            .offload_line_indexes_for_packages(&offloadable_packages);
     }
 }
 

--- a/crates/lsp/engine/src/dirty_state/overlay.rs
+++ b/crates/lsp/engine/src/dirty_state/overlay.rs
@@ -28,6 +28,12 @@ impl DirtyOverlayCache {
         self.cached = None;
     }
 
+    pub(crate) fn release_query_memory(&mut self) {
+        if let Some(cached) = &mut self.cached {
+            cached.project.release_query_memory();
+        }
+    }
+
     pub(crate) fn project_for_dirty(
         &mut self,
         base: &Project,

--- a/crates/lsp/engine/src/engine/project_proxy.rs
+++ b/crates/lsp/engine/src/engine/project_proxy.rs
@@ -53,6 +53,13 @@ impl ProjectProxy {
             .context("LSP engine is not initialized")
     }
 
+    pub(super) fn release_query_memory(&mut self) {
+        if let Some(saved) = &mut self.saved {
+            saved.release_query_memory();
+        }
+        self.dirty_overlay.release_query_memory();
+    }
+
     pub(super) fn with_query_snapshot<T>(
         &mut self,
         dirty: Option<&DirtyDocumentSnapshot>,

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -1290,12 +1290,20 @@ impl EngineWorker {
             MemoryReporter::log_checkpoint(memory_control.as_ref(), label, "query_before");
         let result = query(self);
         let query_elapsed = started.elapsed();
-        MemoryReporter::log_checkpoint_delta(
+        let memory_after_query = MemoryReporter::log_checkpoint_delta(
             memory_control.as_ref(),
             label,
             "query_after",
             memory_before,
         );
+        self.project.release_query_memory();
+        MemoryReporter::log_checkpoint_delta(
+            memory_control.as_ref(),
+            label,
+            "query_cleanup_after",
+            memory_after_query,
+        );
+        MemoryReporter::purge_and_report_debug(memory_control.as_ref(), "after analysis query");
         let should_recover = result
             .as_ref()
             .err()

--- a/crates/lsp/engine/src/memory/report.rs
+++ b/crates/lsp/engine/src/memory/report.rs
@@ -79,4 +79,34 @@ impl MemoryReporter {
             );
         }
     }
+
+    pub(crate) fn purge_and_report_debug(memory_control: &dyn MemoryControl, label: &'static str) {
+        let before_purge = MemoryStats::capture(memory_control);
+        let purge = if memory_control.allocator_purge_enabled() {
+            MemoryPurge::try_purge(memory_control, before_purge)
+        } else {
+            None
+        };
+        let after = match purge {
+            Some(purge) => purge.after,
+            None => before_purge,
+        };
+
+        tracing::debug!(
+            label,
+            allocator = memory_control.allocator_name(),
+            allocator_purge_enabled = memory_control.allocator_purge_enabled(),
+            allocator_purged = purge.is_some(),
+            stats = %after,
+            "allocation info"
+        );
+
+        if let Some(purge) = purge {
+            tracing::debug!(
+                label,
+                purge = %purge,
+                "purge stats"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Without that fix, when the engine starts, vs code runs some default queries (inlay hints / document symbols / etc) and without purge the memory usage remains higher than needed. This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced memory management within the query processing system, implementing improved resource cleanup and release procedures across multiple components.
  * Expanded memory monitoring and diagnostic capabilities with new debug-level reporting features providing detailed tracking and analysis of memory usage patterns during engine operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->