### PR TITLE
feat: Support formatting in lsp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,6 +1548,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "derive_more",
+ "dissimilar",
  "expect-test",
  "futures",
  "ls-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ bumpalo = "3.17.0"
 clap = "4.6.1"
 cargo_metadata = "0.23.1"
 derive_more = { version = "2.1.1" }
+dissimilar = "1.0.11"
 divan = { package = "codspeed-divan-compat", version = "4.6.0" }
 drop_bomb = "0.1.5"
 either = "1.15.0"

--- a/crates/engine/project/src/project/snapshot.rs
+++ b/crates/engine/project/src/project/snapshot.rs
@@ -9,6 +9,7 @@ use rg_ir_model::TargetRef;
 #[cfg(test)]
 use rg_parse::ParseDb;
 use rg_parse::{FileId, LineIndex, Span};
+use rg_workspace::RustEdition;
 
 use super::{
     FileContext, reference_search::ReferenceSearchPlanner, state::ProjectState,
@@ -82,6 +83,15 @@ impl<'a> ProjectSnapshot<'a> {
             .parse_db()
             .package(package.0)
             .is_some_and(|package| package.is_workspace_member())
+    }
+
+    /// Returns the Rust edition declared for a package in the current workspace metadata.
+    pub fn package_edition(&self, package: PackageSlot) -> Option<RustEdition> {
+        self.state
+            .workspace()
+            .packages()
+            .get(package.0)
+            .map(|package| package.edition)
     }
 
     /// Returns source text for a byte span from the same snapshot that backs this project view.

--- a/crates/lsp/engine/Cargo.toml
+++ b/crates/lsp/engine/Cargo.toml
@@ -13,6 +13,7 @@ description.workspace = true
 anyhow.workspace = true
 cargo_metadata.workspace = true
 derive_more = { workspace = true, features = ["debug", "display"] }
+dissimilar.workspace = true
 futures.workspace = true
 ls_types.workspace = true
 rg_analysis.workspace = true

--- a/crates/lsp/engine/src/documents/mod.rs
+++ b/crates/lsp/engine/src/documents/mod.rs
@@ -124,6 +124,12 @@ impl DocumentStore {
         self.documents.remove(path);
     }
 
+    pub(crate) fn current_text(&self, path: &Path) -> Option<Arc<str>> {
+        self.documents
+            .get(path)
+            .and_then(|document| document.live_text.clone())
+    }
+
     #[cfg(test)]
     pub(crate) fn is_dirty(&self, path: &Path) -> bool {
         self.documents

--- a/crates/lsp/engine/src/documents/tests.rs
+++ b/crates/lsp/engine/src/documents/tests.rs
@@ -146,6 +146,36 @@ fn external_saved_change_keeps_unknown_dirty_buffer_dirty() {
 }
 
 #[test]
+fn exposes_current_text_for_clean_and_dirty_full_sync_documents() {
+    let path = PathBuf::from("/workspace/src/lib.rs");
+    let mut store = DocumentStore::default();
+
+    store.did_open(path.clone(), Some(1), "fn main() {}\n");
+    assert_eq!(store.current_text(&path).as_deref(), Some("fn main() {}\n"));
+
+    store.did_change(path.clone(), Some(2), Some("fn main() {\n    live();\n}\n"));
+    assert_eq!(
+        store.current_text(&path).as_deref(),
+        Some("fn main() {\n    live();\n}\n")
+    );
+}
+
+#[test]
+fn current_text_is_absent_for_unknown_dirty_and_closed_documents() {
+    let path = PathBuf::from("/workspace/src/lib.rs");
+    let mut store = DocumentStore::default();
+
+    assert_eq!(store.current_text(&path), None);
+
+    store.did_open(path.clone(), Some(1), "fn main() {}\n");
+    store.did_change(path.clone(), Some(2), None);
+    assert_eq!(store.current_text(&path), None);
+
+    store.did_close(&path);
+    assert_eq!(store.current_text(&path), None);
+}
+
+#[test]
 fn exposes_dirty_snapshot_when_full_live_text_is_available() {
     let path = PathBuf::from("/workspace/src/lib.rs");
     let mut store = DocumentStore::default();

--- a/crates/lsp/engine/src/engine/command.rs
+++ b/crates/lsp/engine/src/engine/command.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use rg_lsp_proto::{AnalysisConfig, CompletionClientCapabilities};
 use tokio::sync::oneshot;
@@ -74,6 +74,11 @@ pub(crate) enum EngineCommand {
         client_capabilities: CompletionClientCapabilities,
         dirty: Option<DirtyDocumentSnapshot>,
         respond_to: EngineResponse<Vec<ls_types::CompletionItem>>,
+    },
+    Formatting {
+        path: PathBuf,
+        text: Arc<str>,
+        respond_to: EngineResponse<Vec<ls_types::TextEdit>>,
     },
     DocumentSymbol {
         path: PathBuf,

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -22,7 +22,7 @@ use rg_project::{
     ProjectMemoryHooks, ProjectSnapshot, SavedFileChange,
 };
 use rg_workspace::{
-    CargoMetadataConfig, SysrootSources, WorkspaceLoweringConfig, WorkspaceMetadata,
+    CargoMetadataConfig, RustEdition, SysrootSources, WorkspaceLoweringConfig, WorkspaceMetadata,
 };
 
 use crate::{
@@ -35,7 +35,10 @@ use crate::{
     },
     memory::{MemoryControl, MemoryReporter, ProjectMemoryReporter},
     project_stats::{ProjectStats, log_retained_memory},
-    proto::{completion, hover, inlay_hint, navigation, position, references, rename, symbols},
+    proto::{
+        completion, formatting as formatting_proto, hover, inlay_hint, navigation, position,
+        references, rename, symbols,
+    },
 };
 
 #[derive(Debug)]
@@ -298,6 +301,20 @@ impl EngineWorker {
                         QueryContext::document("completion", queue_elapsed, dirty.as_ref());
                     self.respond_to_query(context, respond_to, |worker| {
                         worker.completion(path, position, client_capabilities, dirty)
+                    });
+                }
+                EngineCommand::Formatting {
+                    path,
+                    text,
+                    respond_to,
+                } => {
+                    tracing::trace!(
+                        path = %path.display(),
+                        "engine command started: formatting"
+                    );
+                    let context = QueryContext::new("formatting", queue_elapsed);
+                    self.respond_to_query(context, respond_to, |worker| {
+                        worker.formatting(path, text)
                     });
                 }
                 EngineCommand::DocumentSymbol {
@@ -930,6 +947,37 @@ impl EngineWorker {
         );
 
         Ok(lsp_symbols)
+    }
+
+    fn formatting(
+        &mut self,
+        path: PathBuf,
+        text: Arc<str>,
+    ) -> anyhow::Result<Vec<ls_types::TextEdit>> {
+        let started = Instant::now();
+        let edition = {
+            let snapshot = self.project.saved_snapshot()?;
+            let contexts = Self::file_contexts(snapshot, &path)?;
+
+            // Some routed documents may not map to package metadata. We use an explicit fallback
+            // here so formatting can still run without reading Cargo.toml from disk.
+            contexts
+                .first()
+                .and_then(|context| snapshot.package_edition(context.package))
+                .unwrap_or(RustEdition::Edition2024)
+        };
+        let formatted_text = crate::formatting::rustfmt(text.as_ref(), edition)?;
+        let edits = formatting_proto::document_edits(text.as_ref(), formatted_text)?;
+
+        tracing::debug!(
+            path = %path.display(),
+            edition = %edition,
+            edit_count = edits.len(),
+            elapsed_ms = started.elapsed().as_millis(),
+            "formatting query finished"
+        );
+
+        Ok(edits)
     }
 
     fn inlay_hint(

--- a/crates/lsp/engine/src/formatting.rs
+++ b/crates/lsp/engine/src/formatting.rs
@@ -1,0 +1,59 @@
+use std::{
+    io::Write as _,
+    process::{Command, Stdio},
+};
+
+use anyhow::{Context as _, bail};
+use rg_workspace::RustEdition;
+
+/// Runs rustfmt as a pure text transformer for LSP formatting.
+pub(crate) fn rustfmt(text: &str, edition: RustEdition) -> anyhow::Result<String> {
+    let edition = edition.to_string();
+    let mut child = Command::new("rustfmt")
+        .args(["--emit", "stdout", "--edition", edition.as_str()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("while attempting to spawn rustfmt")?;
+
+    child
+        .stdin
+        .take()
+        .context("while attempting to open rustfmt stdin")?
+        .write_all(text.as_bytes())
+        .context("while attempting to write source text to rustfmt stdin")?;
+
+    let output = child
+        .wait_with_output()
+        .context("while attempting to wait for rustfmt")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        if stderr.is_empty() {
+            bail!("rustfmt failed with status {}", output.status);
+        }
+        bail!("rustfmt failed with status {}: {}", output.status, stderr);
+    }
+
+    String::from_utf8(output.stdout).context("while attempting to parse rustfmt stdout as UTF-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use rg_workspace::RustEdition;
+
+    use super::rustfmt;
+
+    #[test]
+    fn rustfmt_failure_includes_process_context() {
+        let error = rustfmt("pub fn broken(", RustEdition::Edition2024)
+            .expect_err("invalid Rust should make rustfmt fail");
+        let error = format!("{error:#}");
+
+        assert!(
+            error.contains("rustfmt failed"),
+            "unexpected rustfmt error: {error}"
+        );
+    }
+}

--- a/crates/lsp/engine/src/lib.rs
+++ b/crates/lsp/engine/src/lib.rs
@@ -8,6 +8,7 @@ mod diagnostics;
 mod dirty_state;
 mod documents;
 mod engine;
+mod formatting;
 mod memory;
 mod project_stats;
 mod proto;

--- a/crates/lsp/engine/src/proto/formatting.rs
+++ b/crates/lsp/engine/src/proto/formatting.rs
@@ -4,6 +4,7 @@
 //! current document. This module owns that translation.
 
 use anyhow::Context as _;
+use dissimilar::Chunk;
 use ls_types::{Position, Range, TextEdit};
 use rg_parse::LineIndex;
 
@@ -15,19 +16,44 @@ pub(crate) fn document_edits(
         return Ok(Vec::new());
     }
 
-    Ok(vec![TextEdit {
-        range: full_document_range(old_text)?,
-        new_text: formatted_text,
-    }])
+    let line_index = LineIndex::new(old_text);
+    let mut old_offset = 0;
+    let mut edits = Vec::new();
+
+    for chunk in dissimilar::diff(old_text, &formatted_text) {
+        match chunk {
+            Chunk::Equal(text) => {
+                old_offset += text.len();
+            }
+            Chunk::Delete(text) => {
+                let start = old_offset;
+                let end = old_offset + text.len();
+                edits.push(TextEdit {
+                    range: range(&line_index, start, end)?,
+                    new_text: String::new(),
+                });
+                old_offset = end;
+            }
+            Chunk::Insert(text) => {
+                edits.push(TextEdit {
+                    range: range(&line_index, old_offset, old_offset)?,
+                    new_text: text.to_owned(),
+                });
+            }
+        }
+    }
+
+    Ok(edits)
 }
 
-fn full_document_range(text: &str) -> anyhow::Result<Range> {
-    let end_offset =
-        u32::try_from(text.len()).context("while attempting to convert document length")?;
-    let end = LineIndex::new(text).utf16_position(end_offset);
+fn range(line_index: &LineIndex, start: usize, end: usize) -> anyhow::Result<Range> {
+    let start = u32::try_from(start).context("while attempting to convert edit start offset")?;
+    let end = u32::try_from(end).context("while attempting to convert edit end offset")?;
+    let start = line_index.utf16_position(start);
+    let end = line_index.utf16_position(end);
 
     Ok(Range {
-        start: Position::new(0, 0),
+        start: Position::new(start.line, start.column),
         end: Position::new(end.line, end.column),
     })
 }
@@ -45,15 +71,47 @@ mod tests {
     }
 
     #[test]
-    fn changed_text_replaces_whole_document_with_utf16_end_position() {
-        let edits = document_edits("let _ = \"🦀\";", "let _ = \"formatted\";\n".to_string())
+    fn inserted_text_becomes_an_insert_edit() {
+        let edits = document_edits(
+            "fn main() {\n}\n",
+            "fn main() {\n    work();\n}\n".to_string(),
+        )
+        .expect("changed formatting should succeed");
+
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].range.start.line, 1);
+        assert_eq!(edits[0].range.start.character, 0);
+        assert_eq!(edits[0].range.end.line, 1);
+        assert_eq!(edits[0].range.end.character, 0);
+        assert_eq!(edits[0].new_text, "    work();\n");
+    }
+
+    #[test]
+    fn deleted_text_becomes_a_delete_edit() {
+        let edits = document_edits(
+            "fn main() {\n    work();\n}\n",
+            "fn main() {\n}\n".to_string(),
+        )
+        .expect("changed formatting should succeed");
+
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].range.start.line, 1);
+        assert_eq!(edits[0].range.start.character, 0);
+        assert_eq!(edits[0].range.end.line, 2);
+        assert_eq!(edits[0].range.end.character, 0);
+        assert_eq!(edits[0].new_text, "");
+    }
+
+    #[test]
+    fn edit_ranges_use_utf16_positions() {
+        let edits = document_edits("🦀value", "🦀value2".to_string())
             .expect("changed formatting should succeed");
 
         assert_eq!(edits.len(), 1);
         assert_eq!(edits[0].range.start.line, 0);
-        assert_eq!(edits[0].range.start.character, 0);
+        assert_eq!(edits[0].range.start.character, 7);
         assert_eq!(edits[0].range.end.line, 0);
-        assert_eq!(edits[0].range.end.character, 13);
-        assert_eq!(edits[0].new_text, "let _ = \"formatted\";\n");
+        assert_eq!(edits[0].range.end.character, 7);
+        assert_eq!(edits[0].new_text, "2");
     }
 }

--- a/crates/lsp/engine/src/proto/formatting.rs
+++ b/crates/lsp/engine/src/proto/formatting.rs
@@ -1,0 +1,59 @@
+//! Normalizes formatter output into the shape expected by LSP formatting.
+//!
+//! The formatter produces document text, while LSP formatting returns text edits to apply to the
+//! current document. This module owns that translation.
+
+use anyhow::Context as _;
+use ls_types::{Position, Range, TextEdit};
+use rg_parse::LineIndex;
+
+pub(crate) fn document_edits(
+    old_text: &str,
+    formatted_text: String,
+) -> anyhow::Result<Vec<TextEdit>> {
+    if formatted_text == old_text {
+        return Ok(Vec::new());
+    }
+
+    Ok(vec![TextEdit {
+        range: full_document_range(old_text)?,
+        new_text: formatted_text,
+    }])
+}
+
+fn full_document_range(text: &str) -> anyhow::Result<Range> {
+    let end_offset =
+        u32::try_from(text.len()).context("while attempting to convert document length")?;
+    let end = LineIndex::new(text).utf16_position(end_offset);
+
+    Ok(Range {
+        start: Position::new(0, 0),
+        end: Position::new(end.line, end.column),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::document_edits;
+
+    #[test]
+    fn unchanged_text_returns_no_edits() {
+        let edits = document_edits("fn main() {}\n", "fn main() {}\n".to_string())
+            .expect("unchanged formatting should succeed");
+
+        assert!(edits.is_empty());
+    }
+
+    #[test]
+    fn changed_text_replaces_whole_document_with_utf16_end_position() {
+        let edits = document_edits("let _ = \"🦀\";", "let _ = \"formatted\";\n".to_string())
+            .expect("changed formatting should succeed");
+
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].range.start.line, 0);
+        assert_eq!(edits[0].range.start.character, 0);
+        assert_eq!(edits[0].range.end.line, 0);
+        assert_eq!(edits[0].range.end.character, 13);
+        assert_eq!(edits[0].new_text, "let _ = \"formatted\";\n");
+    }
+}

--- a/crates/lsp/engine/src/proto/mod.rs
+++ b/crates/lsp/engine/src/proto/mod.rs
@@ -1,6 +1,7 @@
 //! Bridge between engine/analysis internal types and LSP types.
 
 pub(crate) mod completion;
+pub(crate) mod formatting;
 pub(crate) mod hover;
 pub(crate) mod inlay_hint;
 pub(crate) mod markdown;

--- a/crates/lsp/engine/src/service/service_impl.rs
+++ b/crates/lsp/engine/src/service/service_impl.rs
@@ -489,6 +489,46 @@ impl EngineService for Service {
             .map_err(EngineError::from)
     }
 
+    async fn formatting(
+        self,
+        _: context::Context,
+        path: PathBuf,
+    ) -> EngineResult<Option<Vec<ls_types::TextEdit>>> {
+        let text = {
+            let documents = self.engine.documents.lock().await;
+            let freshness = documents.freshness(&path);
+            let text = documents.current_text(&path);
+
+            tracing::trace!(
+                path = %path.display(),
+                tracked = freshness.tracked(),
+                version = ?freshness.version(),
+                dirty = freshness.dirty(),
+                has_text = text.is_some(),
+                "checked document text for formatting"
+            );
+
+            text
+        };
+        let Some(text) = text else {
+            tracing::debug!(
+                path = %path.display(),
+                "formatting skipped because document has no live text"
+            );
+            return Ok(None);
+        };
+
+        self.engine
+            .request(|respond_to| EngineCommand::Formatting {
+                path,
+                text,
+                respond_to,
+            })
+            .await
+            .map(Some)
+            .map_err(EngineError::from)
+    }
+
     async fn document_symbol(
         self,
         _: context::Context,

--- a/crates/lsp/engine/src/tests/formatting_flow.rs
+++ b/crates/lsp/engine/src/tests/formatting_flow.rs
@@ -1,0 +1,137 @@
+use expect_test::expect;
+use test_fixture::testonly::MarkedText;
+
+use super::utils::LspEngineFixture;
+
+#[tokio::test]
+async fn formats_open_saved_document() {
+    let fixture = LspEngineFixture::initialized(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "lsp_formatting_flow"
+        version = "0.1.0"
+        edition = "2024"
+
+        //- /src/lib.rs
+        pub fn demo(){println!("hi");}
+        "#,
+    )
+    .await;
+
+    fixture.did_open_saved("src/lib.rs", 1).await;
+    fixture
+        .check_formatting(
+            "format saved document",
+            "src/lib.rs",
+            expect![[r#"
+                format saved document
+                - /src/lib.rs:0:0-1:0 -> "pub fn demo() {\n    println!(\"hi\");\n}\n"
+            "#]],
+        )
+        .await;
+
+    fixture.shutdown().await;
+}
+
+#[tokio::test]
+async fn unchanged_formatting_returns_no_edits() {
+    let fixture = LspEngineFixture::initialized(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "lsp_formatting_unchanged"
+        version = "0.1.0"
+        edition = "2024"
+
+        //- /src/lib.rs
+        pub fn demo() {
+            println!("hi");
+        }
+        "#,
+    )
+    .await;
+
+    fixture.did_open_saved("src/lib.rs", 1).await;
+    fixture
+        .check_formatting(
+            "format unchanged document",
+            "src/lib.rs",
+            expect![[r#"
+                format unchanged document
+                - no edits
+            "#]],
+        )
+        .await;
+
+    fixture.shutdown().await;
+}
+
+#[tokio::test]
+async fn unopened_document_returns_no_formatting_response() {
+    let fixture = LspEngineFixture::initialized(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "lsp_formatting_unopened"
+        version = "0.1.0"
+        edition = "2024"
+
+        //- /src/lib.rs
+        pub fn demo(){println!("hi");}
+        "#,
+    )
+    .await;
+
+    fixture
+        .check_formatting(
+            "format unopened document",
+            "src/lib.rs",
+            expect![[r#"
+                format unopened document
+                - no response
+            "#]],
+        )
+        .await;
+
+    fixture.shutdown().await;
+}
+
+#[tokio::test]
+async fn formatting_uses_dirty_live_text() {
+    let fixture = LspEngineFixture::initialized(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "lsp_formatting_dirty"
+        version = "0.1.0"
+        edition = "2024"
+
+        //- /src/lib.rs
+        pub fn saved() {}
+        "#,
+    )
+    .await;
+
+    fixture.did_open_saved("src/lib.rs", 1).await;
+    fixture
+        .did_change_full(
+            "src/lib.rs",
+            2,
+            MarkedText::parse(r#"pub fn dirty(){println!("dirty");}"#),
+        )
+        .await;
+
+    fixture
+        .check_formatting(
+            "format dirty document",
+            "src/lib.rs",
+            expect![[r#"
+                format dirty document
+                - /src/lib.rs:0:0-0:34 -> "pub fn dirty() {\n    println!(\"dirty\");\n}\n"
+            "#]],
+        )
+        .await;
+
+    fixture.shutdown().await;
+}

--- a/crates/lsp/engine/src/tests/formatting_flow.rs
+++ b/crates/lsp/engine/src/tests/formatting_flow.rs
@@ -26,7 +26,9 @@ async fn formats_open_saved_document() {
             "src/lib.rs",
             expect![[r#"
                 format saved document
-                - /src/lib.rs:0:0-1:0 -> "pub fn demo() {\n    println!(\"hi\");\n}\n"
+                - /src/lib.rs:0:13-0:14 -> ""
+                - /src/lib.rs:0:14-0:14 -> " {\n    "
+                - /src/lib.rs:0:29-0:29 -> "\n"
             "#]],
         )
         .await;
@@ -128,7 +130,10 @@ async fn formatting_uses_dirty_live_text() {
             "src/lib.rs",
             expect![[r#"
                 format dirty document
-                - /src/lib.rs:0:0-0:34 -> "pub fn dirty() {\n    println!(\"dirty\");\n}\n"
+                - /src/lib.rs:0:14-0:15 -> ""
+                - /src/lib.rs:0:15-0:15 -> " {\n    "
+                - /src/lib.rs:0:33-0:34 -> ""
+                - /src/lib.rs:0:34-0:34 -> "\n}\n"
             "#]],
         )
         .await;

--- a/crates/lsp/engine/src/tests/mod.rs
+++ b/crates/lsp/engine/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod dirty_flow;
 mod external_flow;
 mod flow;
+mod formatting_flow;
 mod rename_flow;
 mod save_flow;
 mod utils;

--- a/crates/lsp/engine/src/tests/utils.rs
+++ b/crates/lsp/engine/src/tests/utils.rs
@@ -7,7 +7,7 @@ use std::{
 use expect_test::Expect;
 use ls_types::{
     CompletionItem, CompletionTextEdit, DocumentSymbol, Hover, HoverContents, Location, Position,
-    Range, WorkspaceEdit,
+    Range, TextEdit, WorkspaceEdit,
 };
 use rg_lsp_proto::{
     AnalysisConfig, CompletionClientCapabilities, EngineConfig, EngineService, ServiceNotification,
@@ -291,6 +291,25 @@ impl LspEngineFixture {
         expect.assert_eq(&rendered);
     }
 
+    pub(super) async fn check_formatting(
+        &self,
+        title: &'static str,
+        path: &'static str,
+        expect: Expect,
+    ) {
+        let edits = self
+            .service
+            .clone()
+            .formatting(context::current(), self.fixture.path(path))
+            .await
+            .expect("formatting query should succeed");
+
+        let mut rendered = String::new();
+        writeln!(rendered, "{title}").expect("snapshot should be writable");
+        self.render_formatting_edits(&mut rendered, path, edits.as_deref());
+        expect.assert_eq(&rendered);
+    }
+
     pub(super) async fn shutdown(&self) {
         self.service
             .clone()
@@ -558,6 +577,33 @@ impl LspEngineFixture {
                 )
                 .expect("snapshot should be writable");
             }
+        }
+    }
+
+    fn render_formatting_edits(
+        &self,
+        rendered: &mut String,
+        path: &str,
+        edits: Option<&[TextEdit]>,
+    ) {
+        let Some(edits) = edits else {
+            writeln!(rendered, "- no response").expect("snapshot should be writable");
+            return;
+        };
+        if edits.is_empty() {
+            writeln!(rendered, "- no edits").expect("snapshot should be writable");
+            return;
+        }
+
+        for edit in edits {
+            writeln!(
+                rendered,
+                "- {}:{} -> {}",
+                self.render_path(self.fixture.path(path).as_path()),
+                Self::render_range(edit.range),
+                Self::render_text(&edit.new_text),
+            )
+            .expect("snapshot should be writable");
         }
     }
 

--- a/crates/lsp/engine/src/tests/utils.rs
+++ b/crates/lsp/engine/src/tests/utils.rs
@@ -636,7 +636,7 @@ impl LspEngineFixture {
     }
 
     fn render_text(text: &str) -> String {
-        if text.contains('\n') {
+        if text.is_empty() || text.contains('\n') {
             format!("{text:?}")
         } else {
             text.to_string()

--- a/crates/lsp/proto/src/service.rs
+++ b/crates/lsp/proto/src/service.rs
@@ -79,6 +79,8 @@ pub trait EngineService {
         client_capabilities: CompletionClientCapabilities,
     ) -> EngineResult<Vec<ls_types::CompletionItem>>;
 
+    async fn formatting(path: PathBuf) -> EngineResult<Option<Vec<ls_types::TextEdit>>>;
+
     async fn document_symbol(path: PathBuf) -> EngineResult<Vec<ls_types::DocumentSymbol>>;
 
     async fn inlay_hint(

--- a/crates/lsp/server/src/backend.rs
+++ b/crates/lsp/server/src/backend.rs
@@ -407,6 +407,17 @@ impl LanguageServer for Backend {
 
     #[tracing::instrument(
         skip_all,
+        fields(rg.method = "formatting", rg.uri = ?params.text_document.uri)
+    )]
+    async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
+        let Some(context) = self.method_context_for(&params.text_document.uri).await? else {
+            return Ok(None);
+        };
+        methods::text_document::formatting::formatting(context, params).await
+    }
+
+    #[tracing::instrument(
+        skip_all,
         fields(rg.method = "documentSymbol", rg.uri = ?params.text_document.uri)
     )]
     async fn document_symbol(

--- a/crates/lsp/server/src/capabilities.rs
+++ b/crates/lsp/server/src/capabilities.rs
@@ -28,6 +28,7 @@ pub(crate) fn server_capabilities() -> ServerCapabilities {
             trigger_characters: Some(vec![".".to_string(), ":".to_string()]),
             ..Default::default()
         }),
+        document_formatting_provider: Some(OneOf::Left(true)),
         document_symbol_provider: Some(OneOf::Left(true)),
         // The VS Code extension sends this request directly, so keep the internal command out of
         // the editor command registry.
@@ -103,6 +104,12 @@ mod tests {
     fn advertises_references_support() {
         let capabilities = server_capabilities();
         assert!(capabilities.references_provider.is_some());
+    }
+
+    #[test]
+    fn advertises_document_formatting_support() {
+        let capabilities = server_capabilities();
+        assert!(capabilities.document_formatting_provider.is_some());
     }
 
     #[test]

--- a/crates/lsp/server/src/methods/text_document/formatting.rs
+++ b/crates/lsp/server/src/methods/text_document/formatting.rs
@@ -1,0 +1,31 @@
+use tower_lsp_server::{jsonrpc::Result, ls_types::*};
+
+use crate::methods::{MethodContext, internal_error, uri_to_path};
+
+#[tracing::instrument(level = "trace", skip_all)]
+pub(crate) async fn formatting(
+    ctx: MethodContext,
+    params: DocumentFormattingParams,
+) -> Result<Option<Vec<TextEdit>>> {
+    let Some(path) = uri_to_path(&params.text_document.uri) else {
+        return Ok(None);
+    };
+    tracing::trace!("formatting request received");
+
+    let edits = ctx
+        .engine_client
+        .call(
+            "formatting",
+            move |engine_client, request_context| async move {
+                engine_client.formatting(request_context, path).await
+            },
+        )
+        .await
+        .map_err(internal_error)?;
+    tracing::trace!(
+        result_count = edits.as_ref().map(Vec::len),
+        "formatting request answered"
+    );
+
+    Ok(edits)
+}

--- a/crates/lsp/server/src/methods/text_document/mod.rs
+++ b/crates/lsp/server/src/methods/text_document/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod did_open;
 pub(crate) mod did_save;
 pub(crate) mod document_highlight;
 pub(crate) mod document_symbol;
+pub(crate) mod formatting;
 pub(crate) mod hover;
 pub(crate) mod implementation;
 pub(crate) mod inlay_hint;


### PR DESCRIPTION
Advertise formatting support & implement it via rusfmt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented LSP document formatting support, enabling users to format Rust source code directly through the language server. The feature respects project Rust editions, properly handles both saved and unsaved document content, and integrates with standard editor formatting workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->