### PR TITLE
fix: Fix #60

### DIFF
--- a/crates/engine/ir-model/src/hir/body/path.rs
+++ b/crates/engine/ir-model/src/hir/body/path.rs
@@ -167,6 +167,10 @@ impl BodyPath {
     /// resolve the enum type, while a cursor on `Variant` should resolve the variant. Rich pieces
     /// such as type anchors intentionally have no DefMap projection.
     pub fn prefix_through(&self, segment_idx: usize) -> Option<Path> {
+        if segment_idx >= self.segments.len() {
+            return None;
+        }
+
         let segments = self
             .segments
             .iter()


### PR DESCRIPTION
Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling by rejecting out-of-bounds segment positions, preventing invalid projections from being returned.
  * Path operations now safely return no result when the requested segment index is beyond the available segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->