### PR TITLE
feat: Project files watching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,6 +1584,7 @@ dependencies = [
  "anyhow",
  "futures",
  "rg_lsp_proto",
+ "rg_std",
  "serde_json",
  "tarpc",
  "test_fixture",

--- a/crates/lsp/engine/src/documents/mod.rs
+++ b/crates/lsp/engine/src/documents/mod.rs
@@ -96,13 +96,10 @@ impl DocumentStore {
         document.dirty = document.live != document.saved;
     }
 
-    /// Processes a change to the document that is not clearly initiated by user,
-    /// e.g. a change outside of the code editor.
+    /// Processes a saved-file change that came from outside the editor save flow.
     ///
-    /// The difference with `did_save` is that if the document is already dirty,
-    /// we enter an ambiguous tri-state: old saved state, new saved state, and dirty
-    /// state that is based on the old saved state. As a result, we use a simpler
-    /// processing model and don't try to be overly smart.
+    /// Clean open documents can follow the new disk text. Dirty documents keep the editor text,
+    /// but still update their saved state so future comparisons use the latest file contents.
     pub(crate) fn external_saved_change(&mut self, path: PathBuf, full_text: &str) {
         let Some(document) = self.documents.get_mut(&path) else {
             return;
@@ -110,8 +107,7 @@ impl DocumentStore {
 
         let saved = TextFingerprint::new(full_text);
         document.saved = Some(saved);
-        // External changes move the saved baseline. A clean editor buffer follows disk, while a
-        // dirty editor buffer remains the authoritative live snapshot.
+        // If the editor has no unsaved changes, keep its live snapshot in sync with disk.
         if !document.dirty {
             document.live = Some(saved);
             document.live_text = Some(Arc::from(full_text));

--- a/crates/lsp/engine/src/documents/mod.rs
+++ b/crates/lsp/engine/src/documents/mod.rs
@@ -96,6 +96,29 @@ impl DocumentStore {
         document.dirty = document.live != document.saved;
     }
 
+    /// Processes a change to the document that is not clearly initiated by user,
+    /// e.g. a change outside of the code editor.
+    ///
+    /// The difference with `did_save` is that if the document is already dirty,
+    /// we enter an ambiguous tri-state: old saved state, new saved state, and dirty
+    /// state that is based on the old saved state. As a result, we use a simpler
+    /// processing model and don't try to be overly smart.
+    pub(crate) fn external_saved_change(&mut self, path: PathBuf, full_text: &str) {
+        let Some(document) = self.documents.get_mut(&path) else {
+            return;
+        };
+
+        let saved = TextFingerprint::new(full_text);
+        document.saved = Some(saved);
+        // External changes move the saved baseline. A clean editor buffer follows disk, while a
+        // dirty editor buffer remains the authoritative live snapshot.
+        if !document.dirty {
+            document.live = Some(saved);
+            document.live_text = Some(Arc::from(full_text));
+        }
+        document.dirty = document.live != document.saved;
+    }
+
     pub(crate) fn mark_dirty_after_failed_save(&mut self, path: PathBuf) {
         let document = self.documents.entry(path).or_default();
         document.dirty = true;

--- a/crates/lsp/engine/src/documents/tests.rs
+++ b/crates/lsp/engine/src/documents/tests.rs
@@ -75,6 +75,77 @@ fn save_keeps_document_dirty_when_a_newer_edit_already_landed() {
 }
 
 #[test]
+fn external_saved_change_updates_clean_open_document() {
+    let path = PathBuf::from("/workspace/src/lib.rs");
+    let mut store = DocumentStore::default();
+
+    store.did_open(path.clone(), Some(1), "fn main() {}\n");
+    store.external_saved_change(path.clone(), "fn main() {\n    external();\n}\n");
+
+    let freshness = store.freshness(&path);
+    assert!(!store.is_dirty(&path));
+    assert_eq!(
+        freshness.saved_len(),
+        Some("fn main() {\n    external();\n}\n".len())
+    );
+    assert_eq!(
+        freshness.live_len(),
+        Some("fn main() {\n    external();\n}\n".len())
+    );
+}
+
+#[test]
+fn external_saved_change_keeps_dirty_live_text() {
+    let path = PathBuf::from("/workspace/src/lib.rs");
+    let mut store = DocumentStore::default();
+
+    store.did_open(path.clone(), Some(1), "fn main() {}\n");
+    store.did_change(
+        path.clone(),
+        Some(2),
+        Some("fn main() {\n    unsaved();\n}\n"),
+    );
+    store.external_saved_change(path.clone(), "fn main() {\n    external();\n}\n");
+
+    let DirtyDocumentSnapshotState::Dirty(snapshot) = store.dirty_snapshot(&path) else {
+        panic!("dirty document should keep exposing its live editor snapshot");
+    };
+    assert_eq!(snapshot.text(), "fn main() {\n    unsaved();\n}\n");
+}
+
+#[test]
+fn external_saved_change_cleans_dirty_document_that_matches_disk() {
+    let path = PathBuf::from("/workspace/src/lib.rs");
+    let mut store = DocumentStore::default();
+
+    store.did_open(path.clone(), Some(1), "fn main() {}\n");
+    store.did_change(
+        path.clone(),
+        Some(2),
+        Some("fn main() {\n    external();\n}\n"),
+    );
+    store.external_saved_change(path.clone(), "fn main() {\n    external();\n}\n");
+
+    assert!(!store.is_dirty(&path));
+}
+
+#[test]
+fn external_saved_change_keeps_unknown_dirty_buffer_dirty() {
+    let path = PathBuf::from("/workspace/src/lib.rs");
+    let mut store = DocumentStore::default();
+
+    store.did_open(path.clone(), Some(1), "fn main() {}\n");
+    store.did_change(path.clone(), Some(2), None);
+    store.external_saved_change(path.clone(), "fn main() {\n    external();\n}\n");
+
+    assert!(store.is_dirty(&path));
+    assert!(matches!(
+        store.dirty_snapshot(&path),
+        DirtyDocumentSnapshotState::DirtyWithoutText
+    ));
+}
+
+#[test]
 fn exposes_dirty_snapshot_when_full_live_text_is_available() {
     let path = PathBuf::from("/workspace/src/lib.rs");
     let mut store = DocumentStore::default();

--- a/crates/lsp/engine/src/engine/command.rs
+++ b/crates/lsp/engine/src/engine/command.rs
@@ -14,9 +14,8 @@ pub(crate) enum EngineCommand {
         analysis: AnalysisConfig,
         respond_to: EngineResponse<()>,
     },
-    DidSave {
-        path: PathBuf,
-        text: Option<String>,
+    ProjectPathsChanged {
+        paths: Vec<PathBuf>,
         respond_to: EngineResponse<()>,
     },
     GotoDefinition {

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -122,18 +122,12 @@ impl EngineWorker {
                     tracing::trace!(root = %root.display(), "engine command started: initialize");
                     let _ = respond_to.send(self.initialize(root, analysis));
                 }
-                EngineCommand::DidSave {
-                    path,
-                    text,
-                    respond_to,
-                } => {
+                EngineCommand::ProjectPathsChanged { paths, respond_to } => {
                     tracing::trace!(
-                        path = %path.display(),
-                        has_text = text.is_some(),
-                        text_len = ?text.as_ref().map(String::len),
-                        "engine command started: did_save"
+                        path_count = paths.len(),
+                        "engine command started: project_paths_changed"
                     );
-                    let _ = respond_to.send(self.did_save(path, text));
+                    let _ = respond_to.send(self.project_paths_changed(paths));
                 }
                 EngineCommand::GotoDefinition {
                     path,
@@ -496,28 +490,41 @@ impl EngineWorker {
         Ok(())
     }
 
-    fn did_save(&mut self, path: PathBuf, text: Option<String>) -> anyhow::Result<()> {
+    fn project_paths_changed(&mut self, paths: Vec<PathBuf>) -> anyhow::Result<()> {
         let started = Instant::now();
-        tracing::info!(
-            path = %path.display(),
-            notification_includes_text = text.is_some(),
-            "processing saved file"
-        );
+        let mut applied_changes = 0usize;
+        let mut changed_files = 0usize;
+        let mut affected_packages = 0usize;
+        let mut changed_targets = 0usize;
 
-        let summary = self.project.mutate_saved(|project| {
-            project
-                .apply_change(SavedFileChange::new(&path))
-                .context("while attempting to apply saved file change")
-        })?;
+        tracing::info!(path_count = paths.len(), "processing project path changes");
+
+        for path in paths {
+            let summary = self.project.mutate_saved(|project| {
+                project
+                    .apply_change(SavedFileChange::new(&path))
+                    .context("while attempting to apply project path change")
+            })?;
+            applied_changes += 1;
+            changed_files += summary.changed_files.len();
+            affected_packages += summary.affected_packages.len();
+            changed_targets += summary.changed_targets.len();
+        }
+
         tracing::info!(
-            path = %path.display(),
-            changed_files = summary.changed_files.len(),
-            affected_packages = summary.affected_packages.len(),
-            changed_targets = summary.changed_targets.len(),
+            applied_changes,
+            changed_files,
+            affected_packages,
+            changed_targets,
             elapsed_ms = started.elapsed().as_millis(),
-            "saved file reindex finished"
+            "project path reindex finished"
         );
-        Self::log_project_snapshot(self.project.saved_snapshot()?, "after save");
+        if applied_changes > 0 {
+            Self::log_project_snapshot(
+                self.project.saved_snapshot()?,
+                "after project path changes",
+            );
+        }
 
         Ok(())
     }

--- a/crates/lsp/engine/src/service/service_impl.rs
+++ b/crates/lsp/engine/src/service/service_impl.rs
@@ -137,9 +137,8 @@ impl EngineService for Service {
         let saved_path = path.clone();
         if let Err(error) = self
             .engine
-            .request(|respond_to| EngineCommand::DidSave {
-                path,
-                text,
+            .request(|respond_to| EngineCommand::ProjectPathsChanged {
+                paths: vec![path],
                 respond_to,
             })
             .await
@@ -151,6 +150,91 @@ impl EngineService for Service {
         }
 
         self.engine.log_freshness_after_save(&saved_path).await;
+        self.engine.refresh_inlay_hints_now();
+
+        Ok(())
+    }
+
+    async fn external_project_paths_changed(
+        self,
+        _: context::Context,
+        paths: Vec<PathBuf>,
+    ) -> EngineResult<()> {
+        let mut forwarded_paths = Vec::new();
+        let mut changed_texts = Vec::new();
+
+        // Collect text from the changed documents to update document states.
+        for path in paths {
+            if !path.is_file() {
+                tracing::trace!(
+                    path = %path.display(),
+                    "external project path skipped because path is not a file"
+                );
+                continue;
+            }
+
+            let text = match std::fs::read_to_string(&path) {
+                Ok(text) => text,
+                Err(error) => {
+                    tracing::debug!(
+                        path = %path.display(),
+                        error = %error,
+                        "external project path skipped because source text could not be read"
+                    );
+                    continue;
+                }
+            };
+
+            changed_texts.push((path.clone(), text));
+            forwarded_paths.push(path);
+        }
+
+        if forwarded_paths.is_empty() {
+            return Ok(());
+        }
+
+        // Update the documents state.
+        let mut documents = self.engine.documents.lock().await;
+        for (path, text) in &changed_texts {
+            documents.external_saved_change(path.clone(), text);
+            let freshness = documents.freshness(path);
+            let dirty = documents.dirty_snapshot(path);
+            self.engine.sync_dirty_state(path, &dirty);
+
+            tracing::trace!(
+                path = %path.display(),
+                tracked = freshness.tracked(),
+                version = ?freshness.version(),
+                dirty = freshness.dirty(),
+                saved_len = ?freshness.saved_len(),
+                live_len = ?freshness.live_len(),
+                saved_hash = ?freshness.saved_hash(),
+                live_hash = ?freshness.live_hash(),
+                "document freshness after external change"
+            );
+        }
+        drop(documents);
+
+        // Launch diagnostics, if required. We don't need to provide all the paths,
+        // since we expect diagnostics to be a global workspace command.
+        if let Some(path) = forwarded_paths.first().cloned() {
+            self.diagnostics.launch_on_save(path).await;
+        }
+
+        // Notify engine about the changes.
+        let changed_file_count = forwarded_paths.len();
+        self.engine
+            .request(|respond_to| EngineCommand::ProjectPathsChanged {
+                paths: forwarded_paths,
+                respond_to,
+            })
+            .await
+            .map_err(EngineError::from)?;
+
+        tracing::debug!(
+            changed_files = changed_file_count,
+            "applied external project path changes"
+        );
         self.engine.refresh_inlay_hints_now();
 
         Ok(())

--- a/crates/lsp/engine/src/service/service_impl.rs
+++ b/crates/lsp/engine/src/service/service_impl.rs
@@ -163,7 +163,8 @@ impl EngineService for Service {
         let mut forwarded_paths = Vec::new();
         let mut changed_texts = Vec::new();
 
-        // Collect text from the changed documents to update document states.
+        // Watched-file notifications only carry paths. Read the files here so document state and
+        // project state are updated from the same disk text.
         for path in paths {
             if !path.is_file() {
                 tracing::trace!(
@@ -193,7 +194,7 @@ impl EngineService for Service {
             return Ok(());
         }
 
-        // Update the documents state.
+        // Update document state before asking the project to rebuild from these files.
         let mut documents = self.engine.documents.lock().await;
         for (path, text) in &changed_texts {
             documents.external_saved_change(path.clone(), text);
@@ -215,13 +216,12 @@ impl EngineService for Service {
         }
         drop(documents);
 
-        // Launch diagnostics, if required. We don't need to provide all the paths,
-        // since we expect diagnostics to be a global workspace command.
+        // Diagnostics run as a workspace command, so one changed path is enough to start them.
         if let Some(path) = forwarded_paths.first().cloned() {
             self.diagnostics.launch_on_save(path).await;
         }
 
-        // Notify engine about the changes.
+        // The project decides whether a path is a source edit or a Cargo graph change.
         let changed_file_count = forwarded_paths.len();
         self.engine
             .request(|respond_to| EngineCommand::ProjectPathsChanged {

--- a/crates/lsp/engine/src/tests/external_flow.rs
+++ b/crates/lsp/engine/src/tests/external_flow.rs
@@ -193,3 +193,58 @@ pub struct GeneratedName;
 
     fixture.shutdown().await;
 }
+
+#[tokio::test]
+async fn external_cargo_manifest_change_refreshes_workspace_graph() {
+    let fixture = LspEngineFixture::initialized(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "lsp_external_manifest"
+        version = "0.1.0"
+        edition = "2024"
+
+        //- /src/lib.rs
+        pub struct Lib;
+
+        //- /src/tool.rs
+        pub struct ToolCommand;
+        "#,
+    )
+    .await;
+
+    fixture
+        .external_file_changed(
+            "Cargo.toml",
+            r#"[package]
+name = "lsp_external_manifest"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "tool"
+path = "src/tool.rs"
+"#,
+        )
+        .await;
+
+    fixture
+        .check(
+            &[LspQuery::document_symbol(
+                "document symbols after external manifest change",
+                "src/tool.rs",
+            )],
+            expect![[r#"
+                document symbols after external manifest change
+                - Struct ToolCommand 0:11-0:22
+            "#]],
+        )
+        .await;
+
+    fixture.check_notification_effects(expect![[r#"
+        notifications
+        - inlay hint refresh
+    "#]]);
+
+    fixture.shutdown().await;
+}

--- a/crates/lsp/engine/src/tests/external_flow.rs
+++ b/crates/lsp/engine/src/tests/external_flow.rs
@@ -1,0 +1,119 @@
+use expect_test::expect;
+
+use super::utils::{LspEngineFixture, LspQuery};
+
+#[tokio::test]
+async fn external_source_change_refreshes_saved_project() {
+    let fixture = LspEngineFixture::initialized(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "lsp_external_flow"
+        version = "0.1.0"
+        edition = "2024"
+
+        //- /src/lib.rs
+        pub struct ExternalUser {
+            pub old_field: OldName,
+        }
+
+        pub struct OldName;
+
+        pub fn demo(user: ExternalUser) {
+            let _completion = user.$complete$;
+            let _hover = user.old_$hover$field;
+        }
+        "#,
+    )
+    .await;
+
+    fixture
+        .check(
+            &[
+                LspQuery::completion("complete field before external change", "complete"),
+                LspQuery::hover("hover field before external change", "hover"),
+                LspQuery::document_symbol("document symbols before external change", "src/lib.rs"),
+            ],
+            expect![[r#"
+                complete field before external change
+                - old_field Field
+                  detail: pub old_field: OldName
+                  edit: /src/lib.rs:7:27-7:27 -> old_field
+
+                hover field before external change
+                - range: /src/lib.rs:8:22-8:31
+                - markdown:
+                  ```rust
+                  lsp_external_flow::ExternalUser
+                  ```
+
+                  ```rust
+                  pub old_field: OldName
+                  ```
+
+                document symbols before external change
+                - Struct ExternalUser 0:11-0:23
+                  - Field old_field 1:8-1:17
+                - Struct OldName 4:11-4:18
+                - Function demo 6:7-6:11
+            "#]],
+        )
+        .await;
+
+    fixture
+        .external_file_changed(
+            "src/lib.rs",
+            r#"pub struct ExternalUser {
+    pub new_field: NewName,
+}
+
+pub struct NewName;
+
+pub fn demo(user: ExternalUser) {
+    let _completion = user.;
+    let _hover = user.new_field;
+}
+"#,
+        )
+        .await;
+
+    fixture
+        .check(
+            &[
+                LspQuery::completion("complete field after external change", "complete"),
+                LspQuery::hover("hover field after external change", "hover"),
+                LspQuery::document_symbol("document symbols after external change", "src/lib.rs"),
+            ],
+            expect![[r#"
+                complete field after external change
+                - new_field Field
+                  detail: pub new_field: NewName
+                  edit: /src/lib.rs:7:27-7:27 -> new_field
+
+                hover field after external change
+                - range: /src/lib.rs:8:22-8:31
+                - markdown:
+                  ```rust
+                  lsp_external_flow::ExternalUser
+                  ```
+
+                  ```rust
+                  pub new_field: NewName
+                  ```
+
+                document symbols after external change
+                - Struct ExternalUser 0:11-0:23
+                  - Field new_field 1:8-1:17
+                - Struct NewName 4:11-4:18
+                - Function demo 6:7-6:11
+            "#]],
+        )
+        .await;
+
+    fixture.check_notification_effects(expect![[r#"
+        notifications
+        - inlay hint refresh
+    "#]]);
+
+    fixture.shutdown().await;
+}

--- a/crates/lsp/engine/src/tests/external_flow.rs
+++ b/crates/lsp/engine/src/tests/external_flow.rs
@@ -117,3 +117,79 @@ pub fn demo(user: ExternalUser) {
 
     fixture.shutdown().await;
 }
+
+#[tokio::test]
+async fn external_created_module_file_refreshes_saved_project() {
+    let fixture = LspEngineFixture::initialized(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "lsp_external_created"
+        version = "0.1.0"
+        edition = "2024"
+
+        //- /src/lib.rs
+        pub mod generated;
+
+        pub fn demo(user: generated::GeneratedUser) {
+            let _completion = user.$complete$;
+            let _hover = user.generated_$hover$field;
+        }
+        "#,
+    )
+    .await;
+
+    fixture
+        .external_file_changed(
+            "src/generated.rs",
+            r#"pub struct GeneratedUser {
+    pub generated_field: GeneratedName,
+}
+
+pub struct GeneratedName;
+"#,
+        )
+        .await;
+
+    fixture
+        .check(
+            &[
+                LspQuery::completion("complete field after external module creation", "complete"),
+                LspQuery::hover("hover field after external module creation", "hover"),
+                LspQuery::document_symbol(
+                    "document symbols after external module creation",
+                    "src/generated.rs",
+                ),
+            ],
+            expect![[r#"
+                complete field after external module creation
+                - generated_field Field
+                  detail: pub generated_field: GeneratedName
+                  edit: /src/lib.rs:3:27-3:27 -> generated_field
+
+                hover field after external module creation
+                - range: /src/lib.rs:4:22-4:37
+                - markdown:
+                  ```rust
+                  lsp_external_created::generated::GeneratedUser
+                  ```
+
+                  ```rust
+                  pub generated_field: GeneratedName
+                  ```
+
+                document symbols after external module creation
+                - Struct GeneratedUser 0:11-0:24
+                  - Field generated_field 1:8-1:23
+                - Struct GeneratedName 4:11-4:24
+            "#]],
+        )
+        .await;
+
+    fixture.check_notification_effects(expect![[r#"
+        notifications
+        - inlay hint refresh
+    "#]]);
+
+    fixture.shutdown().await;
+}

--- a/crates/lsp/engine/src/tests/mod.rs
+++ b/crates/lsp/engine/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod dirty_flow;
+mod external_flow;
 mod flow;
 mod rename_flow;
 mod save_flow;

--- a/crates/lsp/engine/src/tests/utils.rs
+++ b/crates/lsp/engine/src/tests/utils.rs
@@ -164,6 +164,18 @@ impl LspEngineFixture {
             .expect("fixture dirty document should save");
     }
 
+    pub(super) async fn external_file_changed(&self, path: &str, text: &str) {
+        self.notifications.clear();
+        std::fs::write(self.fixture.path(path), text)
+            .expect("fixture external change should be writable");
+
+        self.service
+            .clone()
+            .external_project_paths_changed(context::current(), vec![self.fixture.path(path)])
+            .await
+            .expect("fixture external file change should apply");
+    }
+
     pub(super) fn check_notification_effects(&self, expect: Expect) {
         let mut rendered = String::new();
         writeln!(rendered, "notifications").expect("snapshot should be writable");

--- a/crates/lsp/proto/src/service.rs
+++ b/crates/lsp/proto/src/service.rs
@@ -26,6 +26,8 @@ pub trait EngineService {
 
     async fn did_save(path: PathBuf, text: Option<String>) -> EngineResult<()>;
 
+    async fn external_project_paths_changed(paths: Vec<PathBuf>) -> EngineResult<()>;
+
     async fn did_close(path: PathBuf) -> EngineResult<()>;
 
     async fn goto_definition(

--- a/crates/lsp/proto/src/service.rs
+++ b/crates/lsp/proto/src/service.rs
@@ -26,6 +26,7 @@ pub trait EngineService {
 
     async fn did_save(path: PathBuf, text: Option<String>) -> EngineResult<()>;
 
+    /// Saved project paths changed on disk outside the editor-owned save flow.
     async fn external_project_paths_changed(paths: Vec<PathBuf>) -> EngineResult<()>;
 
     async fn did_close(path: PathBuf) -> EngineResult<()>;

--- a/crates/lsp/server/Cargo.toml
+++ b/crates/lsp/server/Cargo.toml
@@ -13,6 +13,7 @@ description.workspace = true
 anyhow.workspace = true
 futures.workspace = true
 rg_lsp_proto.workspace = true
+rg_std.workspace = true
 tarpc = { workspace = true, features = ["serde-transport", "serde-transport-json", "tcp", "tokio1"] }
 tokio = { workspace = true, features = ["io-std", "io-util", "macros", "process", "rt-multi-thread", "sync"] }
 tower-lsp-server.workspace = true

--- a/crates/lsp/server/src/backend.rs
+++ b/crates/lsp/server/src/backend.rs
@@ -193,6 +193,29 @@ impl LanguageServer for Backend {
         methods::text_document::did_save::did_save(context, params).await;
     }
 
+    #[tracing::instrument(skip_all, fields(rg.method = "didChangeWatchedFiles"))]
+    async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
+        let paths = params
+            .changes
+            .into_iter()
+            .filter(|change| change.typ == FileChangeType::CHANGED)
+            .filter_map(|change| methods::uri_to_path(&change.uri))
+            .filter(|path| path.extension().and_then(|extension| extension.to_str()) == Some("rs"))
+            .collect::<Vec<_>>();
+        if paths.is_empty() {
+            return;
+        }
+
+        tracing::debug!(
+            changed_files = paths.len(),
+            "routing external Rust source changes"
+        );
+        let Some(registry) = self.registry().await.ok() else {
+            return;
+        };
+        registry.external_project_paths_changed(paths).await;
+    }
+
     #[tracing::instrument(
         skip_all,
         fields(rg.method = "didClose", rg.uri = ?params.text_document.uri)

--- a/crates/lsp/server/src/backend.rs
+++ b/crates/lsp/server/src/backend.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Cow, path::PathBuf};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
 
 use tower_lsp_server::{
     Client as LspClient, LanguageServer,
@@ -14,6 +17,7 @@ use crate::{
     engine_client::EngineClient,
     engine_registry::EngineRegistry,
     methods::{self, MethodContext},
+    recent_editor_saves::RecentEditorSaves,
 };
 
 #[derive(Debug)]
@@ -21,6 +25,7 @@ pub(crate) struct Backend {
     lsp_client: LspClient,
     engines: OnceCell<EngineRegistry>,
     client_capabilities: OnceCell<EngineClientCapabilities>,
+    recent_editor_saves: RecentEditorSaves,
 }
 
 impl Backend {
@@ -29,6 +34,7 @@ impl Backend {
             lsp_client,
             engines: OnceCell::new(),
             client_capabilities: OnceCell::new(),
+            recent_editor_saves: RecentEditorSaves::default(),
         }
     }
 
@@ -51,10 +57,14 @@ impl Backend {
         let Some(path) = methods::uri_to_path(uri) else {
             return Ok(None);
         };
+        self.method_context_for_path(&path).await
+    }
+
+    async fn method_context_for_path(&self, path: &Path) -> Result<Option<MethodContext>> {
         let Some(engine_client) = self
             .registry()
             .await?
-            .document(&path)
+            .document(path)
             .await
             .inspect_err(|_| tracing::error!("failed to route LSP method to an engine"))
             .map_err(methods::internal_error)?
@@ -182,38 +192,28 @@ impl LanguageServer for Backend {
         fields(rg.method = "didSave", rg.uri = ?params.text_document.uri)
     )]
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
-        let Some(context) = self
-            .method_context_for(&params.text_document.uri)
-            .await
-            .ok()
-            .flatten()
-        else {
+        let Some(path) = methods::uri_to_path(&params.text_document.uri) else {
             return;
         };
-        methods::text_document::did_save::did_save(context, params).await;
+        self.recent_editor_saves.record_editor_save(&path).await;
+
+        let Some(context) = self.method_context_for_path(&path).await.ok().flatten() else {
+            return;
+        };
+        methods::text_document::did_save::did_save(context, path, params).await;
     }
 
     #[tracing::instrument(skip_all, fields(rg.method = "didChangeWatchedFiles"))]
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
-        let paths = params
-            .changes
-            .into_iter()
-            .filter(|change| change.typ == FileChangeType::CHANGED)
-            .filter_map(|change| methods::uri_to_path(&change.uri))
-            .filter(|path| path.extension().and_then(|extension| extension.to_str()) == Some("rs"))
-            .collect::<Vec<_>>();
-        if paths.is_empty() {
-            return;
-        }
-
-        tracing::debug!(
-            changed_files = paths.len(),
-            "routing external Rust source changes"
-        );
         let Some(registry) = self.registry().await.ok() else {
             return;
         };
-        registry.external_project_paths_changed(paths).await;
+        methods::workspace::did_change_watched_files::did_change_watched_files(
+            registry,
+            &self.recent_editor_saves,
+            params,
+        )
+        .await;
     }
 
     #[tracing::instrument(

--- a/crates/lsp/server/src/engine_client.rs
+++ b/crates/lsp/server/src/engine_client.rs
@@ -60,7 +60,10 @@ impl EngineClient {
     }
 
     fn operation_may_rebuild_analysis(operation: &'static str) -> bool {
-        matches!(operation, "initialize" | "reindex_workspace" | "did_save")
+        matches!(
+            operation,
+            "initialize" | "reindex_workspace" | "did_save" | "external_project_paths_changed"
+        )
     }
 }
 
@@ -78,7 +81,12 @@ mod tests {
 
     #[test]
     fn indexing_operations_get_long_rpc_deadline() {
-        for operation in ["initialize", "reindex_workspace", "did_save"] {
+        for operation in [
+            "initialize",
+            "reindex_workspace",
+            "did_save",
+            "external_project_paths_changed",
+        ] {
             let context = EngineClient::context(operation);
 
             assert!(

--- a/crates/lsp/server/src/engine_registry/mod.rs
+++ b/crates/lsp/server/src/engine_registry/mod.rs
@@ -141,7 +141,7 @@ impl EngineRegistry {
         self.engine_for_document_owner(owner).await
     }
 
-    /// Forwards external project path changes to already-running engines whose roots contain them.
+    /// Forwards external project path changes to ready engines whose roots contain them.
     pub(crate) async fn external_project_paths_changed(&self, paths: Vec<PathBuf>) {
         // In theory, paths might correspond to different engines.
         // So, for given list of paths we try to find a ready engine, and record path

--- a/crates/lsp/server/src/engine_registry/mod.rs
+++ b/crates/lsp/server/src/engine_registry/mod.rs
@@ -1,9 +1,11 @@
 use std::{
+    collections::BTreeMap,
     path::{Path, PathBuf},
     sync::{Arc, Weak},
 };
 
 use rg_lsp_proto::EngineConfig;
+use rg_std::UniqueVec;
 use tokio::sync::Mutex;
 use tower_lsp_server::{Client as LspClient, ls_types::MessageType};
 
@@ -137,6 +139,62 @@ impl EngineRegistry {
         };
 
         self.engine_for_document_owner(owner).await
+    }
+
+    /// Forwards external project path changes to already-running engines whose roots contain them.
+    pub(crate) async fn external_project_paths_changed(&self, paths: Vec<PathBuf>) {
+        // In theory, paths might correspond to different engines.
+        // So, for given list of paths we try to find a ready engine, and record path
+        // as belonging to it.
+        // As a result, we get a mapping of unique paths mapped to ready engines -- rest
+        // is going to be ignored.
+        let paths_by_engine = {
+            let inner = self.inner.lock().await;
+            let mut grouped = BTreeMap::<EngineId, (EngineClient, UniqueVec<PathBuf>)>::new();
+
+            for path in paths {
+                let path = normalize_path(path);
+                let Some(id) = inner.routing.engine_id_for_known_root_path(&path) else {
+                    tracing::trace!(
+                        path = %path.display(),
+                        "external project path skipped without known engine root"
+                    );
+                    continue;
+                };
+                let Some(EngineSlot::Ready(engine)) = inner.engine(id) else {
+                    tracing::trace!(
+                        path = %path.display(),
+                        engine_id = id.index(),
+                        "external project path skipped because engine is not ready"
+                    );
+                    continue;
+                };
+
+                let (_, paths) = grouped
+                    .entry(id)
+                    .or_insert_with(|| (engine.process.engine_client().clone(), UniqueVec::new()));
+                paths.push(path);
+            }
+
+            grouped
+                .into_values()
+                .map(|(engine_client, paths)| (engine_client, paths.into_vec()))
+                .collect::<Vec<_>>()
+        };
+
+        // Now that we have paths for each engine, we can notify each of them.
+        for (engine_client, paths) in paths_by_engine {
+            engine_client
+                .notify(
+                    "external_project_paths_changed",
+                    |engine_client, request_context| async move {
+                        engine_client
+                            .external_project_paths_changed(request_context, paths)
+                            .await
+                    },
+                )
+                .await;
+        }
     }
 
     async fn engine_for_document_owner(

--- a/crates/lsp/server/src/engine_registry/routing.rs
+++ b/crates/lsp/server/src/engine_registry/routing.rs
@@ -94,6 +94,19 @@ impl EngineRouting {
             .copied()
     }
 
+    /// Returns the engine whose known workspace root contains this path.
+    ///
+    /// Watched-file notifications are filesystem facts, not document opens. Routing them through
+    /// already-known roots avoids surprising engine startups for paths the editor never touched.
+    pub(crate) fn engine_id_for_known_root_path(&self, path: &Path) -> Option<EngineId> {
+        let path = normalize_path(path);
+        self.engine_ids_by_root
+            .iter()
+            .filter(|(root, _)| path.starts_with(root.as_path()))
+            .max_by_key(|(root, _)| root.components().count())
+            .map(|(_, id)| *id)
+    }
+
     pub(crate) fn root_for_id(&self, id: EngineId) -> Option<&Path> {
         self.engine_ids_by_root
             .iter()
@@ -108,7 +121,7 @@ impl EngineRouting {
 }
 
 /// Stable engine identity allocated by routing and used as an index into registry slots.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct EngineId(usize);
 
 impl EngineId {

--- a/crates/lsp/server/src/lib.rs
+++ b/crates/lsp/server/src/lib.rs
@@ -14,6 +14,7 @@ mod engine_process;
 mod engine_registry;
 mod methods;
 mod notifications;
+mod recent_editor_saves;
 mod stdio;
 
 #[cfg(test)]

--- a/crates/lsp/server/src/methods/text_document/did_save.rs
+++ b/crates/lsp/server/src/methods/text_document/did_save.rs
@@ -1,16 +1,14 @@
+use std::path::PathBuf;
+
 use tower_lsp_server::ls_types::*;
 
-use crate::methods::{MethodContext, uri_to_path};
+use crate::methods::MethodContext;
 
 #[tracing::instrument(
     level = "trace", skip_all,
     fields(rg.has_text = params.text.is_some())
 )]
-pub(crate) async fn did_save(ctx: MethodContext, params: DidSaveTextDocumentParams) {
-    let Some(path) = uri_to_path(&params.text_document.uri) else {
-        return;
-    };
-
+pub(crate) async fn did_save(ctx: MethodContext, path: PathBuf, params: DidSaveTextDocumentParams) {
     ctx.engine_client
         .notify(
             "did_save",

--- a/crates/lsp/server/src/methods/workspace/did_change_watched_files.rs
+++ b/crates/lsp/server/src/methods/workspace/did_change_watched_files.rs
@@ -18,7 +18,7 @@ pub(crate) async fn did_change_watched_files(
     }
 
     tracing::debug!(
-        changed_files = paths.len(),
+        source_files = paths.len(),
         "routing external Rust source changes"
     );
     registry.external_project_paths_changed(paths).await;
@@ -28,7 +28,12 @@ fn watched_rust_source_paths(params: DidChangeWatchedFilesParams) -> Vec<PathBuf
     params
         .changes
         .into_iter()
-        .filter(|change| change.typ == FileChangeType::CHANGED)
+        .filter(|change| {
+            matches!(
+                change.typ,
+                FileChangeType::CREATED | FileChangeType::CHANGED
+            )
+        })
         .filter_map(|change| uri_to_path(&change.uri))
         .filter(|path| is_rust_source_path(path))
         .collect()
@@ -36,4 +41,45 @@ fn watched_rust_source_paths(params: DidChangeWatchedFilesParams) -> Vec<PathBuf
 
 fn is_rust_source_path(path: &Path) -> bool {
     path.extension().and_then(|extension| extension.to_str()) == Some("rs")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{path::Path, str::FromStr as _};
+
+    use tower_lsp_server::ls_types::Uri;
+
+    use super::*;
+
+    #[test]
+    fn watched_rust_source_paths_accepts_changed_and_created_rust_files() {
+        let root = std::env::current_dir().expect("test process should have a current directory");
+        let created = root.join("src/generated.rs");
+        let changed = root.join("src/lib.rs");
+        let deleted = root.join("src/old.rs");
+        let manifest = root.join("Cargo.toml");
+
+        let params = DidChangeWatchedFilesParams {
+            changes: vec![
+                file_event(&created, FileChangeType::CREATED),
+                file_event(&changed, FileChangeType::CHANGED),
+                file_event(&deleted, FileChangeType::DELETED),
+                file_event(&manifest, FileChangeType::CHANGED),
+                FileEvent {
+                    uri: Uri::from_str("untitled:Scratch.rs")
+                        .expect("untitled URI should be valid"),
+                    typ: FileChangeType::CHANGED,
+                },
+            ],
+        };
+
+        assert_eq!(watched_rust_source_paths(params), vec![created, changed]);
+    }
+
+    fn file_event(path: &Path, typ: FileChangeType) -> FileEvent {
+        FileEvent {
+            uri: Uri::from_file_path(path).expect("test path should convert to URI"),
+            typ,
+        }
+    }
 }

--- a/crates/lsp/server/src/methods/workspace/did_change_watched_files.rs
+++ b/crates/lsp/server/src/methods/workspace/did_change_watched_files.rs
@@ -31,6 +31,14 @@ pub(crate) async fn did_change_watched_files(
 }
 
 fn watched_rust_paths(params: DidChangeWatchedFilesParams) -> Vec<PathBuf> {
+    // We don't watch for deleted files, as file deletion is not really a
+    // valid rust mechanic. If `mod foo;` is already deleted, we don't care
+    // about this file anyway. If it still exists, the project is in an invalid
+    // state as it will miss the module, and keeping analysis for it is not the
+    // worst idea.
+    // There is an edge case where it will be valid (e.g. removing an autodiscovery
+    // target), but this is not worth supporting and will be processed by the next
+    // save anyway.
     params
         .changes
         .into_iter()

--- a/crates/lsp/server/src/methods/workspace/did_change_watched_files.rs
+++ b/crates/lsp/server/src/methods/workspace/did_change_watched_files.rs
@@ -1,3 +1,9 @@
+//! Filters LSP watched-file notifications before engine routing.
+//!
+//! The extension watches Rust source and Cargo inputs, but this server edge still owns URI
+//! conversion, event-kind filtering, and editor-save echo suppression. Engine routing then receives
+//! plain paths and can stay independent from LSP watcher details.
+
 use std::path::{Path, PathBuf};
 
 use tower_lsp_server::ls_types::*;

--- a/crates/lsp/server/src/methods/workspace/did_change_watched_files.rs
+++ b/crates/lsp/server/src/methods/workspace/did_change_watched_files.rs
@@ -1,0 +1,39 @@
+use std::path::{Path, PathBuf};
+
+use tower_lsp_server::ls_types::*;
+
+use crate::{
+    engine_registry::EngineRegistry, methods::uri_to_path, recent_editor_saves::RecentEditorSaves,
+};
+
+pub(crate) async fn did_change_watched_files(
+    registry: &EngineRegistry,
+    recent_editor_saves: &RecentEditorSaves,
+    params: DidChangeWatchedFilesParams,
+) {
+    let paths = watched_rust_source_paths(params);
+    let paths = recent_editor_saves.saves_to_process(paths).await;
+    if paths.is_empty() {
+        return;
+    }
+
+    tracing::debug!(
+        changed_files = paths.len(),
+        "routing external Rust source changes"
+    );
+    registry.external_project_paths_changed(paths).await;
+}
+
+fn watched_rust_source_paths(params: DidChangeWatchedFilesParams) -> Vec<PathBuf> {
+    params
+        .changes
+        .into_iter()
+        .filter(|change| change.typ == FileChangeType::CHANGED)
+        .filter_map(|change| uri_to_path(&change.uri))
+        .filter(|path| is_rust_source_path(path))
+        .collect()
+}
+
+fn is_rust_source_path(path: &Path) -> bool {
+    path.extension().and_then(|extension| extension.to_str()) == Some("rs")
+}

--- a/crates/lsp/server/src/methods/workspace/did_change_watched_files.rs
+++ b/crates/lsp/server/src/methods/workspace/did_change_watched_files.rs
@@ -11,20 +11,20 @@ pub(crate) async fn did_change_watched_files(
     recent_editor_saves: &RecentEditorSaves,
     params: DidChangeWatchedFilesParams,
 ) {
-    let paths = watched_rust_source_paths(params);
+    let paths = watched_rust_paths(params);
     let paths = recent_editor_saves.saves_to_process(paths).await;
     if paths.is_empty() {
         return;
     }
 
     tracing::debug!(
-        source_files = paths.len(),
-        "routing external Rust source changes"
+        rust_paths = paths.len(),
+        "routing external Rust project changes"
     );
     registry.external_project_paths_changed(paths).await;
 }
 
-fn watched_rust_source_paths(params: DidChangeWatchedFilesParams) -> Vec<PathBuf> {
+fn watched_rust_paths(params: DidChangeWatchedFilesParams) -> Vec<PathBuf> {
     params
         .changes
         .into_iter()
@@ -35,12 +35,14 @@ fn watched_rust_source_paths(params: DidChangeWatchedFilesParams) -> Vec<PathBuf
             )
         })
         .filter_map(|change| uri_to_path(&change.uri))
-        .filter(|path| is_rust_source_path(path))
+        .filter(|path| is_rust_path(path))
         .collect()
 }
 
-fn is_rust_source_path(path: &Path) -> bool {
+fn is_rust_path(path: &Path) -> bool {
+    let file_name = path.file_name().and_then(|name| name.to_str());
     path.extension().and_then(|extension| extension.to_str()) == Some("rs")
+        || matches!(file_name, Some("Cargo.toml" | "Cargo.lock"))
 }
 
 #[cfg(test)]
@@ -52,12 +54,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn watched_rust_source_paths_accepts_changed_and_created_rust_files() {
+    fn watched_rust_paths_accepts_changed_and_created_rust_paths() {
         let root = std::env::current_dir().expect("test process should have a current directory");
         let created = root.join("src/generated.rs");
         let changed = root.join("src/lib.rs");
         let deleted = root.join("src/old.rs");
         let manifest = root.join("Cargo.toml");
+        let lockfile = root.join("Cargo.lock");
+        let notes = root.join("notes.md");
 
         let params = DidChangeWatchedFilesParams {
             changes: vec![
@@ -65,6 +69,8 @@ mod tests {
                 file_event(&changed, FileChangeType::CHANGED),
                 file_event(&deleted, FileChangeType::DELETED),
                 file_event(&manifest, FileChangeType::CHANGED),
+                file_event(&lockfile, FileChangeType::CREATED),
+                file_event(&notes, FileChangeType::CHANGED),
                 FileEvent {
                     uri: Uri::from_str("untitled:Scratch.rs")
                         .expect("untitled URI should be valid"),
@@ -73,7 +79,10 @@ mod tests {
             ],
         };
 
-        assert_eq!(watched_rust_source_paths(params), vec![created, changed]);
+        assert_eq!(
+            watched_rust_paths(params),
+            vec![created, changed, manifest, lockfile]
+        );
     }
 
     fn file_event(path: &Path, typ: FileChangeType) -> FileEvent {

--- a/crates/lsp/server/src/methods/workspace/mod.rs
+++ b/crates/lsp/server/src/methods/workspace/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod did_change_watched_files;
 pub(crate) mod execute_command;
 pub(crate) mod symbol;

--- a/crates/lsp/server/src/recent_editor_saves.rs
+++ b/crates/lsp/server/src/recent_editor_saves.rs
@@ -1,11 +1,7 @@
-//! File save de-duplication logic. We both watch file edits to detect edits
-//! made outside of the editor, and we receive `did_save` events. These are not
-//! deduplicated by the client, so we need to deduplicate them ourselves.
+//! Filters repeated incoming file changes.
 //!
-//! We do it on the server, not in the engine, because engines already deal with
-//! a lot of complex logic related to open documents and dirty states, so at
-//! least this way we keep an invariant that incoming changes are not duplicates
-//! of each other.
+//! Editor saves can also show up as watched-file changes. We keep a short cache of recently saved
+//! files and ignore watched changes that still match the same file metadata.
 
 use std::{
     fs,
@@ -18,24 +14,22 @@ use tokio::sync::Mutex;
 const RECENT_EDITOR_SAVE_TTL: Duration = Duration::from_secs(2);
 const MAX_RECENT_EDITOR_SAVES: usize = 128;
 
-/// Short-lived filter for watched-file echoes produced by ordinary editor saves.
+/// Filter for incoming file changes that repeat a recent editor save.
 ///
-/// We keep it as a LSP-ingress concern: it only remembers disk metadata that just came
-/// through `textDocument/didSave`. This way the rest of the application can assume
-/// that changes are not duplicated and we don't have to implement this logic on the
-/// engine level.
+/// If file metadata changes after the save, for example because `rustfmt` rewrote the file, the
+/// watched change goes through.
 #[derive(Debug, Default)]
 pub(crate) struct RecentEditorSaves {
     inner: Mutex<RecentEditorSavesInner>,
 }
 
 impl RecentEditorSaves {
-    /// Some file has been saved recently.
+    /// Remember the current disk identity of a file just saved by the editor.
     pub(crate) async fn record_editor_save(&self, path: &Path) {
         self.inner.lock().await.record(path);
     }
 
-    /// Removes paths that are recent echoes of editor saves.
+    /// Drop watched paths whose current disk identity matches a recent editor save.
     pub(crate) async fn saves_to_process(&self, paths: Vec<PathBuf>) -> Vec<PathBuf> {
         let mut inner = self.inner.lock().await;
         paths
@@ -93,7 +87,7 @@ impl RecentEditorSavesInner {
     }
 }
 
-/// What file was saved, which metadata did it have, and when did it happen.
+/// One recorded editor save plus the timestamp used for cache expiry.
 #[derive(Clone, Debug)]
 struct RecentEditorSave {
     path: PathBuf,
@@ -112,7 +106,7 @@ impl RecentEditorSave {
     }
 }
 
-/// File metadata sufficient to distinguish different file versions.
+/// Disk identity used to decide whether a watched event is the same save.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct FileIdentity {
     len: u64,

--- a/crates/lsp/server/src/recent_editor_saves.rs
+++ b/crates/lsp/server/src/recent_editor_saves.rs
@@ -1,0 +1,223 @@
+//! File save de-duplication logic. We both watch file edits to detect edits
+//! made outside of the editor, and we receive `did_save` events. These are not
+//! deduplicated by the client, so we need to deduplicate them ourselves.
+//!
+//! We do it on the server, not in the engine, because engines already deal with
+//! a lot of complex logic related to open documents and dirty states, so at
+//! least this way we keep an invariant that incoming changes are not duplicates
+//! of each other.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{Duration, Instant, SystemTime},
+};
+
+use tokio::sync::Mutex;
+
+const RECENT_EDITOR_SAVE_TTL: Duration = Duration::from_secs(2);
+const MAX_RECENT_EDITOR_SAVES: usize = 128;
+
+/// Short-lived filter for watched-file echoes produced by ordinary editor saves.
+///
+/// We keep it as a LSP-ingress concern: it only remembers disk metadata that just came
+/// through `textDocument/didSave`. This way the rest of the application can assume
+/// that changes are not duplicated and we don't have to implement this logic on the
+/// engine level.
+#[derive(Debug, Default)]
+pub(crate) struct RecentEditorSaves {
+    inner: Mutex<RecentEditorSavesInner>,
+}
+
+impl RecentEditorSaves {
+    /// Some file has been saved recently.
+    pub(crate) async fn record_editor_save(&self, path: &Path) {
+        self.inner.lock().await.record(path);
+    }
+
+    /// Removes paths that are recent echoes of editor saves.
+    pub(crate) async fn saves_to_process(&self, paths: Vec<PathBuf>) -> Vec<PathBuf> {
+        let mut inner = self.inner.lock().await;
+        paths
+            .into_iter()
+            .filter(|path| !inner.is_save_echo(path))
+            .collect()
+    }
+}
+
+#[derive(Debug, Default)]
+struct RecentEditorSavesInner {
+    entries: Vec<RecentEditorSave>,
+}
+
+impl RecentEditorSavesInner {
+    /// Some file has been saved recently.
+    fn record(&mut self, path: &Path) {
+        self.record_at(path, Instant::now());
+    }
+
+    /// Should we ignore save on this path, because the same save was recorded recently?
+    fn is_save_echo(&mut self, path: &Path) -> bool {
+        self.is_save_echo_at(path, Instant::now())
+    }
+
+    fn record_at(&mut self, path: &Path, now: Instant) {
+        self.prune_expired(now);
+        let Some(saved) = RecentEditorSave::from_path(path, now) else {
+            return;
+        };
+
+        self.entries.retain(|entry| entry.path != saved.path);
+        self.entries.push(saved);
+        if self.entries.len() > MAX_RECENT_EDITOR_SAVES {
+            self.entries.remove(0);
+        }
+    }
+
+    fn is_save_echo_at(&mut self, path: &Path, now: Instant) -> bool {
+        self.prune_expired(now);
+        let Some((path, metadata)) = file_identity(path) else {
+            return false;
+        };
+
+        self.entries
+            .iter()
+            .any(|entry| entry.path == path && entry.metadata == metadata)
+    }
+
+    fn prune_expired(&mut self, now: Instant) {
+        self.entries.retain(|entry| {
+            now.checked_duration_since(entry.recorded_at)
+                .is_none_or(|elapsed| elapsed <= RECENT_EDITOR_SAVE_TTL)
+        });
+    }
+}
+
+/// What file was saved, which metadata did it have, and when did it happen.
+#[derive(Clone, Debug)]
+struct RecentEditorSave {
+    path: PathBuf,
+    metadata: FileIdentity,
+    recorded_at: Instant,
+}
+
+impl RecentEditorSave {
+    fn from_path(path: &Path, recorded_at: Instant) -> Option<Self> {
+        let (path, metadata) = file_identity(path)?;
+        Some(Self {
+            path,
+            metadata,
+            recorded_at,
+        })
+    }
+}
+
+/// File metadata sufficient to distinguish different file versions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FileIdentity {
+    len: u64,
+    modified: SystemTime,
+}
+
+fn file_identity(path: &Path) -> Option<(PathBuf, FileIdentity)> {
+    let metadata = fs::metadata(path).ok()?;
+    if !metadata.is_file() {
+        return None;
+    }
+
+    Some((
+        path.canonicalize().unwrap_or_else(|_| path.to_path_buf()),
+        FileIdentity {
+            len: metadata.len(),
+            modified: metadata.modified().ok()?,
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use test_fixture::fixture_crate;
+
+    use super::{RECENT_EDITOR_SAVE_TTL, RecentEditorSaves, RecentEditorSavesInner};
+
+    #[tokio::test]
+    async fn matching_saved_metadata_is_save_echo() {
+        let fixture = fixture_crate(
+            r#"
+            //- /src/lib.rs
+            pub fn saved() {}
+            "#,
+        );
+        let path = fixture.path("src/lib.rs");
+        let saves = RecentEditorSaves::default();
+
+        saves.record_editor_save(&path).await;
+
+        assert!(saves.saves_to_process(vec![path]).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn changed_file_metadata_is_not_save_echo() {
+        let fixture = fixture_crate(
+            r#"
+            //- /src/lib.rs
+            pub fn saved() {}
+            "#,
+        );
+        let path = fixture.path("src/lib.rs");
+        let saves = RecentEditorSaves::default();
+
+        saves.record_editor_save(&path).await;
+        std::fs::write(&path, "pub fn external_agent_edit() {}\n")
+            .expect("fixture file should be writable");
+
+        assert_eq!(saves.saves_to_process(vec![path.clone()]).await, vec![path]);
+    }
+
+    #[tokio::test]
+    async fn mixed_batches_keep_non_echo_paths() {
+        let fixture = fixture_crate(
+            r#"
+            //- /src/lib.rs
+            pub fn saved() {}
+
+            //- /src/agent.rs
+            pub fn external() {}
+            "#,
+        );
+        let saved_path = fixture.path("src/lib.rs");
+        let external_path = fixture.path("src/agent.rs");
+        let saves = RecentEditorSaves::default();
+
+        saves.record_editor_save(&saved_path).await;
+
+        assert_eq!(
+            saves
+                .saves_to_process(vec![saved_path, external_path.clone()])
+                .await,
+            vec![external_path]
+        );
+    }
+
+    #[test]
+    fn expired_saved_metadata_is_not_save_echo() {
+        let fixture = fixture_crate(
+            r#"
+            //- /src/lib.rs
+            pub fn saved() {}
+            "#,
+        );
+        let path = fixture.path("src/lib.rs");
+        let now = std::time::Instant::now();
+        let mut saves = RecentEditorSavesInner::default();
+
+        saves.record_at(&path, now);
+
+        assert!(!saves.is_save_echo_at(
+            &path,
+            now + RECENT_EDITOR_SAVE_TTL + Duration::from_millis(1)
+        ));
+    }
+}

--- a/crates/lsp/server/src/tests/engine_routing.rs
+++ b/crates/lsp/server/src/tests/engine_routing.rs
@@ -47,6 +47,14 @@ fn routes_documents_to_existing_spawned_or_active_engines() {
                 "workspace/project_a/src/lib.rs",
             ),
             RoutingStep::workspace_root("resolved workspace root spawns engine", "workspace"),
+            RoutingStep::known_root_owner(
+                "watched source file uses known root",
+                "workspace/project_a/src/lib.rs",
+            ),
+            RoutingStep::known_root_owner(
+                "external watched file does not use active engine",
+                "external/thin_vec/src/lib.rs",
+            ),
             RoutingStep::open_file(
                 "didOpen caches exact file owner",
                 "workspace/project_a/src/lib.rs",
@@ -80,6 +88,8 @@ fn routes_documents_to_existing_spawned_or_active_engines() {
         r#"
 unopened workspace member is not cached: unowned
 resolved workspace root spawns engine: spawn e0 /workspace
+watched source file uses known root: known e0 /workspace
+external watched file does not use active engine: unknown
 didOpen caches exact file owner: active e0 /workspace
 same open file reuses cached owner: existing e0 /workspace
 different unopened file is not cached: unowned

--- a/crates/lsp/server/src/tests/utils.rs
+++ b/crates/lsp/server/src/tests/utils.rs
@@ -47,6 +47,11 @@ impl RoutingFixture {
                     )
                     .expect("routing snapshot should be writable");
                 }
+                RoutingStep::KnownRootOwner { title, path } => {
+                    let owner = self.routing.engine_id_for_known_root_path(&self.path(path));
+                    writeln!(rendered, "{title}: {}", self.render_known_root_owner(owner))
+                        .expect("routing snapshot should be writable");
+                }
                 RoutingStep::WorkspaceRoot {
                     title,
                     workspace_root,
@@ -107,6 +112,13 @@ impl RoutingFixture {
         }
     }
 
+    fn render_known_root_owner(&self, owner: Option<EngineId>) -> String {
+        match owner {
+            Some(id) => format!("known {}", self.render_engine(id)),
+            None => "unknown".to_string(),
+        }
+    }
+
     fn render_workspace_route(&self, route: &Option<WorkspaceEngineRoute>) -> String {
         match route {
             Some(WorkspaceEngineRoute::Existing(id)) => {
@@ -162,6 +174,10 @@ pub(super) enum RoutingStep {
         title: &'static str,
         path: &'static str,
     },
+    KnownRootOwner {
+        title: &'static str,
+        path: &'static str,
+    },
     WorkspaceRoot {
         title: &'static str,
         workspace_root: &'static str,
@@ -186,6 +202,10 @@ pub(super) enum RoutingStep {
 impl RoutingStep {
     pub(super) fn cached_file_owner(title: &'static str, path: &'static str) -> Self {
         Self::CachedFileOwner { title, path }
+    }
+
+    pub(super) fn known_root_owner(title: &'static str, path: &'static str) -> Self {
+        Self::KnownRootOwner { title, path }
     }
 
     pub(super) fn workspace_root(title: &'static str, workspace_root: &'static str) -> Self {

--- a/editors/code/src/language-client/language-client-session.ts
+++ b/editors/code/src/language-client/language-client-session.ts
@@ -76,7 +76,7 @@ export class LanguageClientSession implements vscode.Disposable {
     this.clientStatus.starting(statusDetails);
 
     const fileEvents = vscode.workspace.createFileSystemWatcher(
-      new vscode.RelativePattern(this.workspaceFolder, "**/*.rs"),
+      new vscode.RelativePattern(this.workspaceFolder, "**/{*.rs,Cargo.toml,Cargo.lock}"),
     );
     const clientOptions: LanguageClientOptions = {
       documentSelector: [{ scheme: "file", language: "rust" }],

--- a/editors/code/src/language-client/language-client-session.ts
+++ b/editors/code/src/language-client/language-client-session.ts
@@ -75,10 +75,16 @@ export class LanguageClientSession implements vscode.Disposable {
     this.extensionLog.info(`server source: ${statusDetails.serverSource}`);
     this.clientStatus.starting(statusDetails);
 
+    const fileEvents = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(this.workspaceFolder, "**/*.rs"),
+    );
     const clientOptions: LanguageClientOptions = {
       documentSelector: [{ scheme: "file", language: "rust" }],
       diagnosticCollectionName: "rust-glancer",
       outputChannel: this.serverOutput,
+      synchronize: {
+        fileEvents,
+      },
       initializationOptions: {
         cfg: config.cfg,
         diagnostics: config.diagnostics,
@@ -98,6 +104,7 @@ export class LanguageClientSession implements vscode.Disposable {
 
     this.client = client;
     this.clientState = vscode.Disposable.from(
+      fileEvents,
       client.onDidChangeState((event) => {
         switch (event.newState) {
           case State.Starting:


### PR DESCRIPTION
Implements pretty basic metadata watching for changes in both ordinary and metadata-changing files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection and automatic refresh when Rust project files change externally (outside the editor), including watched-file events. Completion, hover, document symbols, diagnostics, and inlay hints now update automatically after on-disk edits.
  * Added a workspace file watcher for Rust-related files (`*.rs`, `Cargo.toml`, `Cargo.lock`).
* **Bug Fixes**
  * Improved handling of external disk updates when the editor buffer has unsaved changes, keeping LSP results and dirty state consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->