### PR TITLE
feat: Fix annoying stuff

### DIFF
--- a/crates/engine/body-ir/src/build/lower/expr.rs
+++ b/crates/engine/body-ir/src/build/lower/expr.rs
@@ -10,8 +10,8 @@ use rg_syntax::{
 };
 
 use rg_ir_model::{
-    ExprId, ScopeId,
-    items::{FieldKey, GenericArg, Mutability},
+    ExprId, Mutability, ScopeId,
+    items::{FieldKey, GenericArg},
 };
 use rg_item_tree::{FromAst as _, MaybeFromAst as _, RecordExprFieldAst};
 use rg_parse::{Span, TextSpan};

--- a/crates/engine/body-ir/src/build/lower/pat.rs
+++ b/crates/engine/body-ir/src/build/lower/pat.rs
@@ -6,15 +6,15 @@ use rg_syntax::{
 };
 
 use rg_ir_model::{
-    BindingId, BodyPath, BodyPathSegment, BodyPathSegmentKind, ExprId, PatId, ScopeId,
+    BindingId, BodyPath, BodyPathSegment, BodyPathSegmentKind, ExprId, Mutability, PatId, ScopeId,
     items::{FieldKey, TypeRef},
 };
 use rg_item_tree::{FromAst as _, RecordPatFieldAst};
 use rg_text::Name;
 
 use crate::ir::{
-    BindingData, BindingKind, LiteralKind, PatBindingMode, PatData, PatKind, PatMutability,
-    PatRangeKind, PendingBindingResolution, RecordFieldSyntax, RecordPatField,
+    BindingData, BindingKind, LiteralKind, PatBindingMode, PatData, PatKind, PatRangeKind,
+    PendingBindingResolution, RecordFieldSyntax, RecordPatField,
 };
 
 use super::body::BodyLowering;
@@ -286,7 +286,7 @@ impl BodyLowering<'_> {
                     return self.alloc_unsupported_pat(pat.syntax());
                 };
                 PatKind::Ref {
-                    mutability: PatMutability::from_ast(&pat, ()),
+                    mutability: Mutability::from_mut_token(pat.mut_token().is_some()),
                     pat: self.lower_pat_inner(inner, scope, kind, None, alloc_bindings, bindings),
                 }
             }

--- a/crates/engine/body-ir/src/build/lower/stmt.rs
+++ b/crates/engine/body-ir/src/build/lower/stmt.rs
@@ -5,7 +5,7 @@ use rg_syntax::{
     ast::{self, HasModuleItem as _, HasName as _, HasVisibility as _},
 };
 
-use rg_ir_model::{ExprId, FunctionParamData, ScopeId, StmtId, items::Mutability};
+use rg_ir_model::{ExprId, FunctionParamData, Mutability, ScopeId, StmtId};
 use rg_item_tree::{
     ConstItem, Documentation, EnumItem, ExternCrateItem, FromAst as _, FunctionItem, ImplItem,
     ImplItemContext, InnerDocs, ItemKind, ItemNode, ItemTreeId, MacroUseAttr, MaybeFromAst,

--- a/crates/engine/body-ir/src/build/state.rs
+++ b/crates/engine/body-ir/src/build/state.rs
@@ -58,17 +58,17 @@ impl<'target> TargetBodyBuildState<'target> {
         // the items declared within the body, and we need to match `impl`
         // blocks to their corresponding `Self` types.
         self.materialize_body_local_items(def_map, semantic_ir)?;
-        self.resolve_body_local_impl_headers(def_map, semantic_ir)?;
 
-        // Now that we collected body local items, we can build a lookup index
-        // to match impls/functions/traits without a complex scan.
-        // Note that here we do _not_ include body-local items; these are routed in
-        // later via `BodyBuildQuerySource`.
+        // Build a target-semantic lookup index once and persist it with Body IR. Body-local items
+        // are deliberately overlaid through `BodyBuildQuerySource` instead of being part of this
+        // target-scoped cache.
         let target_items = TargetItemQuery::new(def_map, semantic_ir, self.target);
         let semantic_index = ItemLookupIndex::build_from(&target_items)?;
+        self.resolve_body_local_impl_headers(def_map, semantic_ir, &semantic_index)?;
 
         // Do a pass on resolving body expressions.
         self.resolve_bodies(def_map, semantic_ir, &semantic_index)?;
+        self.target_bodies.set_semantic_index(semantic_index);
 
         // Finalize the build state, e.g. associate each body with its corresponding
         // defmap/item store.
@@ -223,6 +223,7 @@ impl<'target> TargetBodyBuildState<'target> {
         &mut self,
         def_map: &DefMapReadTxn<'_>,
         semantic_ir: &SemanticIrReadTxn<'_>,
+        semantic_index: &ItemLookupIndex,
     ) -> anyhow::Result<()> {
         for body_idx in 0..self.target_bodies.bodies().len() {
             let body_ref = self.body_ref(body_idx);
@@ -253,7 +254,8 @@ impl<'target> TargetBodyBuildState<'target> {
                     self.target,
                     &self.body_local_items,
                 );
-                let context = BodyResolutionContext::new(&source, &source, body_ref, body);
+                let context =
+                    BodyResolutionContext::new(&source, &source, body_ref, body, semantic_index);
                 let type_paths = context.type_path_query();
                 let mut resolved_headers = Vec::new();
                 for (impl_id, owner, self_ty, trait_ref) in impl_headers {

--- a/crates/engine/body-ir/src/ir/mod.rs
+++ b/crates/engine/body-ir/src/ir/mod.rs
@@ -8,8 +8,8 @@ pub use rg_ir_model::{
     BodySource, BodySourceItems, BuiltinMacroExprKind, ClosureCapture, ClosureKind,
     ClosureParamData, ExprAssignOp, ExprBinaryOp, ExprBlockKind, ExprData, ExprKind, ExprRangeKind,
     ExprUnaryOp, ExprWrapperKind, FunctionParamData, LabelData, LiteralKind, MatchArmData,
-    PatBindingMode, PatData, PatKind, PatMutability, PatRangeKind, RecordExprField,
-    RecordExprSpread, RecordFieldSyntax, RecordPatField, ScopeData, StmtData, StmtKind,
+    PatBindingMode, PatData, PatKind, PatRangeKind, RecordExprField, RecordExprSpread,
+    RecordFieldSyntax, RecordPatField, ScopeData, StmtData, StmtKind,
 };
 
 pub use self::{

--- a/crates/engine/body-ir/src/lib.rs
+++ b/crates/engine/body-ir/src/lib.rs
@@ -28,9 +28,8 @@ pub use self::{
         BodySelfParamKind, BodySource, BodySourceItems, BuiltinMacroExprKind, ClosureCapture,
         ClosureKind, ClosureParamData, ExprAssignOp, ExprBinaryOp, ExprBlockKind, ExprData,
         ExprFacts, ExprKind, ExprRangeKind, ExprUnaryOp, FunctionParamData, LabelData, LiteralKind,
-        PatBindingMode, PatData, PatKind, PatMutability, PatRangeKind, RecordExprField,
-        RecordExprSpread, RecordFieldSyntax, RecordPatField, ResolvedBodyData, ScopeData, StmtData,
-        StmtKind,
+        PatBindingMode, PatData, PatKind, PatRangeKind, RecordExprField, RecordExprSpread,
+        RecordFieldSyntax, RecordPatField, ResolvedBodyData, ScopeData, StmtData, StmtKind,
     },
     resolution::{BodyMethodQuery, BodyResolutionContext, BodyTypePathQuery, BodyValuePathQuery},
     store::{

--- a/crates/engine/body-ir/src/resolution/infer/pattern.rs
+++ b/crates/engine/body-ir/src/resolution/infer/pattern.rs
@@ -3,8 +3,8 @@
 //! This layer links bindings inside tuple, reference, and slice patterns to the matching
 //! initializer slots, so later evidence on the binding can solve the initializer.
 
-use rg_ir_model::{ExprId, PatId};
-use rg_ty::{RefMutability, inference::InferTy};
+use rg_ir_model::{ExprId, PatId, items::Mutability};
+use rg_ty::inference::InferTy;
 
 use crate::{
     ir::{PatKind, PatMutability},
@@ -147,10 +147,10 @@ impl<'query, D, I> BodyPatternInference<'query, D, I> {
             .is_some_and(|pat| matches!(&pat.kind, PatKind::Rest))
     }
 
-    fn ref_mutability(mutability: PatMutability) -> RefMutability {
+    fn ref_mutability(mutability: PatMutability) -> Mutability {
         match mutability {
-            PatMutability::Shared => RefMutability::Shared,
-            PatMutability::Mut => RefMutability::Mutable,
+            PatMutability::Shared => Mutability::Shared,
+            PatMutability::Mut => Mutability::Mutable,
         }
     }
 }

--- a/crates/engine/body-ir/src/resolution/infer/pattern.rs
+++ b/crates/engine/body-ir/src/resolution/infer/pattern.rs
@@ -3,13 +3,10 @@
 //! This layer links bindings inside tuple, reference, and slice patterns to the matching
 //! initializer slots, so later evidence on the binding can solve the initializer.
 
-use rg_ir_model::{ExprId, PatId, items::Mutability};
+use rg_ir_model::{ExprId, Mutability, PatId};
 use rg_ty::inference::InferTy;
 
-use crate::{
-    ir::{PatKind, PatMutability},
-    resolution::BodyResolutionContext,
-};
+use crate::{ir::PatKind, resolution::BodyResolutionContext};
 
 use super::BodyInferenceCtx;
 
@@ -104,13 +101,13 @@ impl<'query, D, I> BodyPatternInference<'query, D, I> {
         &self,
         inference: &mut BodyInferenceCtx,
         pat: PatId,
-        pat_mutability: PatMutability,
+        pat_mutability: Mutability,
         ty: &InferTy,
     ) -> bool {
         let InferTy::Reference { mutability, inner } = ty else {
             return false;
         };
-        if *mutability != Self::ref_mutability(pat_mutability) {
+        if *mutability != pat_mutability {
             return false;
         }
 
@@ -145,12 +142,5 @@ impl<'query, D, I> BodyPatternInference<'query, D, I> {
             .body()
             .pat(pat)
             .is_some_and(|pat| matches!(&pat.kind, PatKind::Rest))
-    }
-
-    fn ref_mutability(mutability: PatMutability) -> Mutability {
-        match mutability {
-            PatMutability::Shared => Mutability::Shared,
-            PatMutability::Mut => Mutability::Mutable,
-        }
     }
 }

--- a/crates/engine/body-ir/src/resolution/infer/trait_obligation.rs
+++ b/crates/engine/body-ir/src/resolution/infer/trait_obligation.rs
@@ -367,7 +367,7 @@ where
         Ok(None)
     }
 
-    /// Probe a trait goal using the same indexed or non-indexed query path everywhere.
+    /// Probe a trait goal using the target lookup index persisted with Body IR.
     ///
     /// Keeping this as probe mode matters: callers decide when an `ExpectedUnique::One` result is
     /// strong enough to commit the returned inference table.
@@ -376,18 +376,12 @@ where
         goal: &TraitGoal,
         inference: &BodyInferenceCtx,
     ) -> Result<ExpectedUnique<TraitSelection>, PackageStoreError> {
-        match self.context.semantic_index() {
-            Some(index) => TraitSelectionQuery::with_index(
-                self.context.item_paths(),
-                self.context.target_items(),
-                index,
-            )
-            .probe(goal, &inference.table),
-            None => {
-                TraitSelectionQuery::new(self.context.item_paths(), self.context.target_items())
-                    .probe(goal, &inference.table)
-            }
-        }
+        TraitSelectionQuery::with_index(
+            self.context.item_paths(),
+            self.context.target_items(),
+            self.context.semantic_index(),
+        )
+        .probe(goal, &inference.table)
     }
 
     fn self_associated_type_name(ty: &TypeRef) -> Option<&str> {

--- a/crates/engine/body-ir/src/resolution/pass/builtin_macro.rs
+++ b/crates/engine/body-ir/src/resolution/pass/builtin_macro.rs
@@ -11,7 +11,7 @@ use rg_ir_model::{
 use rg_ir_storage::{DefMapSource, ItemStoreSource};
 use rg_package_store::PackageStoreError;
 use rg_text::Name;
-use rg_ty::{PrimitiveTy, RefMutability, Ty, UnsignedIntTy};
+use rg_ty::{PrimitiveTy, Ty, UnsignedIntTy};
 
 use crate::resolution::{BodyResolutionContext, TypeRefUseSite};
 
@@ -48,7 +48,7 @@ where
             | BuiltinMacroExprKind::ModulePath
             | BuiltinMacroExprKind::Stringify => Ok(Self::static_str_ty()),
             BuiltinMacroExprKind::IncludeBytes => Ok(Ty::reference(
-                RefMutability::Shared,
+                Mutability::Shared,
                 Ty::slice(Ty::Primitive(PrimitiveTy::UnsignedInt(UnsignedIntTy::U8))),
             )),
             BuiltinMacroExprKind::FormatArgs | BuiltinMacroExprKind::FormatArgsNl => {
@@ -151,6 +151,6 @@ where
     }
 
     fn static_str_ty() -> Ty {
-        Ty::reference(RefMutability::Shared, Ty::Primitive(PrimitiveTy::Str))
+        Ty::reference(Mutability::Shared, Ty::Primitive(PrimitiveTy::Str))
     }
 }

--- a/crates/engine/body-ir/src/resolution/pass/builtin_macro.rs
+++ b/crates/engine/body-ir/src/resolution/pass/builtin_macro.rs
@@ -5,8 +5,8 @@
 //! module keeps the synthetic type construction out of the general expression walker.
 
 use rg_ir_model::{
-    BuiltinMacroExprKind, ExprId, Span, TextSpan,
-    items::{GenericArg as ItemGenericArg, Mutability, TypePath, TypePathSegment, TypeRef},
+    BuiltinMacroExprKind, ExprId, Mutability, Span, TextSpan,
+    items::{GenericArg as ItemGenericArg, TypePath, TypePathSegment, TypeRef},
 };
 use rg_ir_storage::{DefMapSource, ItemStoreSource};
 use rg_package_store::PackageStoreError;

--- a/crates/engine/body-ir/src/resolution/pass/pattern_type.rs
+++ b/crates/engine/body-ir/src/resolution/pass/pattern_type.rs
@@ -5,15 +5,15 @@
 //! not infer the scrutinee type by themselves.
 
 use rg_ir_model::{
-    BindingId, BodyPath, ExprId, PatId, Path, PathSegment, ScopeId, StmtId, TypeDefId,
-    items::{FieldKey, Mutability, TypeRef},
+    BindingId, BodyPath, ExprId, Mutability, PatId, Path, PathSegment, ScopeId, StmtId, TypeDefId,
+    items::{FieldKey, TypeRef},
 };
 use rg_ir_storage::{DefMapSource, ItemStoreSource};
 use rg_package_store::PackageStoreError;
 use rg_std::ExpectedUnique;
 use rg_ty::{ReferencePeelingCandidates, Ty};
 
-use crate::ir::{ExprKind, PatKind, PatMutability, RecordPatField, StmtKind};
+use crate::ir::{ExprKind, PatKind, RecordPatField, StmtKind};
 use crate::resolution::{BodyResolutionContext, TypeRefUseSite};
 
 pub(super) struct PatternTypePropagationPass<'query, D, I> {
@@ -270,14 +270,14 @@ where
     fn propagate_ref_pat(
         &self,
         pat: PatId,
-        pat_mutability: PatMutability,
+        pat_mutability: Mutability,
         expected_ty: &Ty,
         updates: &mut Vec<(BindingId, Ty)>,
     ) -> Result<(), PackageStoreError> {
         let Some((inner_ty, mutability)) = expected_ty.reference_inner() else {
             return Ok(());
         };
-        if mutability != Self::ref_mutability(pat_mutability) {
+        if mutability != pat_mutability {
             return Ok(());
         }
 
@@ -432,13 +432,6 @@ where
         }
 
         updates.push((binding, ty));
-    }
-
-    fn ref_mutability(mutability: PatMutability) -> Mutability {
-        match mutability {
-            PatMutability::Shared => Mutability::Shared,
-            PatMutability::Mut => Mutability::Mutable,
-        }
     }
 }
 

--- a/crates/engine/body-ir/src/resolution/pass/pattern_type.rs
+++ b/crates/engine/body-ir/src/resolution/pass/pattern_type.rs
@@ -6,12 +6,12 @@
 
 use rg_ir_model::{
     BindingId, BodyPath, ExprId, PatId, Path, PathSegment, ScopeId, StmtId, TypeDefId,
-    items::{FieldKey, TypeRef},
+    items::{FieldKey, Mutability, TypeRef},
 };
 use rg_ir_storage::{DefMapSource, ItemStoreSource};
 use rg_package_store::PackageStoreError;
 use rg_std::ExpectedUnique;
-use rg_ty::{RefMutability, ReferencePeelingCandidates, Ty};
+use rg_ty::{ReferencePeelingCandidates, Ty};
 
 use crate::ir::{ExprKind, PatKind, PatMutability, RecordPatField, StmtKind};
 use crate::resolution::{BodyResolutionContext, TypeRefUseSite};
@@ -434,10 +434,10 @@ where
         updates.push((binding, ty));
     }
 
-    fn ref_mutability(mutability: PatMutability) -> RefMutability {
+    fn ref_mutability(mutability: PatMutability) -> Mutability {
         match mutability {
-            PatMutability::Shared => RefMutability::Shared,
-            PatMutability::Mut => RefMutability::Mutable,
+            PatMutability::Shared => Mutability::Shared,
+            PatMutability::Mut => Mutability::Mutable,
         }
     }
 }

--- a/crates/engine/body-ir/src/resolution/query/associated_item.rs
+++ b/crates/engine/body-ir/src/resolution/query/associated_item.rs
@@ -350,14 +350,12 @@ where
             return Ok(items);
         }
 
-        let target_items = self.context.target_items();
-        let semantic_trait_impls = match self.context.semantic_index() {
-            Some(index) => index
-                .trait_impls_for_type(ty.def)
-                .cloned()
-                .unwrap_or_default(),
-            None => target_items.trait_impls_for_type(ty.def)?,
-        };
+        let semantic_trait_impls = self
+            .context
+            .semantic_index()
+            .trait_impls_for_type(ty.def)
+            .cloned()
+            .unwrap_or_default();
         self.push_trait_associated_const_candidates_for_impls(
             &mut items,
             semantic_trait_impls,
@@ -394,7 +392,7 @@ where
 
         let body_trait_impls = body_items.trait_impls_for_type(ty.def)?;
         for (function_ref, _) in matcher.trait_function_candidates_from_impls(
-            self.context.semantic_index(),
+            Some(self.context.semantic_index()),
             body_trait_impls,
             ty,
             Some(name),
@@ -404,7 +402,7 @@ where
 
         if ty.def.origin.as_target_ref().is_some() {
             for (function_ref, _) in matcher.trait_function_candidates_for_receiver(
-                self.context.semantic_index(),
+                Some(self.context.semantic_index()),
                 ty,
                 Some(name),
             )? {
@@ -427,7 +425,7 @@ where
                 .context
                 .impl_matcher()
                 .trait_function_candidates_from_impls(
-                    self.context.semantic_index(),
+                    Some(self.context.semantic_index()),
                     receiver.impls().clone(),
                     receiver.receiver_ty(),
                     Some(name),
@@ -463,22 +461,18 @@ where
         Ok(consts)
     }
 
-    /// Read target-visible inherent functions, using the index when available.
+    /// Read target-visible inherent functions from the persisted lookup index.
     fn semantic_inherent_function_items_for_type(
         &self,
         ty: &NominalTy,
         name: &str,
     ) -> Result<UniqueVec<FunctionRef>, PackageStoreError> {
-        match self.context.semantic_index() {
-            Some(index) => Ok(index
-                .inherent_functions_for_type_and_name(ty.def, name)
-                .cloned()
-                .unwrap_or_default()),
-            None => self
-                .context
-                .target_items()
-                .inherent_functions_for_type(ty.def),
-        }
+        Ok(self
+            .context
+            .semantic_index()
+            .inherent_functions_for_type_and_name(ty.def, name)
+            .cloned()
+            .unwrap_or_default())
     }
 
     /// Add a function only if it is static and has the requested name.

--- a/crates/engine/body-ir/src/resolution/query/associated_item.rs
+++ b/crates/engine/body-ir/src/resolution/query/associated_item.rs
@@ -322,8 +322,8 @@ where
 
         self.associated_const_candidate_for_impls(
             self.context
-                .target_items()
-                .inherent_impls_for_type(ty.def)?,
+                .semantic_index()
+                .inherent_impls_for_type(ty.def),
             ty,
             name,
         )
@@ -392,7 +392,7 @@ where
 
         let body_trait_impls = body_items.trait_impls_for_type(ty.def)?;
         for (function_ref, _) in matcher.trait_function_candidates_from_impls(
-            Some(self.context.semantic_index()),
+            self.context.semantic_index(),
             body_trait_impls,
             ty,
             Some(name),
@@ -402,7 +402,7 @@ where
 
         if ty.def.origin.as_target_ref().is_some() {
             for (function_ref, _) in matcher.trait_function_candidates_for_receiver(
-                Some(self.context.semantic_index()),
+                self.context.semantic_index(),
                 ty,
                 Some(name),
             )? {
@@ -425,7 +425,7 @@ where
                 .context
                 .impl_matcher()
                 .trait_function_candidates_from_impls(
-                    Some(self.context.semantic_index()),
+                    self.context.semantic_index(),
                     receiver.impls().clone(),
                     receiver.receiver_ty(),
                     Some(name),

--- a/crates/engine/body-ir/src/resolution/query/method.rs
+++ b/crates/engine/body-ir/src/resolution/query/method.rs
@@ -181,7 +181,7 @@ where
 
         let body_trait_impls = body_items.trait_impls_for_type(receiver_ty.def)?;
         for (function, applicability) in matcher.trait_function_candidates_from_impls(
-            Some(self.context.semantic_index()),
+            self.context.semantic_index(),
             body_trait_impls,
             receiver_ty,
             method_name,
@@ -194,7 +194,7 @@ where
 
         if receiver_ty.def.origin.as_target_ref().is_some() {
             for (function, applicability) in matcher.trait_function_candidates_for_receiver(
-                Some(self.context.semantic_index()),
+                self.context.semantic_index(),
                 receiver_ty,
                 method_name,
             )? {

--- a/crates/engine/body-ir/src/resolution/query/method.rs
+++ b/crates/engine/body-ir/src/resolution/query/method.rs
@@ -181,7 +181,7 @@ where
 
         let body_trait_impls = body_items.trait_impls_for_type(receiver_ty.def)?;
         for (function, applicability) in matcher.trait_function_candidates_from_impls(
-            self.context.semantic_index(),
+            Some(self.context.semantic_index()),
             body_trait_impls,
             receiver_ty,
             method_name,
@@ -194,7 +194,7 @@ where
 
         if receiver_ty.def.origin.as_target_ref().is_some() {
             for (function, applicability) in matcher.trait_function_candidates_for_receiver(
-                self.context.semantic_index(),
+                Some(self.context.semantic_index()),
                 receiver_ty,
                 method_name,
             )? {
@@ -220,7 +220,6 @@ where
             return Ok(Vec::new());
         }
 
-        let target_items = self.context.target_items();
         let matcher = self.context.impl_matcher();
         let item_query = self.context.item_query();
         let mut candidates = Vec::new();
@@ -228,10 +227,11 @@ where
         // Structural inherent impls model language/core-provided builtins such as `impl<T> [T]`.
         // Body-local impl lookup remains nominal-only because block-local impls are useful for
         // local structs, not for defining new inherent methods on builtin shaped types.
-        let impl_refs = match self.context.semantic_index() {
-            Some(index) => index.structural_inherent_impls().clone(),
-            None => target_items.inherent_impls()?,
-        };
+        let impl_refs = self
+            .context
+            .semantic_index()
+            .structural_inherent_impls()
+            .clone();
         for impl_ref in impl_refs {
             self.push_structural_inherent_functions_for_impl(
                 &item_query,
@@ -317,21 +317,15 @@ where
         receiver_ty: &NominalTy,
         method_name: Option<&str>,
     ) -> Result<UniqueVec<FunctionRef>, PackageStoreError> {
-        match (self.context.semantic_index(), method_name) {
-            (Some(index), Some(name)) => Ok(index
+        let index = self.context.semantic_index();
+        match method_name {
+            Some(name) => Ok(index
                 .inherent_functions_for_type_and_name(receiver_ty.def, name)
                 .cloned()
                 .unwrap_or_default()),
-            (Some(index), None) => {
+            None => {
                 let item_query = self.context.item_query();
                 index.inherent_functions_for_type(&item_query, receiver_ty.def)
-            }
-            (None, method_name) => {
-                let functions = self
-                    .context
-                    .target_items()
-                    .inherent_functions_for_type(receiver_ty.def)?;
-                self.filter_functions_by_name(functions, method_name)
             }
         }
     }

--- a/crates/engine/body-ir/src/resolution/query/traits.rs
+++ b/crates/engine/body-ir/src/resolution/query/traits.rs
@@ -153,14 +153,12 @@ where
         )?;
 
         if ty.def.origin.as_target_ref().is_some() {
-            let target_items = self.context.target_items();
-            let semantic_impls = match self.context.semantic_index() {
-                Some(index) => index
-                    .trait_impls_for_type(ty.def)
-                    .cloned()
-                    .unwrap_or_default(),
-                None => target_items.trait_impls_for_type(ty.def)?,
-            };
+            let semantic_impls = self
+                .context
+                .semantic_index()
+                .trait_impls_for_type(ty.def)
+                .cloned()
+                .unwrap_or_default();
             self.push_matching_qualified_trait_impls(
                 &mut impls,
                 semantic_impls,

--- a/crates/engine/body-ir/src/resolution/query/type_alias.rs
+++ b/crates/engine/body-ir/src/resolution/query/type_alias.rs
@@ -1,8 +1,9 @@
 //! Type alias projection.
 
-use rg_ir_model::{AssocItemId, TypeAliasRef};
+use rg_ir_model::{AssocItemId, DefMapRef, ImplRef, TypeAliasRef};
 use rg_ir_storage::{DefMapSource, ItemStoreSource, TypePathContext};
 use rg_package_store::PackageStoreError;
+use rg_std::UniqueVec;
 use rg_ty::{GenericArg, NominalTy, Ty, TypeSubst};
 
 use crate::resolution::{BodyResolutionContext, TypeRefUseSite};
@@ -29,11 +30,38 @@ where
         ty: &NominalTy,
         name: &str,
     ) -> Result<Option<TypeAliasRef>, PackageStoreError> {
-        let impls = self
-            .context
-            .body_local_items()
-            .inherent_impls_for_type(ty.def)?;
+        // Block-local impls can add aliases even to target-origin types, e.g.
+        // `impl TargetType { type LocalAlias = ... }` inside a function.
+        let body_alias = self.associated_alias_for_impls(
+            self.context
+                .body_local_items()
+                .inherent_impls_for_type(ty.def)?,
+            ty,
+            name,
+        )?;
 
+        // If type originates in body or we already have response, we don't need
+        // to check semantic items.
+        if matches!(ty.def.origin, DefMapRef::Body(_)) || body_alias.is_some() {
+            return Ok(body_alias);
+        }
+
+        self.associated_alias_for_impls(
+            self.context
+                .semantic_index()
+                .inherent_impls_for_type(ty.def),
+            ty,
+            name,
+        )
+    }
+
+    /// Find the first matching associated type alias across inherent impls.
+    fn associated_alias_for_impls(
+        &self,
+        impls: UniqueVec<ImplRef>,
+        ty: &NominalTy,
+        name: &str,
+    ) -> Result<Option<TypeAliasRef>, PackageStoreError> {
         let item_query = self.context.item_query();
         for impl_ref in impls {
             let Some(impl_data) = item_query.impl_data(impl_ref)? else {

--- a/crates/engine/body-ir/src/resolution/query/type_ref.rs
+++ b/crates/engine/body-ir/src/resolution/query/type_ref.rs
@@ -2,12 +2,12 @@
 
 use rg_ir_model::{
     DefMapRef, FunctionRef, ModuleRef, Path, ScopeId, TraitRef, TypePathResolution,
-    items::{GenericArg as ItemGenericArg, Mutability, PrimitiveTy, TypePath, TypeRef},
+    items::{GenericArg as ItemGenericArg, PrimitiveTy, TypePath, TypeRef},
 };
 use rg_ir_storage::{DefMapSource, ItemStoreSource, TypePathContext};
 use rg_package_store::PackageStoreError;
 use rg_std::ExpectedUnique;
-use rg_ty::{ExpectedNominalTyExt, GenericArg, NominalTy, RefMutability, Ty, TypeSubst};
+use rg_ty::{ExpectedNominalTyExt, GenericArg, NominalTy, Ty, TypeSubst};
 
 use crate::resolution::BodyResolutionContext;
 
@@ -198,13 +198,7 @@ where
             TypeRef::Never => Ok(Ty::Never),
             TypeRef::Reference {
                 mutability, inner, ..
-            } => Ok(Ty::reference(
-                match mutability {
-                    Mutability::Shared => RefMutability::Shared,
-                    Mutability::Mutable => RefMutability::Mutable,
-                },
-                self.resolve_at(inner, anchor)?,
-            )),
+            } => Ok(Ty::reference(*mutability, self.resolve_at(inner, anchor)?)),
             TypeRef::Unknown(_) | TypeRef::Infer => Ok(Ty::Unknown),
             TypeRef::Tuple(types) if types.is_empty() => Ok(Ty::Unit),
             TypeRef::Tuple(types) => Ok(Ty::tuple(

--- a/crates/engine/body-ir/src/resolution/source/context.rs
+++ b/crates/engine/body-ir/src/resolution/source/context.rs
@@ -24,20 +24,16 @@ use super::BodyQuerySource;
 #[derive(Clone, Copy)]
 pub struct BodyResolutionContext<'a, D, I> {
     source: BodyQuerySource<'a, D, I>,
-    semantic_index: Option<&'a ItemLookupIndex>,
+    semantic_index: &'a ItemLookupIndex,
 }
 
 impl<'a, D, I> BodyResolutionContext<'a, D, I> {
-    pub fn new(def_maps: D, item_stores: I, body_ref: BodyRef, body: &'a ResolvedBodyData) -> Self {
-        Self::with_semantic_index(def_maps, item_stores, body_ref, body, None)
-    }
-
-    pub(crate) fn with_semantic_index(
+    pub fn new(
         def_maps: D,
         item_stores: I,
         body_ref: BodyRef,
         body: &'a ResolvedBodyData,
-        semantic_index: Option<&'a ItemLookupIndex>,
+        semantic_index: &'a ItemLookupIndex,
     ) -> Self {
         Self {
             source: BodyQuerySource::new(def_maps, item_stores, body_ref, body),
@@ -53,7 +49,7 @@ impl<'a, D, I> BodyResolutionContext<'a, D, I> {
         self.source.body()
     }
 
-    pub(crate) fn semantic_index(&self) -> Option<&'a ItemLookupIndex> {
+    pub(crate) fn semantic_index(&self) -> &'a ItemLookupIndex {
         self.semantic_index
     }
 }
@@ -146,20 +142,16 @@ where
     pub(crate) fn autoderef(
         &self,
     ) -> Autoderef<'a, BodyQuerySource<'a, D, I>, BodyQuerySource<'a, D, I>> {
-        match self.semantic_index {
-            Some(index) => Autoderef::with_index(self.item_paths(), self.target_items(), index),
-            None => Autoderef::new(self.item_paths(), self.target_items()),
-        }
+        Autoderef::with_index(self.item_paths(), self.target_items(), self.semantic_index)
     }
 
     pub(crate) fn iteration_items(
         &self,
     ) -> IterationItemResolver<'a, BodyQuerySource<'a, D, I>, BodyQuerySource<'a, D, I>> {
-        match self.semantic_index {
-            Some(index) => {
-                IterationItemResolver::with_index(self.item_paths(), self.target_items(), index)
-            }
-            None => IterationItemResolver::new(self.item_paths(), self.target_items()),
-        }
+        IterationItemResolver::with_index(
+            self.item_paths(),
+            self.target_items(),
+            self.semantic_index,
+        )
     }
 }

--- a/crates/engine/body-ir/src/resolution/source/providers.rs
+++ b/crates/engine/body-ir/src/resolution/source/providers.rs
@@ -48,12 +48,12 @@ impl<'query, D, I> BodyResolutionProviders<'query, D, I> {
         &'source self,
         body: &'source ResolvedBodyData,
     ) -> BodyResolutionContext<'source, &'source D, &'source I> {
-        BodyResolutionContext::with_semantic_index(
+        BodyResolutionContext::new(
             self.def_maps,
             self.item_stores,
             self.body_ref,
             body,
-            Some(self.semantic_index),
+            self.semantic_index,
         )
     }
 }

--- a/crates/engine/body-ir/src/store/package.rs
+++ b/crates/engine/body-ir/src/store/package.rs
@@ -2,7 +2,7 @@ use wincode::{SchemaRead, SchemaWrite};
 
 use rg_arena::Arena;
 use rg_ir_model::BodyId;
-use rg_ir_storage::{BodyLocalItems, DefMap, ItemStore};
+use rg_ir_storage::{BodyLocalItems, DefMap, ItemLookupIndex, ItemStore};
 use rg_parse::TargetId;
 
 use crate::ir::body::ResolvedBodyData;
@@ -38,6 +38,7 @@ impl PackageBodies {
 #[derive(Debug, Clone, PartialEq, Eq, SchemaRead, SchemaWrite, MemorySize, Shrink)]
 pub struct TargetBodies {
     pub(crate) status: TargetBodiesStatus,
+    pub(crate) semantic_index: ItemLookupIndex,
     pub(crate) bodies: Arena<BodyId, ResolvedBodyData>,
     pub(crate) body_local_items: Arena<BodyId, BodyLocalItems>,
 }
@@ -46,6 +47,7 @@ impl TargetBodies {
     pub(crate) fn new() -> Self {
         Self {
             status: TargetBodiesStatus::Built,
+            semantic_index: ItemLookupIndex::default(),
             bodies: Arena::new(),
             body_local_items: Arena::new(),
         }
@@ -54,6 +56,7 @@ impl TargetBodies {
     pub(crate) fn skipped() -> Self {
         Self {
             status: TargetBodiesStatus::Skipped,
+            semantic_index: ItemLookupIndex::default(),
             bodies: Arena::new(),
             body_local_items: Arena::new(),
         }
@@ -65,6 +68,10 @@ impl TargetBodies {
 
     pub fn body(&self, body: BodyId) -> Option<&ResolvedBodyData> {
         self.bodies.get(body)
+    }
+
+    pub fn semantic_index(&self) -> &ItemLookupIndex {
+        &self.semantic_index
     }
 
     pub fn body_local_items(&self, body: BodyId) -> Option<&BodyLocalItems> {
@@ -94,6 +101,10 @@ impl TargetBodies {
             "every built body should have finalized body-local items"
         );
         self.body_local_items = Arena::from_vec(items);
+    }
+
+    pub(crate) fn set_semantic_index(&mut self, index: ItemLookupIndex) {
+        self.semantic_index = index;
     }
 
     pub(crate) fn bodies_mut(&mut self) -> &mut [ResolvedBodyData] {

--- a/crates/engine/ir-model/src/hir/body/binding.rs
+++ b/crates/engine/ir-model/src/hir/body/binding.rs
@@ -3,10 +3,7 @@ use wincode::{SchemaRead, SchemaWrite};
 use rg_parse::Span;
 use rg_text::Name;
 
-use crate::{
-    ScopeId,
-    items::{Mutability, TypeRef},
-};
+use crate::{Mutability, ScopeId, items::TypeRef};
 use rg_std::{MemorySize, Shrink};
 
 use super::BodySource;

--- a/crates/engine/ir-model/src/hir/body/expr.rs
+++ b/crates/engine/ir-model/src/hir/body/expr.rs
@@ -6,8 +6,8 @@ use rg_parse::Span;
 use rg_text::Name;
 
 use crate::{
-    BindingId, ExprId, PatId, ScopeId, StmtId,
-    items::{FieldKey, GenericArg, Mutability, TypeRef},
+    BindingId, ExprId, Mutability, PatId, ScopeId, StmtId,
+    items::{FieldKey, GenericArg, TypeRef},
 };
 use rg_std::{MemorySize, Shrink};
 

--- a/crates/engine/ir-model/src/hir/body/mod.rs
+++ b/crates/engine/ir-model/src/hir/body/mod.rs
@@ -30,7 +30,7 @@ pub use self::{
     literal::LiteralKind,
     macro_call::BodyMacroCallData,
     owner::BodyOwner,
-    pat::{PatBindingMode, PatData, PatKind, PatMutability, PatRangeKind, RecordPatField},
+    pat::{PatBindingMode, PatData, PatKind, PatRangeKind, RecordPatField},
     path::{
         BodyAssociatedPathPrefix, BodyPath, BodyPathSegment, BodyPathSegmentArgs,
         BodyPathSegmentKind,

--- a/crates/engine/ir-model/src/hir/body/pat.rs
+++ b/crates/engine/ir-model/src/hir/body/pat.rs
@@ -2,7 +2,7 @@ use wincode::{SchemaRead, SchemaWrite};
 
 use rg_parse::Span;
 
-use crate::{BindingId, ExprId, PatId, items::FieldKey};
+use crate::{BindingId, ExprId, Mutability, PatId, items::FieldKey};
 use rg_std::{MemorySize, Shrink};
 
 use super::{BodyPath, BodySource, LiteralKind, RecordFieldSyntax};
@@ -16,30 +16,6 @@ use super::{BodyPath, BodySource, LiteralKind, RecordFieldSyntax};
 pub struct PatBindingMode {
     pub by_ref: bool,
     pub mutable: bool,
-}
-
-/// Mutability written on a reference pattern.
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    derive_more::Display,
-    SchemaRead,
-    SchemaWrite,
-    MemorySize,
-    Shrink,
-)]
-#[memsize(leaf)]
-#[shrink(leaf)]
-pub enum PatMutability {
-    /// `&<pat>`.
-    #[display("shared")]
-    Shared,
-    /// `&mut <pat>`.
-    #[display("mut")]
-    Mut,
 }
 
 /// Range operator written in a range pattern.
@@ -102,10 +78,7 @@ pub enum PatKind {
     /// `[<pat>, ...]`.
     Slice { fields: Vec<PatId> },
     /// `&<pat>` or `&mut <pat>`.
-    Ref {
-        mutability: PatMutability,
-        pat: PatId,
-    },
+    Ref { mutability: Mutability, pat: PatId },
     /// `box <pat>`.
     Box { pat: PatId },
     /// `CONST`, `Enum::Variant`, or another path-only pattern.

--- a/crates/engine/ir-model/src/hir/items.rs
+++ b/crates/engine/ir-model/src/hir/items.rs
@@ -1,6 +1,9 @@
-use crate::items::{
-    Documentation, EnumVariantItem, FieldItem, FieldList, GenericParams, Mutability, ParamKind,
-    TypeBound, TypeRef, VisibilityLevel,
+use crate::{
+    Mutability,
+    items::{
+        Documentation, EnumVariantItem, FieldItem, FieldList, GenericParams, ParamKind, TypeBound,
+        TypeRef, VisibilityLevel,
+    },
 };
 use rg_parse::{FileId, Span};
 use rg_std::{ExpectedUnique, MemorySize, Shrink};

--- a/crates/engine/ir-model/src/items/decl.rs
+++ b/crates/engine/ir-model/src/items/decl.rs
@@ -10,7 +10,8 @@ use wincode::{SchemaRead, SchemaWrite};
 use rg_parse::Span;
 use rg_text::Name;
 
-use super::{Documentation, ItemTreeId, Mutability, TypeBound, TypeRef, VisibilityLevel};
+use super::{Documentation, ItemTreeId, TypeBound, TypeRef, VisibilityLevel};
+use crate::Mutability;
 
 /// Generic parameter data attached to an item declaration.
 #[derive(Debug, Clone, PartialEq, Eq, Default, SchemaRead, SchemaWrite, MemorySize, Shrink)]

--- a/crates/engine/ir-model/src/items/mod.rs
+++ b/crates/engine/ir-model/src/items/mod.rs
@@ -23,7 +23,7 @@ pub use self::{
     },
     module::{ModuleItem, ModuleSource},
     primitive::{FloatTy, PrimitiveTy, SignedIntTy, UnsignedIntTy},
-    type_ref::{GenericArg, Mutability, TypeBound, TypePath, TypePathSegment, TypeRef},
+    type_ref::{GenericArg, TypeBound, TypePath, TypePathSegment, TypeRef},
     visibility::VisibilityLevel,
 };
 

--- a/crates/engine/ir-model/src/items/type_ref.rs
+++ b/crates/engine/ir-model/src/items/type_ref.rs
@@ -6,36 +6,7 @@ use rg_parse::Span;
 use rg_std::{MemorySize, Shrink};
 use rg_text::Name;
 
-/// Syntax-level mutability marker used by lowered declarations and type refs.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, SchemaRead, SchemaWrite, MemorySize, Shrink)]
-#[memsize(leaf)]
-#[shrink(leaf)]
-pub enum Mutability {
-    Shared,
-    Mutable,
-}
-
-impl Mutability {
-    pub fn from_mut_token(is_mut: bool) -> Self {
-        if is_mut { Self::Mutable } else { Self::Shared }
-    }
-
-    pub fn render_prefix(self) -> &'static str {
-        match self {
-            Self::Shared => "&",
-            Self::Mutable => "&mut ",
-        }
-    }
-}
-
-impl fmt::Display for Mutability {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Shared => write!(f, "shared"),
-            Self::Mutable => write!(f, "mut"),
-        }
-    }
-}
+use crate::Mutability;
 
 /// Unresolved type syntax lowered into the item tree.
 ///

--- a/crates/engine/ir-model/src/lib.rs
+++ b/crates/engine/ir-model/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod hir;
 mod ids;
 pub mod items;
+mod mutability;
 pub mod path;
 mod resolution;
 
@@ -16,8 +17,8 @@ pub use self::hir::body::{
     BodySource, BodySourceItem, BodySourceItems, BuiltinMacroExprKind, ClosureCapture, ClosureKind,
     ClosureParamData, ExprAssignOp, ExprBinaryOp, ExprBlockKind, ExprData, ExprKind, ExprRangeKind,
     ExprUnaryOp, ExprWrapperKind, FunctionParamData, LabelData, LiteralKind, MatchArmData,
-    PatBindingMode, PatData, PatKind, PatMutability, PatRangeKind, RecordExprField,
-    RecordExprSpread, RecordFieldSyntax, RecordPatField, ScopeData, StmtData, StmtKind,
+    PatBindingMode, PatData, PatKind, PatRangeKind, RecordExprField, RecordExprSpread,
+    RecordFieldSyntax, RecordPatField, ScopeData, StmtData, StmtKind,
 };
 pub use self::ids::{
     TargetId,
@@ -34,6 +35,7 @@ pub use self::ids::{
         TypeDefId, TypeDefRef, UnionId,
     },
 };
+pub use self::mutability::Mutability;
 pub use self::path::{Path, PathSegment, last_segment_name};
 pub use self::resolution::TypePathResolution;
 pub use rg_parse::{FileId, Span, TextSpan};

--- a/crates/engine/ir-model/src/mutability.rs
+++ b/crates/engine/ir-model/src/mutability.rs
@@ -1,0 +1,35 @@
+use std::fmt;
+
+use rg_std::{MemorySize, Shrink};
+use wincode::{SchemaRead, SchemaWrite};
+
+/// Reference mutability marker shared by type syntax and body forms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, SchemaRead, SchemaWrite, MemorySize, Shrink)]
+#[memsize(leaf)]
+#[shrink(leaf)]
+pub enum Mutability {
+    Shared,
+    Mutable,
+}
+
+impl Mutability {
+    pub fn from_mut_token(is_mut: bool) -> Self {
+        if is_mut { Self::Mutable } else { Self::Shared }
+    }
+
+    pub fn render_prefix(self) -> &'static str {
+        match self {
+            Self::Shared => "&",
+            Self::Mutable => "&mut ",
+        }
+    }
+}
+
+impl fmt::Display for Mutability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Shared => write!(f, "shared"),
+            Self::Mutable => write!(f, "mut"),
+        }
+    }
+}

--- a/crates/engine/ir-storage/src/item/lookup_index.rs
+++ b/crates/engine/ir-storage/src/item/lookup_index.rs
@@ -197,6 +197,42 @@ impl ItemLookupIndex {
         &self.structural_inherent_impls
     }
 
+    /// Returns inherent impls indexed for a receiver type.
+    pub fn inherent_impls_for_type(&self, ty: TypeDefRef) -> UniqueVec<ImplRef> {
+        self.inherent_impls_by_type
+            .get(&ty)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Returns impl blocks indexed for a receiver type, including inherent and trait impls.
+    pub fn impls_for_type(&self, ty: TypeDefRef) -> UniqueVec<ImplRef> {
+        let mut impls = self.inherent_impls_for_type(ty);
+        if let Some(trait_impls) = self.trait_impls_by_type.get(&ty) {
+            impls.extend(trait_impls.iter().map(|trait_impl| trait_impl.impl_ref));
+        }
+        impls
+    }
+
+    /// Returns impl blocks indexed for an implemented trait.
+    pub fn impls_for_trait(&self, trait_ref: TraitRef) -> UniqueVec<ImplRef> {
+        self.trait_impls_by_trait
+            .get(&trait_ref)
+            .into_iter()
+            .flat_map(|trait_impls| trait_impls.iter())
+            .map(|trait_impl| trait_impl.impl_ref)
+            .collect()
+    }
+
+    /// Returns all indexed trait impl candidates.
+    pub fn trait_impls(&self) -> UniqueVec<TraitImplRef> {
+        let mut trait_impls = UniqueVec::new();
+        for candidates in self.trait_impls_by_trait.values() {
+            trait_impls.extend(candidates.iter().copied());
+        }
+        trait_impls
+    }
+
     /// Returns trait impl candidates indexed for a receiver type.
     pub fn trait_impls_for_type(&self, ty: TypeDefRef) -> Option<&UniqueVec<TraitImplRef>> {
         self.trait_impls_by_type.get(&ty)

--- a/crates/engine/ir-storage/src/item/lookup_index.rs
+++ b/crates/engine/ir-storage/src/item/lookup_index.rs
@@ -7,13 +7,14 @@
 use std::collections::HashMap;
 
 use rg_ir_model::{AssocItemId, FunctionRef, ImplRef, TraitImplRef, TraitRef, TypeDefRef};
-use rg_std::UniqueVec;
+use rg_std::{MemorySize, Shrink, UniqueVec};
 use rg_text::Name;
+use wincode::{SchemaRead, SchemaWrite};
 
 use crate::{ItemStoreQuery, ItemStoreSource, TargetItemQuery};
 
 /// Receiver-oriented lookup cache built from the stores visible from one use-site target.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, SchemaRead, SchemaWrite, MemorySize, Shrink)]
 pub struct ItemLookupIndex {
     // Method lookup starts from a receiver type. These maps let callers jump directly to impls
     // whose already-resolved `Self` type mentions that receiver, instead of re-scanning all impls.

--- a/crates/engine/ir-storage/src/lib.rs
+++ b/crates/engine/ir-storage/src/lib.rs
@@ -2,6 +2,8 @@ mod body;
 mod def_map;
 mod item;
 
+pub use rg_std::UniqueVec;
+
 pub use self::{
     body::BodyLocalItems,
     def_map::{

--- a/crates/engine/ir-view/src/body/resolution.rs
+++ b/crates/engine/ir-view/src/body/resolution.rs
@@ -4,8 +4,9 @@
 //! construct its context. This adapter is the single `ir-view` entry point for body-local path and
 //! member facts.
 
-use rg_body_ir::BodyResolutionContext;
+use rg_body_ir::{BodyResolutionContext, ResolvedBodyData};
 use rg_ir_model::{BodyRef, Path, ScopeId, TypePathResolution, identity::DeclarationRef};
+use rg_ir_storage::ItemLookupIndex;
 use rg_ty::{MemberMethodCandidateRef, Ty};
 
 use crate::IndexedViewDb;
@@ -20,6 +21,20 @@ impl<'a, 'db> BodyResolutionView<'a, 'db> {
         Self { db }
     }
 
+    fn body_with_index(
+        &self,
+        body_ref: BodyRef,
+    ) -> anyhow::Result<Option<(&ResolvedBodyData, &ItemLookupIndex)>> {
+        let Some(target_bodies) = self.db.body_ir.target_bodies(body_ref.target)? else {
+            return Ok(None);
+        };
+        let Some(body) = target_bodies.body(body_ref.body) else {
+            return Ok(None);
+        };
+
+        Ok(Some((body, target_bodies.semantic_index())))
+    }
+
     /// Resolve a type path in a body scope.
     pub(crate) fn type_path_resolution(
         &self,
@@ -27,12 +42,12 @@ impl<'a, 'db> BodyResolutionView<'a, 'db> {
         scope: ScopeId,
         path: &Path,
     ) -> anyhow::Result<Option<TypePathResolution>> {
-        let Some(body) = self.db.body_ir.body_data(body_ref)? else {
+        let Some((body, semantic_index)) = self.body_with_index(body_ref)? else {
             return Ok(None);
         };
 
         Ok(Some(
-            BodyResolutionContext::new(self.db, self.db, body_ref, body)
+            BodyResolutionContext::new(self.db, self.db, body_ref, body, semantic_index)
                 .type_path_query()
                 .resolve_in_scope(scope, path)?,
         ))
@@ -45,13 +60,15 @@ impl<'a, 'db> BodyResolutionView<'a, 'db> {
         scope: ScopeId,
         path: &Path,
     ) -> anyhow::Result<Vec<DeclarationRef>> {
-        let Some(body) = self.db.body_ir.body_data(body_ref)? else {
+        let Some((body, semantic_index)) = self.body_with_index(body_ref)? else {
             return Ok(Vec::new());
         };
 
-        Ok(BodyResolutionContext::new(self.db, self.db, body_ref, body)
-            .value_paths()
-            .resolve_nonlocal_path_declarations(scope, path)?)
+        Ok(
+            BodyResolutionContext::new(self.db, self.db, body_ref, body, semantic_index)
+                .value_paths()
+                .resolve_nonlocal_path_declarations(scope, path)?,
+        )
     }
 
     /// Resolve the type of a body value path without local binding ordering.
@@ -61,13 +78,15 @@ impl<'a, 'db> BodyResolutionView<'a, 'db> {
         scope: ScopeId,
         path: &Path,
     ) -> anyhow::Result<Ty> {
-        let Some(body) = self.db.body_ir.body_data(body_ref)? else {
+        let Some((body, semantic_index)) = self.body_with_index(body_ref)? else {
             return Ok(Ty::Unknown);
         };
 
-        Ok(BodyResolutionContext::new(self.db, self.db, body_ref, body)
-            .value_paths()
-            .resolve_nonlocal_path_ty(scope, path)?)
+        Ok(
+            BodyResolutionContext::new(self.db, self.db, body_ref, body, semantic_index)
+                .value_paths()
+                .resolve_nonlocal_path_ty(scope, path)?,
+        )
     }
 
     /// Return body-aware method refs for a receiver type.
@@ -76,12 +95,12 @@ impl<'a, 'db> BodyResolutionView<'a, 'db> {
         body_ref: BodyRef,
         ty: &Ty,
     ) -> anyhow::Result<Option<Vec<MemberMethodCandidateRef>>> {
-        let Some(body) = self.db.body_ir.body_data(body_ref)? else {
+        let Some((body, semantic_index)) = self.body_with_index(body_ref)? else {
             return Ok(None);
         };
 
         Ok(Some(
-            BodyResolutionContext::new(self.db, self.db, body_ref, body)
+            BodyResolutionContext::new(self.db, self.db, body_ref, body, semantic_index)
                 .methods()
                 .method_candidates_for_ty(ty)?,
         ))

--- a/crates/engine/ir-view/src/display/signature.rs
+++ b/crates/engine/ir-view/src/display/signature.rs
@@ -4,13 +4,14 @@
 //! stores instead of trying to reconstruct rustc-perfect signatures.
 
 use rg_body_ir::BindingData;
+use rg_ir_model::Mutability;
 use rg_ir_model::hir::items::{
     ConstData, EnumData, FieldData, FunctionData, StaticData, StructData, TraitData, TypeAliasData,
     UnionData,
 };
 use rg_ir_model::items::{
-    EnumVariantItem, FieldItem, FieldKey, FieldList, FunctionQualifiers, GenericParams, Mutability,
-    ParamItem, TypeBound, TypeRef, VisibilityLevel, WherePredicate,
+    EnumVariantItem, FieldItem, FieldKey, FieldList, FunctionQualifiers, GenericParams, ParamItem,
+    TypeBound, TypeRef, VisibilityLevel, WherePredicate,
 };
 use rg_ty::Ty;
 

--- a/crates/engine/ir-view/src/implementation.rs
+++ b/crates/engine/ir-view/src/implementation.rs
@@ -4,11 +4,11 @@
 //! indexes and body expression facts. This view keeps those storage-shaped queries out of analysis.
 
 use rg_ir_model::{
-    ExprKind, FunctionRef, SemanticItemRef, TargetRef,
+    BodyRef, DefMapRef, ExprKind, FunctionRef, SemanticItemRef, TargetRef, TraitRef, TypeDefRef,
     identity::{DeclarationRef, ExprRef},
 };
-use rg_ir_storage::{ItemStoreQuery, TargetItemQuery};
-use rg_ty::{ImplementationQuery, ItemPathQuery, Ty};
+use rg_ir_storage::{ItemLookupIndex, ItemStoreQuery, TargetItemQuery, UniqueVec};
+use rg_ty::{ImplementationQuery, ItemPathQuery, ReferencePeelingCandidates, Ty};
 
 use crate::{IndexedViewDb, lookup::resolution::ResolutionView};
 
@@ -26,7 +26,7 @@ impl<'a, 'db> ImplementationView<'a, 'db> {
     pub fn method_call_implementations(
         &self,
         expr: ExprRef,
-    ) -> anyhow::Result<Option<Vec<DeclarationRef>>> {
+    ) -> anyhow::Result<Option<UniqueVec<DeclarationRef>>> {
         let body_ref = expr.body_ir();
         let Some(body_data) = self.db.body_ir.body_data(body_ref)? else {
             return Ok(None);
@@ -47,8 +47,10 @@ impl<'a, 'db> ImplementationView<'a, 'db> {
             return Ok(None);
         }
 
-        let implementation_query = self.implementation_query(body_ref.target);
-        let mut implementations = Vec::new();
+        let Some(implementation_query) = self.implementation_query(body_ref.target)? else {
+            return Ok(None);
+        };
+        let mut implementations = UniqueVec::new();
         for declaration in declarations {
             let Some(function) = self.function_ref_for_declaration(declaration)? else {
                 continue;
@@ -56,7 +58,7 @@ impl<'a, 'db> ImplementationView<'a, 'db> {
             for implementation in
                 implementation_query.function_implementations(function, receiver_ty)?
             {
-                Self::push_unique(&mut implementations, DeclarationRef::from(implementation));
+                implementations.push(DeclarationRef::from(implementation));
             }
         }
         Ok(Some(implementations))
@@ -67,36 +69,37 @@ impl<'a, 'db> ImplementationView<'a, 'db> {
         &self,
         use_site: TargetRef,
         declaration: DeclarationRef,
-    ) -> anyhow::Result<Vec<DeclarationRef>> {
-        let implementation_query = self.implementation_query(use_site);
-        let mut implementations = Vec::new();
+    ) -> anyhow::Result<UniqueVec<DeclarationRef>> {
+        let mut implementations = UniqueVec::new();
+        let Some(implementation_query) = self.implementation_query(use_site)? else {
+            return Ok(implementations);
+        };
 
         match declaration {
             DeclarationRef::Item(item) => match item {
                 SemanticItemRef::TypeDef(ty) => {
-                    for implementation in implementation_query.impls_for_type_def(ty)? {
-                        Self::push_unique(
+                    if let DefMapRef::Body(body_ref) = ty.origin {
+                        self.push_body_local_impls_for_type_def(
                             &mut implementations,
-                            DeclarationRef::from(implementation),
-                        );
+                            body_ref,
+                            ty,
+                        )?;
+                    }
+                    for implementation in implementation_query.impls_for_type_def(ty)? {
+                        implementations.push(DeclarationRef::from(implementation));
                     }
                 }
                 SemanticItemRef::Trait(trait_ref) => {
+                    self.push_body_local_impls_for_trait(&mut implementations, trait_ref)?;
                     for implementation in implementation_query.impls_for_trait(trait_ref)? {
-                        Self::push_unique(
-                            &mut implementations,
-                            DeclarationRef::from(implementation),
-                        );
+                        implementations.push(DeclarationRef::from(implementation));
                     }
                 }
                 SemanticItemRef::Function(function) => {
                     for implementation in
                         implementation_query.function_implementations(function, None)?
                     {
-                        Self::push_unique(
-                            &mut implementations,
-                            DeclarationRef::from(implementation),
-                        );
+                        implementations.push(DeclarationRef::from(implementation));
                     }
                 }
                 SemanticItemRef::Impl(_)
@@ -113,7 +116,7 @@ impl<'a, 'db> ImplementationView<'a, 'db> {
                 for implementation in
                     implementation_query.function_implementations(function, None)?
                 {
-                    Self::push_unique(&mut implementations, DeclarationRef::from(implementation));
+                    implementations.push(DeclarationRef::from(implementation));
                 }
             }
             DeclarationRef::BodyBinding(binding) => {
@@ -123,8 +126,9 @@ impl<'a, 'db> ImplementationView<'a, 'db> {
                 let Some(binding_ty) = body.binding_ty(binding.binding) else {
                     return Ok(implementations);
                 };
+                self.push_body_local_impls_for_ty(&mut implementations, binding.body, binding_ty)?;
                 for implementation in implementation_query.impls_for_ty(binding_ty)? {
-                    Self::push_unique(&mut implementations, DeclarationRef::from(implementation));
+                    implementations.push(DeclarationRef::from(implementation));
                 }
             }
             DeclarationRef::Module(_)
@@ -140,24 +144,95 @@ impl<'a, 'db> ImplementationView<'a, 'db> {
         &self,
         use_site: TargetRef,
         ty: &Ty,
-    ) -> anyhow::Result<Vec<DeclarationRef>> {
-        let implementation_query = self.implementation_query(use_site);
-        let mut implementations = Vec::new();
+    ) -> anyhow::Result<UniqueVec<DeclarationRef>> {
+        let mut implementations = UniqueVec::new();
+        let Some(implementation_query) = self.implementation_query(use_site)? else {
+            return Ok(implementations);
+        };
         for implementation in implementation_query.impls_for_ty(ty)? {
-            Self::push_unique(&mut implementations, DeclarationRef::from(implementation));
+            implementations.push(DeclarationRef::from(implementation));
         }
         Ok(implementations)
+    }
+
+    /// Add impls declared in the same body item store as the selected local type.
+    fn push_body_local_impls_for_type_def(
+        &self,
+        implementations: &mut UniqueVec<DeclarationRef>,
+        body_ref: BodyRef,
+        ty: TypeDefRef,
+    ) -> anyhow::Result<()> {
+        let Some(store) = self.db.body_ir.body_item_store(body_ref)? else {
+            return Ok(());
+        };
+
+        for (impl_ref, impl_data) in store.impls_with_refs() {
+            if impl_data.resolved_self_ty.is(&ty) {
+                implementations.push(DeclarationRef::from(impl_ref));
+            }
+        }
+        Ok(())
+    }
+
+    /// Add impls from the body that owns a binding whose type is being inspected.
+    fn push_body_local_impls_for_ty(
+        &self,
+        implementations: &mut UniqueVec<DeclarationRef>,
+        body_ref: BodyRef,
+        ty: &Ty,
+    ) -> anyhow::Result<()> {
+        for candidate in ReferencePeelingCandidates::new(ty) {
+            for nominal in candidate.ty().as_nominals() {
+                self.push_body_local_impls_for_type_def(implementations, body_ref, nominal.def)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Add impls declared next to a body-local trait.
+    fn push_body_local_impls_for_trait(
+        &self,
+        implementations: &mut UniqueVec<DeclarationRef>,
+        trait_ref: TraitRef,
+    ) -> anyhow::Result<()> {
+        let DefMapRef::Body(body_ref) = trait_ref.origin else {
+            return Ok(());
+        };
+        let Some(store) = self.db.body_ir.body_item_store(body_ref)? else {
+            return Ok(());
+        };
+
+        for (impl_ref, impl_data) in store.impls_with_refs() {
+            if impl_data.resolved_trait_ref.is(&trait_ref) {
+                implementations.push(DeclarationRef::from(impl_ref));
+            }
+        }
+        Ok(())
     }
 
     /// Build the lower implementation query for one target.
     fn implementation_query(
         &self,
         use_site: TargetRef,
-    ) -> ImplementationQuery<'_, &IndexedViewDb<'_>, &IndexedViewDb<'_>> {
-        ImplementationQuery::new(
+    ) -> anyhow::Result<Option<ImplementationQuery<'_, &IndexedViewDb<'_>, &IndexedViewDb<'_>>>>
+    {
+        let Some(semantic_index) = self.semantic_index(use_site)? else {
+            return Ok(None);
+        };
+        Ok(Some(ImplementationQuery::with_index(
             ItemPathQuery::new(self.db, self.db),
             TargetItemQuery::new(self.db, self.db, use_site),
-        )
+            semantic_index,
+        )))
+    }
+
+    /// Return the target-scoped semantic index that backs fast type/member queries.
+    fn semantic_index(&self, use_site: TargetRef) -> anyhow::Result<Option<&ItemLookupIndex>> {
+        Ok(self
+            .db
+            .body_ir
+            .target_bodies(use_site)?
+            .map(|target_bodies| target_bodies.semantic_index()))
     }
 
     /// Extract a function ref from a declaration when it denotes a function.
@@ -178,13 +253,6 @@ impl<'a, 'db> ImplementationView<'a, 'db> {
             | DeclarationRef::Field(_)
             | DeclarationRef::EnumVariant(_)
             | DeclarationRef::BodyBinding(_) => Ok(None),
-        }
-    }
-
-    /// Push a declaration once, preserving discovery order.
-    fn push_unique(declarations: &mut Vec<DeclarationRef>, declaration: DeclarationRef) {
-        if !declarations.contains(&declaration) {
-            declarations.push(declaration);
         }
     }
 }

--- a/crates/engine/ir-view/src/member.rs
+++ b/crates/engine/ir-view/src/member.rs
@@ -12,7 +12,7 @@ use rg_ir_model::{
     TypePathResolution,
     hir::items::{EnumVariantData, FieldData, FunctionData},
 };
-use rg_ir_storage::{ItemStoreQuery, TargetItemQuery};
+use rg_ir_storage::{ItemLookupIndex, ItemStoreQuery, TargetItemQuery};
 use rg_ty::MemberMethodOrigin;
 use rg_ty::{ItemPathQuery, MemberMethodCandidateRef, MemberQuery, Ty};
 
@@ -171,9 +171,13 @@ impl<'a, 'db> MemberView<'a, 'db> {
         ty: &Ty,
     ) -> anyhow::Result<Vec<MemberField<'view>>> {
         let mut fields = Vec::new();
-        let member_query = MemberQuery::new(
+        let Some(semantic_index) = self.semantic_index(use_site)? else {
+            return Ok(fields);
+        };
+        let member_query = MemberQuery::with_index(
             ItemPathQuery::new(self.db, self.db),
             TargetItemQuery::new(self.db, self.db, use_site),
+            semantic_index,
         );
         for field_ref in member_query.fields_for_ty(ty)? {
             let Some(field) = self.field(field_ref)? else {
@@ -198,9 +202,13 @@ impl<'a, 'db> MemberView<'a, 'db> {
         };
 
         let mut fields = Vec::new();
-        let member_query = MemberQuery::new(
+        let Some(semantic_index) = self.semantic_index(body.target)? else {
+            return Ok(fields);
+        };
+        let member_query = MemberQuery::with_index(
             ItemPathQuery::new(self.db, self.db),
             TargetItemQuery::new(self.db, self.db, body.target),
+            semantic_index,
         );
         if let TypePathResolution::SelfType(ty) | TypePathResolution::TypeDef(ty) = resolution {
             for field_ref in member_query.fields_for_type_def(ty)? {
@@ -299,9 +307,13 @@ impl<'a, 'db> MemberView<'a, 'db> {
         use_site: TargetRef,
         ty: &Ty,
     ) -> anyhow::Result<Vec<MemberMethodCandidateRef>> {
-        let member_query = MemberQuery::new(
+        let Some(semantic_index) = self.semantic_index(use_site)? else {
+            return Ok(Vec::new());
+        };
+        let member_query = MemberQuery::with_index(
             ItemPathQuery::new(self.db, self.db),
             TargetItemQuery::new(self.db, self.db, use_site),
+            semantic_index,
         );
         Ok(member_query.method_candidates_for_ty(ty)?)
     }
@@ -347,5 +359,14 @@ impl<'a, 'db> MemberView<'a, 'db> {
             function,
             origin: candidate.origin(),
         }
+    }
+
+    /// Return the target-scoped semantic index that backs fast type/member queries.
+    fn semantic_index(&self, use_site: TargetRef) -> anyhow::Result<Option<&ItemLookupIndex>> {
+        Ok(self
+            .db
+            .body_ir
+            .target_bodies(use_site)?
+            .map(|target_bodies| target_bodies.semantic_index()))
     }
 }

--- a/crates/engine/item-tree/src/body/mod.rs
+++ b/crates/engine/item-tree/src/body/mod.rs
@@ -5,7 +5,7 @@
 
 use rg_ir_model::{
     ClosureCapture, ClosureKind, ExprAssignOp, ExprBinaryOp, ExprRangeKind, ExprUnaryOp,
-    PatBindingMode, PatMutability, PatRangeKind, RecordFieldSyntax,
+    PatBindingMode, PatRangeKind, RecordFieldSyntax,
 };
 use rg_syntax::ast;
 
@@ -138,19 +138,6 @@ impl FromAst for PatBindingMode {
         Self {
             by_ref: pat.ref_token().is_some(),
             mutable: pat.mut_token().is_some(),
-        }
-    }
-}
-
-impl FromAst for PatMutability {
-    type AstNode = ast::RefPat;
-    type Context<'a> = ();
-
-    fn from_ast(pat: &Self::AstNode, (): Self::Context<'_>) -> Self {
-        if pat.mut_token().is_some() {
-            Self::Mut
-        } else {
-            Self::Shared
         }
     }
 }

--- a/crates/engine/item-tree/src/item/decl.rs
+++ b/crates/engine/item-tree/src/item/decl.rs
@@ -1,8 +1,11 @@
-use rg_ir_model::items::{
-    ConstItem, ConstParamData, Documentation, EnumItem, EnumVariantItem, FieldItem, FieldKey,
-    FieldList, FunctionItem, FunctionQualifiers, GenericParams, ImplItem, ItemTreeId,
-    LifetimeParamData, Mutability, ParamItem, ParamKind, StaticItem, StructItem, TraitItem,
-    TypeAliasItem, TypeParamData, TypeRef, UnionItem, VisibilityLevel, WherePredicate,
+use rg_ir_model::{
+    Mutability,
+    items::{
+        ConstItem, ConstParamData, Documentation, EnumItem, EnumVariantItem, FieldItem, FieldKey,
+        FieldList, FunctionItem, FunctionQualifiers, GenericParams, ImplItem, ItemTreeId,
+        LifetimeParamData, ParamItem, ParamKind, StaticItem, StructItem, TraitItem, TypeAliasItem,
+        TypeParamData, TypeRef, UnionItem, VisibilityLevel, WherePredicate,
+    },
 };
 use rg_parse::{LineIndex, Span};
 use rg_syntax::{

--- a/crates/engine/item-tree/src/item/type_ref.rs
+++ b/crates/engine/item-tree/src/item/type_ref.rs
@@ -1,4 +1,7 @@
-use rg_ir_model::items::{GenericArg, Mutability, TypeBound, TypePath, TypePathSegment, TypeRef};
+use rg_ir_model::{
+    Mutability,
+    items::{GenericArg, TypeBound, TypePath, TypePathSegment, TypeRef},
+};
 use rg_parse::{LineIndex, Span};
 use rg_syntax::{
     AstNode as _,

--- a/crates/engine/item-tree/src/lib.rs
+++ b/crates/engine/item-tree/src/lib.rs
@@ -20,12 +20,13 @@ pub use self::{
         ImplItemContext, ImportAlias, InnerDocs, ItemKind, ItemNode, ItemTag, ItemTreeId,
         ItemTreeRef, MacroCallContext, MacroCallItem, MacroDefAst, MacroDefContext,
         MacroDefinitionAttrs, MacroDefinitionItem, MacroRulesAst, MacroRulesContext, MacroUseAttr,
-        MacroUseSelector, MaybeFromAst, ModuleItem, ModuleSource, Mutability, OuterDocs, ParamItem,
-        ParamKind, StaticItem, StructItem, TraitItem, TraitItemContext, TypeAliasItem, TypeBound,
-        TypePath, TypePathSegment, TypeRef, UnionItem, UseImport, UseImportKind, UseItem, UsePath,
+        MacroUseSelector, MaybeFromAst, ModuleItem, ModuleSource, OuterDocs, ParamItem, ParamKind,
+        StaticItem, StructItem, TraitItem, TraitItemContext, TypeAliasItem, TypeBound, TypePath,
+        TypePathSegment, TypeRef, UnionItem, UseImport, UseImportKind, UseItem, UsePath,
         UsePathSegment, UsePathSegmentKind, VisibilityLevel, WherePredicate,
     },
     package::{FileTree, Package, TargetRoot},
 };
 pub use rg_cfg_eval::{CfgExpr, CfgGate, CfgPredicate};
+pub use rg_ir_model::Mutability;
 pub use rg_text::{Name, PackageNameInterners};

--- a/crates/engine/project/src/cache/header.rs
+++ b/crates/engine/project/src/cache/header.rs
@@ -11,7 +11,7 @@ use super::{cached::CachedPackage, fingerprint::Fingerprint};
 
 /// Current on-disk package artifact schema.
 pub const CURRENT_PACKAGE_CACHE_SCHEMA_VERSION: PackageCacheSchemaVersion =
-    PackageCacheSchemaVersion(2);
+    PackageCacheSchemaVersion(3);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SchemaRead, SchemaWrite, MemorySize)]
 #[memsize(leaf)]

--- a/crates/engine/project/src/cache/tests/mod.rs
+++ b/crates/engine/project/src/cache/tests/mod.rs
@@ -88,7 +88,7 @@ pub struct DevHelper;
             workspace cache plan
 
             package #0 app
-            schema 2
+            schema 3
             id path+file://./#app@0.1.0
             source workspace
             edition 2024
@@ -105,7 +105,7 @@ pub struct DevHelper;
             - dev_support -> dev-helper (#3) [dev]
 
             package #1 build-helper
-            schema 2
+            schema 3
             id path+file://./build-helper#0.1.0
             source path
             edition 2021
@@ -116,7 +116,7 @@ pub struct DevHelper;
             - <none>
 
             package #2 dep-pkg
-            schema 2
+            schema 3
             id path+file://./dep#dep-pkg@0.1.0
             source path
             edition 2021
@@ -127,7 +127,7 @@ pub struct DevHelper;
             - <none>
 
             package #3 dev-helper
-            schema 2
+            schema 3
             id path+file://./dev-helper#0.1.0
             source path
             edition 2018
@@ -216,7 +216,7 @@ fn package_slot(workspace: &WorkspaceMetadata, package_name: &str) -> PackageSlo
 fn roundtrips_package_cache_header_codec() {
     utils::check_cache_header_codec(expect![[r#"
         encoded header bytes 315
-        0200000007000000000000002000000000000000706174682b66696c653a2f2f
+        0300000007000000000000002000000000000000706174682b66696c653a2f2f
         2f776f726b73706163652361707040302e312e30030000000000000061707000
         0000000300000015000000000000002f776f726b73706163652f436172676f2e
         746f6d6c00000000000000000000000000000000020000000000000003000000
@@ -228,7 +228,7 @@ fn roundtrips_package_cache_header_codec() {
         070707070707070707070707070707070707070707070707070707
 
         decoded header
-        schema 2
+        schema 3
         source fingerprint 0707070707070707070707070707070707070707070707070707070707070707
         package #7 app
         id path+file:///workspace#app@0.1.0
@@ -247,7 +247,7 @@ fn roundtrips_package_cache_header_codec() {
 fn roundtrips_minimal_package_cache_artifact_codec() {
     utils::check_minimal_cache_artifact_codec(expect![[r#"
         encoded artifact has bytes true
-        0200000007000000000000002200000000000000706174682b66696c653a2f2f
+        0300000007000000000000002200000000000000706174682b66696c653a2f2f
         2f776f726b737061636523656d70747940302e312e3000000000000000000000
         00000300000015000000000000002f776f726b73706163652f436172676f2e74
         6f6d6c0000000000000000000000000000000000000000000000000000000000
@@ -257,7 +257,7 @@ fn roundtrips_minimal_package_cache_artifact_codec() {
         000000
 
         decoded artifact
-        schema 2
+        schema 3
         source fingerprint 0707070707070707070707070707070707070707070707070707070707070707
         package #7 
         header targets 0
@@ -285,7 +285,7 @@ pub struct App;
         expect![[r#"
             encoded artifact has bytes true
             decoded artifact
-            schema 2
+            schema 3
             source fingerprint 5cb07c1684eeeb2c51a750cf465c7cd8f62d74e2e1dbdace0df9b4481058d206
             package #0 app
             header targets 1

--- a/crates/engine/ty/src/autoderef.rs
+++ b/crates/engine/ty/src/autoderef.rs
@@ -18,7 +18,7 @@ const AUTODEREF_LIMIT: usize = 8;
 pub struct Autoderef<'query, D, I> {
     item_paths: ItemPathQuery<'query, D, I>,
     target_items: TargetItemQuery<'query, D, I>,
-    lookup_index: Option<&'query ItemLookupIndex>,
+    lookup_index: &'query ItemLookupIndex,
 }
 
 impl<'query, D, I> Autoderef<'query, D, I>
@@ -26,19 +26,7 @@ where
     D: DefMapSource + Clone,
     I: ItemStoreSource<'query, Error = D::Error> + Clone,
 {
-    /// Creates an autoderef engine without a precomputed lookup index.
-    pub fn new(
-        item_paths: ItemPathQuery<'query, D, I>,
-        target_items: TargetItemQuery<'query, D, I>,
-    ) -> Self {
-        Self {
-            item_paths,
-            target_items,
-            lookup_index: None,
-        }
-    }
-
-    /// Creates an autoderef engine that can reuse a receiver lookup index.
+    /// Creates an autoderef engine over a target-scoped receiver lookup index.
     pub fn with_index(
         item_paths: ItemPathQuery<'query, D, I>,
         target_items: TargetItemQuery<'query, D, I>,
@@ -47,7 +35,7 @@ where
         Self {
             item_paths,
             target_items,
-            lookup_index: Some(lookup_index),
+            lookup_index,
         }
     }
 

--- a/crates/engine/ty/src/autoderef.rs
+++ b/crates/engine/ty/src/autoderef.rs
@@ -8,7 +8,7 @@ use std::{borrow::Cow, collections::VecDeque};
 
 use rg_ir_storage::{DefMapSource, ItemLookupIndex, ItemStoreSource, TargetItemQuery};
 
-use crate::{ItemPathQuery, RefMutability, Ty, deref::DerefResolver};
+use crate::{ItemPathQuery, Mutability, Ty, deref::DerefResolver};
 use rg_std::UniqueVec;
 
 const AUTODEREF_LIMIT: usize = 8;
@@ -122,7 +122,7 @@ impl AutoderefMode {
 pub struct AutoderefCandidate<'ty> {
     ty: Cow<'ty, Ty>,
     depth: usize,
-    mutability: Option<RefMutability>,
+    mutability: Option<Mutability>,
 }
 
 impl<'ty> AutoderefCandidate<'ty> {
@@ -137,7 +137,7 @@ impl<'ty> AutoderefCandidate<'ty> {
     }
 
     /// Mutability of the reference dereferenced to reach this candidate.
-    pub fn mutability(&self) -> Option<RefMutability> {
+    pub fn mutability(&self) -> Option<Mutability> {
         self.mutability
     }
 }
@@ -165,7 +165,7 @@ enum AutoderefCandidatesKind<'ty> {
 struct PendingAutoderefCandidate<'ty> {
     ty: PendingAutoderefTy<'ty>,
     depth: usize,
-    mutability: Option<RefMutability>,
+    mutability: Option<Mutability>,
 }
 
 #[derive(Debug, Clone)]
@@ -189,7 +189,7 @@ impl<'ty> PendingAutoderefTy<'ty> {
         }
     }
 
-    fn reference_inner(&self) -> Option<(Self, RefMutability)> {
+    fn reference_inner(&self) -> Option<(Self, Mutability)> {
         match self {
             Self::Borrowed(ty) => ty
                 .reference_inner()
@@ -301,7 +301,7 @@ where
 pub struct ReferencePeelingCandidates<'ty> {
     next_ty: Option<&'ty Ty>,
     next_depth: usize,
-    next_mutability: Option<RefMutability>,
+    next_mutability: Option<Mutability>,
 }
 
 impl<'ty> ReferencePeelingCandidates<'ty> {

--- a/crates/engine/ty/src/call_arg.rs
+++ b/crates/engine/ty/src/call_arg.rs
@@ -1,7 +1,7 @@
 use rg_ir_model::items::{GenericParams, Mutability, ParamItem, TypeRef};
 use rg_text::Name;
 
-use crate::{RefMutability, Ty, TypeSubst};
+use crate::{Ty, TypeSubst};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CallArgMapping {
@@ -156,12 +156,8 @@ impl<'signature, 'arg> CallArgInference<'signature, 'arg> {
         subst.push(name, arg_ty.clone());
     }
 
-    fn ref_mutability_matches(param_mutability: Mutability, arg_mutability: RefMutability) -> bool {
-        matches!(
-            (param_mutability, arg_mutability),
-            (Mutability::Shared, RefMutability::Shared)
-                | (Mutability::Mutable, RefMutability::Mutable)
-        )
+    fn ref_mutability_matches(param_mutability: Mutability, arg_mutability: Mutability) -> bool {
+        param_mutability == arg_mutability
     }
 
     fn ty_is_inferable_arg(ty: &Ty) -> bool {

--- a/crates/engine/ty/src/call_arg.rs
+++ b/crates/engine/ty/src/call_arg.rs
@@ -1,4 +1,7 @@
-use rg_ir_model::items::{GenericParams, Mutability, ParamItem, TypeRef};
+use rg_ir_model::{
+    Mutability,
+    items::{GenericParams, ParamItem, TypeRef},
+};
 use rg_text::Name;
 
 use crate::{Ty, TypeSubst};

--- a/crates/engine/ty/src/deref.rs
+++ b/crates/engine/ty/src/deref.rs
@@ -19,7 +19,7 @@ use crate::{
 pub(crate) struct DerefResolver<'query, D, I> {
     item_paths: ItemPathQuery<'query, D, I>,
     target_items: TargetItemQuery<'query, D, I>,
-    lookup_index: Option<&'query ItemLookupIndex>,
+    lookup_index: &'query ItemLookupIndex,
 }
 
 impl<'query, D, I> DerefResolver<'query, D, I>
@@ -30,7 +30,7 @@ where
     pub(crate) fn new(
         item_paths: ItemPathQuery<'query, D, I>,
         target_items: TargetItemQuery<'query, D, I>,
-        lookup_index: Option<&'query ItemLookupIndex>,
+        lookup_index: &'query ItemLookupIndex,
     ) -> Self {
         Self {
             item_paths,
@@ -60,13 +60,11 @@ where
         let matcher = ImplMatcher::new(self.item_paths.clone(), self.target_items.clone());
         let item_query = self.item_paths.items();
         let mut targets = UniqueVec::new();
-        let trait_impls = match self.lookup_index {
-            Some(index) => index
-                .trait_impls_for_type(receiver_ty.def)
-                .cloned()
-                .unwrap_or_default(),
-            None => self.target_items.trait_impls_for_type(receiver_ty.def)?,
-        };
+        let trait_impls = self
+            .lookup_index
+            .trait_impls_for_type(receiver_ty.def)
+            .cloned()
+            .unwrap_or_default();
 
         for trait_impl in trait_impls {
             let Some(impl_data) = item_query.impl_data(trait_impl.impl_ref)? else {

--- a/crates/engine/ty/src/impl_match/projection.rs
+++ b/crates/engine/ty/src/impl_match/projection.rs
@@ -5,8 +5,8 @@
 
 use crate::{GenericArg, NominalTy, Ty, TypeSubst};
 use rg_ir_model::hir::items::ImplData;
-use rg_ir_model::items::{GenericArg as ItemGenericArg, Mutability, TypePath, TypeRef};
-use rg_ir_model::{ImplRef, Path, TraitImplRef, TypePathResolution};
+use rg_ir_model::items::{GenericArg as ItemGenericArg, TypePath, TypeRef};
+use rg_ir_model::{ImplRef, Mutability, Path, TraitImplRef, TypePathResolution};
 use rg_ir_storage::{DefMapSource, ItemStoreSource, TypePathContext};
 use rg_text::Name;
 

--- a/crates/engine/ty/src/impl_match/projection.rs
+++ b/crates/engine/ty/src/impl_match/projection.rs
@@ -3,7 +3,7 @@
 //! `Deref`, structural inherent lookup, and associated-type projection all affect real type facts.
 //! This module therefore rejects uncertain headers instead of returning maybe-applicable matches.
 
-use crate::{GenericArg, NominalTy, RefMutability, Ty, TypeSubst};
+use crate::{GenericArg, NominalTy, Ty, TypeSubst};
 use rg_ir_model::hir::items::ImplData;
 use rg_ir_model::items::{GenericArg as ItemGenericArg, Mutability, TypePath, TypeRef};
 use rg_ir_model::{ImplRef, Path, TraitImplRef, TypePathResolution};
@@ -544,13 +544,9 @@ where
 
     fn ref_mutability_matches(
         impl_mutability: Mutability,
-        receiver_mutability: RefMutability,
+        receiver_mutability: Mutability,
     ) -> bool {
-        matches!(
-            (impl_mutability, receiver_mutability),
-            (Mutability::Shared, RefMutability::Shared)
-                | (Mutability::Mutable, RefMutability::Mutable)
-        )
+        impl_mutability == receiver_mutability
     }
 
     fn array_len_matches(

--- a/crates/engine/ty/src/impl_match/trait_methods.rs
+++ b/crates/engine/ty/src/impl_match/trait_methods.rs
@@ -57,22 +57,16 @@ where
     }
 
     /// Returns trait-associated function candidates for a nominal receiver.
-    ///
-    /// The optional index lets hot method lookup reuse a precomputed receiver cache. Without it,
-    /// the query falls back to direct item-store scans through the same provider.
     pub fn trait_function_candidates_for_receiver(
         &self,
-        index: Option<&ItemLookupIndex>,
+        index: &ItemLookupIndex,
         receiver_ty: &NominalTy,
         method_name: Option<&str>,
     ) -> Result<Vec<(FunctionRef, TraitApplicability)>, D::Error> {
-        let trait_impls = match index {
-            Some(index) => index
-                .trait_impls_for_type(receiver_ty.def)
-                .cloned()
-                .unwrap_or_default(),
-            None => self.target_items.trait_impls_for_type(receiver_ty.def)?,
-        };
+        let trait_impls = index
+            .trait_impls_for_type(receiver_ty.def)
+            .cloned()
+            .unwrap_or_default();
         self.trait_function_candidates_from_impls(index, trait_impls, receiver_ty, method_name)
     }
 
@@ -82,7 +76,7 @@ where
     /// this method owns only receiver applicability and trait-associated function expansion.
     pub fn trait_function_candidates_from_impls(
         &self,
-        index: Option<&ItemLookupIndex>,
+        index: &ItemLookupIndex,
         trait_impls: UniqueVec<TraitImplRef>,
         receiver_ty: &NominalTy,
         method_name: Option<&str>,
@@ -94,7 +88,7 @@ where
             // If the indexed trait has no function with that name, this impl cannot contribute a
             // candidate regardless of how well the impl header matches the receiver.
             let mut indexed_trait_functions = None;
-            if let (Some(index), Some(method_name)) = (index, method_name)
+            if let Some(method_name) = method_name
                 && let Some(indexed_functions) =
                     index.trait_functions_by_name(trait_impl.trait_ref, method_name)
             {
@@ -111,17 +105,13 @@ where
 
             let trait_functions = if let Some(functions) = indexed_trait_functions {
                 functions
+            } else if let Some(functions) = index.trait_functions(trait_impl.trait_ref) {
+                functions.clone()
             } else {
-                let trait_functions = if let Some(index) = index
-                    && let Some(functions) = index.trait_functions(trait_impl.trait_ref)
-                {
-                    functions.clone()
-                } else {
-                    item_query
-                        .trait_data(trait_impl.trait_ref)?
-                        .map(|t| t.functions().collect())
-                        .unwrap_or_default()
-                };
+                let trait_functions = item_query
+                    .trait_data(trait_impl.trait_ref)?
+                    .map(|t| t.functions().collect())
+                    .unwrap_or_default();
 
                 // The direct item-store fallback cannot skip the impl check up front, but it can
                 // still avoid returning unrelated trait functions to the later method-call filter.

--- a/crates/engine/ty/src/implementation.rs
+++ b/crates/engine/ty/src/implementation.rs
@@ -5,7 +5,7 @@
 //! declaration shape that UI-facing analysis expects.
 
 use rg_ir_model::{AssocItemId, FunctionRef, ImplRef, ItemOwner, TraitRef, TypeDefRef};
-use rg_ir_storage::{DefMapSource, ItemStoreSource, TargetItemQuery};
+use rg_ir_storage::{DefMapSource, ItemLookupIndex, ItemStoreSource, TargetItemQuery};
 use rg_std::UniqueVec;
 
 use crate::{Autoderef, AutoderefMode, ImplMatcher, ItemPathQuery, ReferencePeelingCandidates, Ty};
@@ -14,6 +14,7 @@ use crate::{Autoderef, AutoderefMode, ImplMatcher, ItemPathQuery, ReferencePeeli
 pub struct ImplementationQuery<'query, D, I> {
     item_paths: ItemPathQuery<'query, D, I>,
     target_items: TargetItemQuery<'query, D, I>,
+    lookup_index: &'query ItemLookupIndex,
 }
 
 impl<'query, D, I> ImplementationQuery<'query, D, I>
@@ -21,13 +22,16 @@ where
     D: DefMapSource + Clone,
     I: ItemStoreSource<'query, Error = D::Error> + Clone,
 {
-    pub fn new(
+    /// Creates an implementation query over a target-scoped receiver lookup index.
+    pub fn with_index(
         item_paths: ItemPathQuery<'query, D, I>,
         target_items: TargetItemQuery<'query, D, I>,
+        lookup_index: &'query ItemLookupIndex,
     ) -> Self {
         Self {
             item_paths,
             target_items,
+            lookup_index,
         }
     }
 
@@ -46,12 +50,12 @@ where
 
     /// Returns impl blocks whose resolved self type mentions this nominal type definition.
     pub fn impls_for_type_def(&self, ty: TypeDefRef) -> Result<UniqueVec<ImplRef>, D::Error> {
-        self.target_items.impls_for_type(ty)
+        Ok(self.lookup_index.impls_for_type(ty))
     }
 
     /// Returns impl blocks that resolve to the requested trait.
     pub fn impls_for_trait(&self, trait_ref: TraitRef) -> Result<UniqueVec<ImplRef>, D::Error> {
-        self.target_items.impls_for_trait(trait_ref)
+        Ok(self.lookup_index.impls_for_trait(trait_ref))
     }
 
     /// Returns concrete functions that implement or correspond to the selected function.
@@ -102,14 +106,23 @@ where
         method_name: &str,
         receiver_ty: &Ty,
     ) -> Result<UniqueVec<FunctionRef>, D::Error> {
-        let autoderef = Autoderef::new(self.item_paths.clone(), self.target_items.clone());
+        let autoderef = Autoderef::with_index(
+            self.item_paths.clone(),
+            self.target_items.clone(),
+            self.lookup_index,
+        );
         let matcher = ImplMatcher::new(self.item_paths.clone(), self.target_items.clone());
         let mut functions = UniqueVec::new();
 
         for candidate in autoderef.candidates(AutoderefMode::MethodReceiver, receiver_ty) {
             let candidate = candidate?;
             for ty in candidate.ty().as_nominals() {
-                for trait_impl in self.target_items.trait_impls_for_type(ty.def)? {
+                let trait_impls = self
+                    .lookup_index
+                    .trait_impls_for_type(ty.def)
+                    .cloned()
+                    .unwrap_or_default();
+                for trait_impl in trait_impls {
                     if trait_impl.trait_ref != trait_ref {
                         continue;
                     }

--- a/crates/engine/ty/src/inference/model.rs
+++ b/crates/engine/ty/src/inference/model.rs
@@ -5,7 +5,7 @@ use rg_text::Name;
 
 use super::family::{PlainTyToInferMapper, TyToInferMapper};
 use super::table::{InferVarId, InferVarKind};
-use crate::{GenericArg, PrimitiveTy, RefMutability, Ty};
+use crate::{GenericArg, Mutability, PrimitiveTy, Ty};
 
 /// Inference-aware mirror of `Ty`.
 ///
@@ -28,7 +28,7 @@ pub enum InferTy {
     },
     Slice(Box<InferTy>),
     Reference {
-        mutability: RefMutability,
+        mutability: Mutability,
         inner: Box<InferTy>,
     },
     Opaque {

--- a/crates/engine/ty/src/inference/subst.rs
+++ b/crates/engine/ty/src/inference/subst.rs
@@ -3,9 +3,7 @@
 //! This is the `InferTy` mirror of ordinary `TypeSubst` use: bind declared type params from
 //! inference evidence, then project another type ref while preserving `?T` slots.
 
-use rg_ir_model::items::{
-    GenericArg as ItemGenericArg, GenericParams, Mutability, TypePath, TypeRef,
-};
+use rg_ir_model::items::{GenericArg as ItemGenericArg, GenericParams, TypePath, TypeRef};
 use rg_text::Name;
 
 use super::{
@@ -13,7 +11,7 @@ use super::{
     model::{InferGenericArg, InferTy},
     table::{InferenceConflict, InferenceTable},
 };
-use crate::{RefMutability, Ty};
+use crate::Ty;
 
 /// Substitution from declared type params to inference-aware types.
 ///
@@ -112,7 +110,7 @@ impl InferTypeSubst {
                     mutability: evidence_mutability,
                     inner: evidence_inner,
                 },
-            ) if Self::ref_mutability(*mutability) == *evidence_mutability => {
+            ) if *mutability == *evidence_mutability => {
                 self.bind_type_ref(table, pattern_inner, evidence_inner, generics);
             }
             (TypeRef::Path(path), InferTy::Nominal(evidence_ty) | InferTy::SelfTy(evidence_ty)) => {
@@ -211,14 +209,6 @@ impl InferTypeSubst {
                 self.bind_type_ref(table, pattern_ty, evidence_ty, generics);
             }
             _ => {}
-        }
-    }
-
-    /// Convert syntax mutability into the type-layer reference mutability.
-    fn ref_mutability(mutability: Mutability) -> RefMutability {
-        match mutability {
-            Mutability::Shared => RefMutability::Shared,
-            Mutability::Mutable => RefMutability::Mutable,
         }
     }
 }

--- a/crates/engine/ty/src/item_path.rs
+++ b/crates/engine/ty/src/item_path.rs
@@ -4,14 +4,14 @@
 //! answers "which semantic item does this local definition lower to?". Type algorithms use this
 //! query to stay independent from the concrete target/body storage that provided those answers.
 
-use rg_ir_model::items::{GenericArg as ItemGenericArg, Mutability, TypeBound, TypePath, TypeRef};
+use rg_ir_model::items::{GenericArg as ItemGenericArg, TypeBound, TypePath, TypeRef};
 use rg_ir_model::{
     DefId, ModuleRef, Path, SemanticItemRef, TraitRef, TypeDefRef, TypePathResolution,
 };
 use rg_ir_storage::{DefMapQuery, DefMapSource, ItemStoreQuery, ItemStoreSource, TypePathContext};
 use rg_std::{ExpectedUnique, UniqueVec};
 
-use crate::{GenericArg, OpaqueTraitBound, PrimitiveTy, RefMutability, Ty, TypeSubst};
+use crate::{GenericArg, OpaqueTraitBound, PrimitiveTy, Ty, TypeSubst};
 
 /// Resolves paths into semantic-shaped item refs using independent DefMap and ItemStore sources.
 #[derive(Clone)]
@@ -75,10 +75,7 @@ where
             TypeRef::Reference {
                 mutability, inner, ..
             } => Ok(Ty::reference(
-                match mutability {
-                    Mutability::Shared => RefMutability::Shared,
-                    Mutability::Mutable => RefMutability::Mutable,
-                },
+                *mutability,
                 self.resolve_type_ref(inner, context, Ty::syntax((**inner).clone()), subst)?,
             )),
             TypeRef::Unknown(_) | TypeRef::Infer => Ok(Ty::Unknown),

--- a/crates/engine/ty/src/iteration.rs
+++ b/crates/engine/ty/src/iteration.rs
@@ -24,7 +24,7 @@ use crate::{
 pub struct IterationItemResolver<'query, D, I> {
     item_paths: ItemPathQuery<'query, D, I>,
     target_items: TargetItemQuery<'query, D, I>,
-    lookup_index: Option<&'query ItemLookupIndex>,
+    lookup_index: &'query ItemLookupIndex,
 }
 
 impl<'query, D, I> IterationItemResolver<'query, D, I>
@@ -32,18 +32,7 @@ where
     D: DefMapSource + Clone,
     I: ItemStoreSource<'query, Error = D::Error> + Clone,
 {
-    pub fn new(
-        item_paths: ItemPathQuery<'query, D, I>,
-        target_items: TargetItemQuery<'query, D, I>,
-    ) -> Self {
-        Self {
-            item_paths,
-            target_items,
-            lookup_index: None,
-        }
-    }
-
-    /// Creates an iteration resolver that can reuse a target-scoped item lookup index.
+    /// Creates an iteration resolver over a target-scoped item lookup index.
     pub fn with_index(
         item_paths: ItemPathQuery<'query, D, I>,
         target_items: TargetItemQuery<'query, D, I>,
@@ -52,7 +41,7 @@ where
         Self {
             item_paths,
             target_items,
-            lookup_index: Some(lookup_index),
+            lookup_index,
         }
     }
 
@@ -130,18 +119,10 @@ where
     ) -> Result<UniqueVec<TraitImplRef>, D::Error> {
         let mut candidates = UniqueVec::new();
         for trait_ref in canonical_traits {
-            if let Some(indexed_impls) = self
-                .lookup_index
-                .and_then(|index| index.trait_impls_for_trait(*trait_ref))
-            {
+            if let Some(indexed_impls) = self.lookup_index.trait_impls_for_trait(*trait_ref) {
                 for trait_impl in indexed_impls {
                     candidates.push(*trait_impl);
                 }
-                continue;
-            }
-
-            for trait_impl in self.target_items.trait_impls_for_trait(*trait_ref)? {
-                candidates.push(trait_impl);
             }
         }
 
@@ -149,27 +130,19 @@ where
             return Ok(candidates);
         }
 
-        // Some fixture/core-like contexts cannot resolve `::core` from the use-site root. Keep the
-        // older impl-context scan as a rare fallback so the fast path does not narrow semantics.
-        for store in self.target_items.visible_stores()? {
-            for (impl_ref, impl_data) in store.impls_with_refs() {
-                if impl_data.trait_ref.is_none() {
-                    continue;
-                }
-
-                let Some(trait_ref) = impl_data.resolved_trait_ref.as_option() else {
-                    continue;
-                };
-                let trait_impl = TraitImplRef {
-                    impl_ref,
-                    trait_ref: *trait_ref,
-                };
-                if !self.is_canonical_trait_impl(projector, trait_impl, impl_data, trait_kind)? {
-                    continue;
-                }
-
-                candidates.push(trait_impl);
+        // Some fixture/core-like contexts cannot resolve `::core` from the use-site root. Walk the
+        // indexed trait impl candidates as a rare fallback so the fast path does not narrow
+        // semantics, but still avoids re-scanning visible stores.
+        let item_query = self.item_paths.items();
+        for trait_impl in self.lookup_index.trait_impls() {
+            let Some(impl_data) = item_query.impl_data(trait_impl.impl_ref)? else {
+                continue;
+            };
+            if !self.is_canonical_trait_impl(projector, trait_impl, impl_data, trait_kind)? {
+                continue;
             }
+
+            candidates.push(trait_impl);
         }
 
         Ok(candidates)

--- a/crates/engine/ty/src/lib.rs
+++ b/crates/engine/ty/src/lib.rs
@@ -15,7 +15,10 @@ mod primitive_expr;
 mod trait_selection;
 mod ty;
 
-pub use rg_ir_model::items::{FloatTy, Mutability, PrimitiveTy, SignedIntTy, UnsignedIntTy};
+pub use rg_ir_model::{
+    Mutability,
+    items::{FloatTy, PrimitiveTy, SignedIntTy, UnsignedIntTy},
+};
 
 pub use self::{
     autoderef::{

--- a/crates/engine/ty/src/lib.rs
+++ b/crates/engine/ty/src/lib.rs
@@ -15,9 +15,7 @@ mod primitive_expr;
 mod trait_selection;
 mod ty;
 
-pub use rg_ir_model::items::{
-    FloatTy, Mutability as RefMutability, PrimitiveTy, SignedIntTy, UnsignedIntTy,
-};
+pub use rg_ir_model::items::{FloatTy, Mutability, PrimitiveTy, SignedIntTy, UnsignedIntTy};
 
 pub use self::{
     autoderef::{

--- a/crates/engine/ty/src/member.rs
+++ b/crates/engine/ty/src/member.rs
@@ -52,7 +52,7 @@ pub enum MemberMethodOrigin {
 pub struct MemberQuery<'query, D, I> {
     item_paths: ItemPathQuery<'query, D, I>,
     target_items: TargetItemQuery<'query, D, I>,
-    lookup_index: Option<&'query ItemLookupIndex>,
+    lookup_index: &'query ItemLookupIndex,
 }
 
 impl<'query, D, I> MemberQuery<'query, D, I>
@@ -60,19 +60,7 @@ where
     D: DefMapSource + Clone,
     I: ItemStoreSource<'query, Error = D::Error> + Clone,
 {
-    /// Creates a member query that scans the visible item stores directly.
-    pub fn new(
-        item_paths: ItemPathQuery<'query, D, I>,
-        target_items: TargetItemQuery<'query, D, I>,
-    ) -> Self {
-        Self {
-            item_paths,
-            target_items,
-            lookup_index: None,
-        }
-    }
-
-    /// Creates a member query that can reuse a precomputed receiver lookup index.
+    /// Creates a member query over a target-scoped receiver lookup index.
     pub fn with_index(
         item_paths: ItemPathQuery<'query, D, I>,
         target_items: TargetItemQuery<'query, D, I>,
@@ -81,7 +69,7 @@ where
         Self {
             item_paths,
             target_items,
-            lookup_index: Some(lookup_index),
+            lookup_index,
         }
     }
 
@@ -152,22 +140,15 @@ where
         &self,
         receiver_ty: &NominalTy,
     ) -> Result<UniqueVec<FunctionRef>, D::Error> {
-        match self.lookup_index {
-            Some(index) => {
-                index.inherent_functions_for_type(self.item_paths.items(), receiver_ty.def)
-            }
-            None => self
-                .target_items
-                .inherent_functions_for_type(receiver_ty.def),
-        }
+        self.lookup_index
+            .inherent_functions_for_type(self.item_paths.items(), receiver_ty.def)
     }
 
     fn autoderef(&self) -> Autoderef<'query, D, I> {
-        match self.lookup_index {
-            Some(index) => {
-                Autoderef::with_index(self.item_paths.clone(), self.target_items.clone(), index)
-            }
-            None => Autoderef::new(self.item_paths.clone(), self.target_items.clone()),
-        }
+        Autoderef::with_index(
+            self.item_paths.clone(),
+            self.target_items.clone(),
+            self.lookup_index,
+        )
     }
 }

--- a/crates/engine/ty/src/primitive_expr.rs
+++ b/crates/engine/ty/src/primitive_expr.rs
@@ -1,6 +1,6 @@
 use rg_ir_model::{ExprBinaryOp, ExprUnaryOp, LiteralKind};
 
-use crate::{PrimitiveTy, RefMutability, Ty};
+use crate::{Mutability, PrimitiveTy, Ty};
 
 /// Returns the primitive type implied by a lowered literal token.
 pub fn ty_for_literal(kind: LiteralKind) -> Ty {
@@ -10,9 +10,7 @@ pub fn ty_for_literal(kind: LiteralKind) -> Ty {
         LiteralKind::Float { primitive_ty } | LiteralKind::Int { primitive_ty } => {
             primitive_ty.map(Ty::Primitive).unwrap_or(Ty::Unknown)
         }
-        LiteralKind::String => {
-            Ty::reference(RefMutability::Shared, Ty::Primitive(PrimitiveTy::Str))
-        }
+        LiteralKind::String => Ty::reference(Mutability::Shared, Ty::Primitive(PrimitiveTy::Str)),
         LiteralKind::Unknown => Ty::Unknown,
     }
 }
@@ -133,7 +131,7 @@ mod tests {
             ),
             (
                 LiteralKind::String,
-                Ty::reference(RefMutability::Shared, Ty::Primitive(PrimitiveTy::Str)),
+                Ty::reference(Mutability::Shared, Ty::Primitive(PrimitiveTy::Str)),
                 "string literal",
             ),
             (

--- a/crates/engine/ty/src/trait_selection/mod.rs
+++ b/crates/engine/ty/src/trait_selection/mod.rs
@@ -42,7 +42,7 @@ pub struct TraitSelection {
 pub struct TraitSelectionQuery<'query, D, I> {
     item_paths: ItemPathQuery<'query, D, I>,
     target_items: TargetItemQuery<'query, D, I>,
-    lookup_index: Option<&'query ItemLookupIndex>,
+    lookup_index: &'query ItemLookupIndex,
 }
 
 impl<'query, D, I> TraitSelectionQuery<'query, D, I>
@@ -50,17 +50,6 @@ where
     D: DefMapSource<Error = I::Error>,
     I: ItemStoreSource<'query>,
 {
-    pub fn new(
-        item_paths: ItemPathQuery<'query, D, I>,
-        target_items: TargetItemQuery<'query, D, I>,
-    ) -> Self {
-        Self {
-            item_paths,
-            target_items,
-            lookup_index: None,
-        }
-    }
-
     pub fn with_index(
         item_paths: ItemPathQuery<'query, D, I>,
         target_items: TargetItemQuery<'query, D, I>,
@@ -69,7 +58,7 @@ where
         Self {
             item_paths,
             target_items,
-            lookup_index: Some(lookup_index),
+            lookup_index,
         }
     }
 
@@ -130,17 +119,11 @@ where
     }
 
     fn trait_impl_candidates(&self, trait_ref: TraitRef) -> Result<Vec<TraitImplRef>, I::Error> {
-        if let Some(index) = self.lookup_index
-            && let Some(candidates) = index.trait_impls_for_trait(trait_ref)
-        {
-            return Ok(candidates.iter().copied().collect());
-        }
-
         Ok(self
-            .target_items
-            .trait_impls_for_trait(trait_ref)?
-            .into_iter()
-            .collect())
+            .lookup_index
+            .trait_impls_for_trait(trait_ref)
+            .map(|candidates| candidates.iter().copied().collect())
+            .unwrap_or_default())
     }
 
     fn probe_impl(

--- a/crates/engine/ty/src/trait_selection/tests.rs
+++ b/crates/engine/ty/src/trait_selection/tests.rs
@@ -11,7 +11,10 @@ use rg_ir_model::{
     StructId, TargetId, TargetRef, TextSpan, TraitId, TraitImplRef, TraitRef, TypeDefId,
     TypeDefRef,
 };
-use rg_ir_storage::{DefMap, DefMapSource, ItemStore, ItemStoreBuilder, ItemStoreSource};
+use rg_ir_storage::{
+    DefMap, DefMapSource, ItemLookupIndex, ItemStore, ItemStoreBuilder, ItemStoreSource,
+    TargetItemQuery,
+};
 use rg_std::ExpectedUnique;
 use rg_text::Name;
 
@@ -22,6 +25,7 @@ use crate::{GenericArg, ItemPathQuery, NominalTy, Ty};
 struct TraitSelectionFixture {
     store: ItemStore,
     target: TargetRef,
+    lookup_index: ItemLookupIndex,
 }
 
 impl DefMapSource for TraitSelectionFixture {
@@ -216,18 +220,26 @@ fn fixture(impls: Vec<ImplData>) -> TraitSelectionFixture {
     for impl_data in impls {
         builder.impls.alloc(impl_data);
     }
-    TraitSelectionFixture {
+    let mut fixture = TraitSelectionFixture {
         store: builder.build(),
         target: target(),
+        lookup_index: ItemLookupIndex::default(),
+    };
+    {
+        let target_items = TargetItemQuery::new(&fixture, &fixture, fixture.target);
+        fixture.lookup_index =
+            ItemLookupIndex::build_from(&target_items).expect("fixture lookup index should build");
     }
+    fixture
 }
 
 fn query(
     fixture: &TraitSelectionFixture,
 ) -> TraitSelectionQuery<'_, &TraitSelectionFixture, &TraitSelectionFixture> {
-    TraitSelectionQuery::new(
+    TraitSelectionQuery::with_index(
         ItemPathQuery::new(fixture, fixture),
-        rg_ir_storage::TargetItemQuery::new(fixture, fixture, fixture.target),
+        TargetItemQuery::new(fixture, fixture, fixture.target),
+        &fixture.lookup_index,
     )
 }
 

--- a/crates/engine/ty/src/ty.rs
+++ b/crates/engine/ty/src/ty.rs
@@ -3,7 +3,7 @@ use rg_ir_model::{TraitRef, TypeDefRef, TypePathResolution};
 use rg_std::{ExpectedUnique, MemorySize, Shrink, UniqueVec};
 use rg_text::Name;
 
-use crate::{GenericArg, PrimitiveTy, RefMutability};
+use crate::{GenericArg, Mutability, PrimitiveTy};
 use wincode::{SchemaRead, SchemaWrite};
 
 /// Ordered substitutions for type parameters visible at one use site.
@@ -80,7 +80,7 @@ pub enum Ty {
     },
     Slice(#[wincode(with = "rg_wincode_utils::WincodeDynamic<Box<Ty>>")] Box<Ty>),
     Reference {
-        mutability: RefMutability,
+        mutability: Mutability,
         #[wincode(with = "rg_wincode_utils::WincodeDynamic<Box<Ty>>")]
         inner: Box<Ty>,
     },
@@ -139,7 +139,7 @@ impl Ty {
         Self::Slice(Box::new(inner))
     }
 
-    pub fn reference(mutability: RefMutability, inner: Self) -> Self {
+    pub fn reference(mutability: Mutability, inner: Self) -> Self {
         if matches!(inner, Self::Unknown) {
             return Self::Unknown;
         }
@@ -203,7 +203,7 @@ impl Ty {
         }
     }
 
-    pub fn reference_inner(&self) -> Option<(&Self, RefMutability)> {
+    pub fn reference_inner(&self) -> Option<(&Self, Mutability)> {
         match self {
             Self::Reference { mutability, inner } => Some((inner, *mutability)),
             Self::Unit

--- a/crates/lsp/engine/src/dirty_state/overlay.rs
+++ b/crates/lsp/engine/src/dirty_state/overlay.rs
@@ -53,8 +53,7 @@ impl DirtyOverlayCache {
 
             let started = Instant::now();
             let memory_control = self.memory_control.as_ref();
-            let memory_before =
-                MemoryReporter::log_checkpoint(memory_control, "dirty_overlay", "before_rebuild");
+            let memory_before = MemoryReporter::snapshot(memory_control);
             let overlay = base
                 .dirty_overlay([DirtyFileChange::new(dirty.path(), dirty.text().to_string())])
                 .with_context(|| {
@@ -63,7 +62,7 @@ impl DirtyOverlayCache {
                         dirty.path().display()
                     )
                 })?;
-            MemoryReporter::log_checkpoint_delta(
+            MemoryReporter::log_delta_debug(
                 memory_control,
                 "dirty_overlay",
                 "after_rebuild",

--- a/crates/lsp/engine/src/engine/mod.rs
+++ b/crates/lsp/engine/src/engine/mod.rs
@@ -102,21 +102,8 @@ impl EngineHandle {
 
     pub(crate) async fn dirty_document_snapshot(&self, path: &Path) -> DirtyDocumentSnapshotState {
         let documents = self.documents.lock().await;
-        let freshness = documents.freshness(path);
         let dirty = documents.dirty_snapshot(path);
         drop(documents);
-
-        tracing::trace!(
-            path = %path.display(),
-            tracked = freshness.tracked(),
-            version = ?freshness.version(),
-            dirty = freshness.dirty(),
-            saved_len = ?freshness.saved_len(),
-            live_len = ?freshness.live_len(),
-            saved_hash = ?freshness.saved_hash(),
-            live_hash = ?freshness.live_hash(),
-            "checked document freshness"
-        );
 
         match &dirty {
             DirtyDocumentSnapshotState::Dirty(snapshot) => {

--- a/crates/lsp/engine/src/engine/mod.rs
+++ b/crates/lsp/engine/src/engine/mod.rs
@@ -162,7 +162,7 @@ impl EngineHandle {
             "document freshness after failed save reindex"
         );
 
-        let message = format!("failed to process saved file: {error}");
+        let message = format!("failed to process saved file: {error:#}");
         self.notifications.send(ServiceNotification::LogMessage {
             level: ServiceLogLevel::Error,
             message,

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -1363,14 +1363,30 @@ impl EngineWorker {
             .as_ref()
             .err()
             .is_some_and(Project::is_recoverable_cache_load_failure);
-        tracing::debug!(
-            label,
-            queued_ms = queue_elapsed.as_millis(),
-            query_elapsed_ms = query_elapsed.as_millis(),
-            result_ok = result.is_ok(),
-            recoverable_cache_failure = should_recover,
-            "analysis query finished"
-        );
+        match &result {
+            Ok(_) => {
+                tracing::debug!(
+                    label,
+                    queued_ms = queue_elapsed.as_millis(),
+                    query_elapsed_ms = query_elapsed.as_millis(),
+                    result_ok = true,
+                    recoverable_cache_failure = should_recover,
+                    "analysis query finished"
+                );
+            }
+            Err(error) => {
+                let error = format!("{error:#}");
+                tracing::debug!(
+                    label,
+                    queued_ms = queue_elapsed.as_millis(),
+                    query_elapsed_ms = query_elapsed.as_millis(),
+                    result_ok = false,
+                    recoverable_cache_failure = should_recover,
+                    error = %error,
+                    "analysis query finished"
+                );
+            }
+        }
 
         let _ = respond_to.send(result);
 
@@ -1411,6 +1427,7 @@ impl EngineWorker {
                 );
             }
             Err(error) => {
+                let error = format!("{error:#}");
                 tracing::error!(
                     label,
                     error = %error,

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -612,7 +612,7 @@ impl EngineWorker {
                 Ok(locations)
             })?;
 
-        tracing::debug!(
+        tracing::trace!(
             path = %path.display(),
             line = position.line,
             character = position.character,
@@ -666,7 +666,7 @@ impl EngineWorker {
                 Ok(None)
             })?;
 
-        tracing::debug!(
+        tracing::trace!(
             path = %path.display(),
             line = position.line,
             character = position.character,
@@ -734,7 +734,7 @@ impl EngineWorker {
                 rename::workspace_edit(snapshot, edits).map(Some)
             })?;
 
-        tracing::debug!(
+        tracing::trace!(
             path = %path.display(),
             line = position.line,
             character = position.character,
@@ -794,7 +794,7 @@ impl EngineWorker {
                 Ok(highlights)
             })?;
 
-        tracing::debug!(
+        tracing::trace!(
             path = %path.display(),
             line = position.line,
             character = position.character,
@@ -849,7 +849,7 @@ impl EngineWorker {
                 Ok(completions)
             })?;
 
-        tracing::debug!(
+        tracing::trace!(
             path = %path.display(),
             line = position.line,
             character = position.character,
@@ -895,7 +895,7 @@ impl EngineWorker {
                 Ok(None)
             })?;
 
-        tracing::debug!(
+        tracing::trace!(
             path = %path.display(),
             line = position.line,
             character = position.character,
@@ -939,7 +939,7 @@ impl EngineWorker {
                 Ok(lsp_symbols)
             })?;
 
-        tracing::debug!(
+        tracing::trace!(
             path = %path.display(),
             result_count = lsp_symbols.len(),
             elapsed_ms = started.elapsed().as_millis(),
@@ -969,7 +969,7 @@ impl EngineWorker {
         let formatted_text = crate::formatting::rustfmt(text.as_ref(), edition)?;
         let edits = formatting_proto::document_edits(text.as_ref(), formatted_text)?;
 
-        tracing::debug!(
+        tracing::trace!(
             path = %path.display(),
             edition = %edition,
             edit_count = edits.len(),
@@ -1026,7 +1026,7 @@ impl EngineWorker {
                 Ok(lsp_hints)
             })?;
 
-        tracing::debug!(
+        tracing::trace!(
             path = %path.display(),
             result_count = lsp_hints.len(),
             elapsed_ms = started.elapsed().as_millis(),
@@ -1051,7 +1051,7 @@ impl EngineWorker {
             }
         }
 
-        tracing::debug!(
+        tracing::trace!(
             query,
             result_count = lsp_symbols.len(),
             elapsed_ms = started.elapsed().as_millis(),
@@ -1107,7 +1107,7 @@ impl EngineWorker {
                 Ok(locations)
             })?;
 
-        tracing::debug!(
+        tracing::trace!(
             query = query.name(),
             path = %path.display(),
             line = position.line,
@@ -1190,17 +1190,11 @@ impl EngineWorker {
             .iter()
             .map(|context| context.targets.len())
             .sum::<usize>();
-        tracing::debug!(
-            path = %path.display(),
-            context_count = contexts.len(),
-            target_count,
-            "resolved file contexts"
-        );
         tracing::trace!(
             path = %path.display(),
             context_count = contexts.len(),
             target_count,
-            "resolved file contexts for query"
+            "resolved file contexts"
         );
 
         Ok(contexts)
@@ -1334,56 +1328,42 @@ impl EngineWorker {
         // analysis query.
         let label = context.label;
         let queue_elapsed = context.queue_elapsed;
-        tracing::debug!(
+        tracing::trace!(
             label,
             queued_ms = queue_elapsed.as_millis(),
-            "analysis query dequeued"
+            "analysis query started"
         );
         let started = Instant::now();
         let memory_control = Arc::clone(&self.memory_control);
-        let memory_before =
-            MemoryReporter::log_checkpoint(memory_control.as_ref(), label, "query_before");
+        let memory_before = MemoryReporter::snapshot(memory_control.as_ref());
         let result = query(self);
         let query_elapsed = started.elapsed();
-        let memory_after_query = MemoryReporter::log_checkpoint_delta(
-            memory_control.as_ref(),
-            label,
-            "query_after",
-            memory_before,
-        );
         self.project.release_query_memory();
-        MemoryReporter::log_checkpoint_delta(
-            memory_control.as_ref(),
-            label,
-            "query_cleanup_after",
-            memory_after_query,
-        );
-        MemoryReporter::purge_and_report_debug(memory_control.as_ref(), "after analysis query");
+        MemoryReporter::purge_and_report_delta_debug(memory_control.as_ref(), label, memory_before);
         let should_recover = result
             .as_ref()
             .err()
             .is_some_and(Project::is_recoverable_cache_load_failure);
         match &result {
             Ok(_) => {
-                tracing::debug!(
-                    label,
+                tracing::info!(
+                    query = label,
                     queued_ms = queue_elapsed.as_millis(),
-                    query_elapsed_ms = query_elapsed.as_millis(),
-                    result_ok = true,
-                    recoverable_cache_failure = should_recover,
-                    "analysis query finished"
+                    elapsed_ms = query_elapsed.as_millis(),
+                    status = "ok",
+                    "analysis query completed"
                 );
             }
             Err(error) => {
                 let error = format!("{error:#}");
-                tracing::debug!(
-                    label,
+                tracing::warn!(
+                    query = label,
                     queued_ms = queue_elapsed.as_millis(),
-                    query_elapsed_ms = query_elapsed.as_millis(),
-                    result_ok = false,
+                    elapsed_ms = query_elapsed.as_millis(),
+                    status = "error",
                     recoverable_cache_failure = should_recover,
                     error = %error,
-                    "analysis query finished"
+                    "analysis query completed"
                 );
             }
         }

--- a/crates/lsp/engine/src/lib.rs
+++ b/crates/lsp/engine/src/lib.rs
@@ -19,7 +19,7 @@ mod service;
 mod tests;
 
 pub use self::{
-    memory::{AllocatorPurgeResult, AllocatorStats, MemoryControl},
+    memory::{AllocatorStats, MemoryControl},
     rpc::run_rpc,
     service::{Service, ServiceNotificationsSink},
 };

--- a/crates/lsp/engine/src/memory/mod.rs
+++ b/crates/lsp/engine/src/memory/mod.rs
@@ -23,8 +23,9 @@ pub trait MemoryControl: std::fmt::Debug + Send + Sync {
         None
     }
 
-    fn try_purge_allocator(&self) -> Option<AllocatorPurgeResult> {
-        None
+    /// Attempts allocator-specific release work, returning whether a purge path ran.
+    fn try_purge_allocator(&self) -> bool {
+        false
     }
 }
 
@@ -60,13 +61,6 @@ pub struct AllocatorStats {
     pub retained_bytes: usize,
 }
 
-/// Outcome of one allocator purge attempt.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct AllocatorPurgeResult {
-    pub tcache_flushed: bool,
-    pub arenas_purged: bool,
-}
-
 #[derive(Clone, Copy, derive_more::Debug, derive_more::Display)]
 #[display("{:?}", self)]
 pub(crate) struct MemoryStats {
@@ -83,7 +77,7 @@ pub(crate) struct MemoryStats {
 }
 
 impl MemoryStats {
-    pub(crate) fn capture(memory_control: &dyn MemoryControl) -> Self {
+    fn capture(memory_control: &dyn MemoryControl) -> Self {
         let allocator = memory_control.allocator_stats();
         Self {
             allocated: allocator.map(|stats| stats.allocated_bytes),
@@ -95,36 +89,10 @@ impl MemoryStats {
     }
 }
 
-#[derive(Debug, Clone, Copy, derive_more::Display)]
-#[display("{:?}", self)]
-pub(crate) struct MemoryPurge {
-    tcache_flushed: bool,
-    arenas_purged: bool,
-    after: MemoryStats,
-    delta: MemoryDelta,
-}
-
-impl MemoryPurge {
-    pub(crate) fn try_purge(
-        memory_control: &dyn MemoryControl,
-        before: MemoryStats,
-    ) -> Option<Self> {
-        let result = memory_control.try_purge_allocator()?;
-        let after = MemoryStats::capture(memory_control);
-
-        Some(Self {
-            tcache_flushed: result.tcache_flushed,
-            arenas_purged: result.arenas_purged,
-            after,
-            delta: MemoryDelta::between(before, after),
-        })
-    }
-}
-
 /// Difference between two allocator snapshots, formatted for memory logs.
 #[derive(Clone, Copy, derive_more::Debug, derive_more::Display)]
 #[display("{:?}", self)]
-pub(crate) struct MemoryDelta {
+struct MemoryDelta {
     #[debug("{}", format_optional_byte_delta(*allocated))]
     allocated: Option<i64>,
     #[debug("{}", format_optional_byte_delta(*active))]
@@ -138,7 +106,7 @@ pub(crate) struct MemoryDelta {
 }
 
 impl MemoryDelta {
-    pub(crate) fn between(before: MemoryStats, after: MemoryStats) -> Self {
+    fn between(before: MemoryStats, after: MemoryStats) -> Self {
         Self {
             allocated: byte_delta(after.allocated, before.allocated),
             active: byte_delta(after.active, before.active),
@@ -149,28 +117,64 @@ impl MemoryDelta {
     }
 }
 
-pub(crate) fn format_bytes(bytes: usize) -> String {
-    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+#[derive(Clone, Copy)]
+enum ByteFormatStyle {
+    Human,
+    Compact,
+}
 
-    let mut value = bytes as f64;
-    let mut unit = UNITS[0];
-    for next_unit in UNITS.iter().skip(1) {
-        if value < 1024.0 {
-            break;
+impl ByteFormatStyle {
+    fn format_bytes(self, bytes: usize) -> String {
+        const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+
+        let mut value = bytes as f64;
+        let mut unit = UNITS[0];
+        for next_unit in UNITS.iter().skip(1) {
+            if value < 1024.0 {
+                break;
+            }
+            value /= 1024.0;
+            unit = next_unit;
         }
-        value /= 1024.0;
-        unit = next_unit;
+
+        let separator = self.unit_separator();
+        if unit == "B" {
+            format!("{bytes}{separator}{unit}")
+        } else {
+            format!("{value:.1}{separator}{unit}")
+        }
     }
 
-    if unit == "B" {
-        format!("{bytes} B")
-    } else {
-        format!("{value:.1} {unit}")
+    fn format_delta(self, delta: Option<i64>) -> String {
+        let Some(delta) = delta else {
+            return "-".to_string();
+        };
+
+        let prefix = if delta >= 0 { "+" } else { "-" };
+        let bytes = delta.unsigned_abs();
+        let bytes = usize::try_from(bytes)
+            .ok()
+            .map(|bytes| self.format_bytes(bytes));
+        match bytes {
+            Some(bytes) => format!("{prefix}{bytes}"),
+            None => format!("{delta}{}B", self.unit_separator()),
+        }
+    }
+
+    fn unit_separator(self) -> &'static str {
+        match self {
+            Self::Human => " ",
+            Self::Compact => "",
+        }
     }
 }
 
+pub(crate) fn format_bytes(bytes: usize) -> String {
+    ByteFormatStyle::Human.format_bytes(bytes)
+}
+
 fn format_bytes_compact(bytes: usize) -> String {
-    format_bytes(bytes).replace(' ', "")
+    ByteFormatStyle::Compact.format_bytes(bytes)
 }
 
 // Used by `derive_more::Debug` field formatting above; dead-code analysis does not look inside
@@ -190,31 +194,11 @@ fn byte_delta(after: Option<usize>, before: Option<usize>) -> Option<i64> {
 // derive expansion.
 #[allow(dead_code)]
 fn format_optional_byte_delta(delta: Option<i64>) -> String {
-    let Some(delta) = delta else {
-        return "-".to_string();
-    };
-
-    let prefix = if delta >= 0 { "+" } else { "-" };
-    let bytes = delta.unsigned_abs();
-    let bytes = usize::try_from(bytes).ok().map(format_bytes);
-    match bytes {
-        Some(bytes) => format!("{prefix}{bytes}"),
-        None => format!("{delta} B"),
-    }
+    ByteFormatStyle::Human.format_delta(delta)
 }
 
 fn format_optional_memory_delta(delta: Option<i64>) -> String {
-    let Some(delta) = delta else {
-        return "-".to_string();
-    };
-
-    let prefix = if delta >= 0 { "+" } else { "-" };
-    let bytes = delta.unsigned_abs();
-    let bytes = usize::try_from(bytes).ok().map(format_bytes_compact);
-    match bytes {
-        Some(bytes) => format!("{prefix}{bytes}"),
-        None => format!("{delta}B"),
-    }
+    ByteFormatStyle::Compact.format_delta(delta)
 }
 
 fn format_memory_report_field(bytes: Option<usize>, delta: Option<i64>) -> String {
@@ -231,7 +215,14 @@ fn format_memory_report_field(bytes: Option<usize>, delta: Option<i64>) -> Strin
 
 #[cfg(test)]
 mod tests {
-    use super::format_memory_report_field;
+    use super::{format_memory_report_field, format_optional_byte_delta};
+
+    #[test]
+    fn byte_delta_formatting_keeps_human_spacing_for_debug() {
+        assert_eq!(format_optional_byte_delta(Some(1536)), "+1.5 KiB");
+        assert_eq!(format_optional_byte_delta(Some(-1536)), "-1.5 KiB");
+        assert_eq!(format_optional_byte_delta(None), "-");
+    }
 
     #[test]
     fn memory_report_field_is_compact_for_log_rendering() {

--- a/crates/lsp/engine/src/memory/mod.rs
+++ b/crates/lsp/engine/src/memory/mod.rs
@@ -83,7 +83,7 @@ pub(crate) struct MemoryStats {
 }
 
 impl MemoryStats {
-    fn capture(memory_control: &dyn MemoryControl) -> Self {
+    pub(crate) fn capture(memory_control: &dyn MemoryControl) -> Self {
         let allocator = memory_control.allocator_stats();
         Self {
             allocated: allocator.map(|stats| stats.allocated_bytes),
@@ -138,7 +138,7 @@ pub(crate) struct MemoryDelta {
 }
 
 impl MemoryDelta {
-    fn between(before: MemoryStats, after: MemoryStats) -> Self {
+    pub(crate) fn between(before: MemoryStats, after: MemoryStats) -> Self {
         Self {
             allocated: byte_delta(after.allocated, before.allocated),
             active: byte_delta(after.active, before.active),
@@ -169,6 +169,10 @@ pub(crate) fn format_bytes(bytes: usize) -> String {
     }
 }
 
+fn format_bytes_compact(bytes: usize) -> String {
+    format_bytes(bytes).replace(' ', "")
+}
+
 // Used by `derive_more::Debug` field formatting above; dead-code analysis does not look inside
 // derive expansion.
 #[allow(dead_code)]
@@ -196,5 +200,45 @@ fn format_optional_byte_delta(delta: Option<i64>) -> String {
     match bytes {
         Some(bytes) => format!("{prefix}{bytes}"),
         None => format!("{delta} B"),
+    }
+}
+
+fn format_optional_memory_delta(delta: Option<i64>) -> String {
+    let Some(delta) = delta else {
+        return "-".to_string();
+    };
+
+    let prefix = if delta >= 0 { "+" } else { "-" };
+    let bytes = delta.unsigned_abs();
+    let bytes = usize::try_from(bytes).ok().map(format_bytes_compact);
+    match bytes {
+        Some(bytes) => format!("{prefix}{bytes}"),
+        None => format!("{delta}B"),
+    }
+}
+
+fn format_memory_report_field(bytes: Option<usize>, delta: Option<i64>) -> String {
+    if bytes.is_none() && delta.is_none() {
+        return "-".to_string();
+    }
+
+    let bytes = bytes
+        .map(format_bytes_compact)
+        .unwrap_or_else(|| "-".to_string());
+    let delta = format_optional_memory_delta(delta);
+    format!("{bytes}({delta})")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_memory_report_field;
+
+    #[test]
+    fn memory_report_field_is_compact_for_log_rendering() {
+        assert_eq!(
+            format_memory_report_field(Some(12 * 1024 * 1024), Some(-2 * 1024 * 1024)),
+            "12.0MiB(-2.0MiB)",
+        );
+        assert_eq!(format_memory_report_field(None, None), "-");
     }
 }

--- a/crates/lsp/engine/src/memory/report.rs
+++ b/crates/lsp/engine/src/memory/report.rs
@@ -3,7 +3,7 @@
 //! The core memory module defines what the executable can expose. This module owns the logging
 //! shape: point-in-time records and human-readable byte formatting.
 
-use super::{MemoryControl, MemoryDelta, MemoryPurge, MemoryStats, format_memory_report_field};
+use super::{MemoryControl, MemoryDelta, MemoryStats, format_memory_report_field};
 
 /// Reports allocator memory at explicit retention checkpoints.
 pub(crate) struct MemoryReporter;
@@ -57,9 +57,11 @@ impl MemoryReporter {
             return before_purge;
         }
 
-        MemoryPurge::try_purge(memory_control, before_purge)
-            .map(|purge| purge.after)
-            .unwrap_or(before_purge)
+        if memory_control.try_purge_allocator() {
+            MemoryStats::capture(memory_control)
+        } else {
+            before_purge
+        }
     }
 
     fn log_report_debug(label: &'static str, after: MemoryStats, delta: MemoryDelta) {

--- a/crates/lsp/engine/src/memory/report.rs
+++ b/crates/lsp/engine/src/memory/report.rs
@@ -3,110 +3,86 @@
 //! The core memory module defines what the executable can expose. This module owns the logging
 //! shape: point-in-time records and human-readable byte formatting.
 
-use super::{MemoryControl, MemoryDelta, MemoryPurge, MemoryStats};
+use super::{MemoryControl, MemoryDelta, MemoryPurge, MemoryStats, format_memory_report_field};
 
 /// Reports allocator memory at explicit retention checkpoints.
 pub(crate) struct MemoryReporter;
 
 impl MemoryReporter {
-    pub(crate) fn log_checkpoint(
-        memory_control: &dyn MemoryControl,
-        label: &'static str,
-        phase: &'static str,
-    ) -> MemoryStats {
-        let stats = MemoryStats::capture(memory_control);
-        tracing::debug!(
-            target: "rg_lsp_engine::memory",
-            label,
-            phase,
-            allocator = memory_control.allocator_name(),
-            allocator_purge_enabled = memory_control.allocator_purge_enabled(),
-            allocator_purged = false,
-            stats = %stats,
-            "temporary allocation checkpoint"
-        );
-        stats
+    pub(crate) fn snapshot(memory_control: &dyn MemoryControl) -> MemoryStats {
+        MemoryStats::capture(memory_control)
     }
 
-    pub(crate) fn log_checkpoint_delta(
+    pub(crate) fn log_delta_debug(
         memory_control: &dyn MemoryControl,
         label: &'static str,
         phase: &'static str,
         before: MemoryStats,
     ) -> MemoryStats {
         let after = MemoryStats::capture(memory_control);
+        let delta = MemoryDelta::between(before, after);
         tracing::debug!(
             target: "rg_lsp_engine::memory",
             label,
             phase,
-            allocator = memory_control.allocator_name(),
-            allocator_purge_enabled = memory_control.allocator_purge_enabled(),
-            allocator_purged = false,
-            before = %before,
-            after = %after,
-            delta = %MemoryDelta::between(before, after),
-            "temporary allocation checkpoint delta"
+            allocated = %format_memory_report_field(after.allocated, delta.allocated),
+            active = %format_memory_report_field(after.active, delta.active),
+            resident = %format_memory_report_field(after.resident, delta.resident),
+            mapped = %format_memory_report_field(after.mapped, delta.mapped),
+            "memory report"
         );
         after
     }
 
     pub(crate) fn purge_and_report(memory_control: &dyn MemoryControl, label: &'static str) {
-        let before_purge = MemoryStats::capture(memory_control);
-        let purge = if memory_control.allocator_purge_enabled() {
-            MemoryPurge::try_purge(memory_control, before_purge)
-        } else {
-            None
-        };
-        let after = match purge {
-            Some(purge) => purge.after,
-            None => before_purge,
-        };
-
-        tracing::info!(
-            label,
-            allocator = memory_control.allocator_name(),
-            allocator_purge_enabled = memory_control.allocator_purge_enabled(),
-            allocator_purged = purge.is_some(),
-            stats = %after,
-            "allocation info"
-        );
-
-        if let Some(purge) = purge {
-            tracing::info!(
-                label,
-                purge = %purge,
-                "purge stats"
-            );
-        }
+        let before = MemoryStats::capture(memory_control);
+        let after = Self::purge_after(memory_control, before);
+        let delta = MemoryDelta::between(before, after);
+        Self::log_report_info(label, after, delta);
     }
 
-    pub(crate) fn purge_and_report_debug(memory_control: &dyn MemoryControl, label: &'static str) {
+    pub(crate) fn purge_and_report_delta_debug(
+        memory_control: &dyn MemoryControl,
+        label: &'static str,
+        before: MemoryStats,
+    ) {
         let before_purge = MemoryStats::capture(memory_control);
-        let purge = if memory_control.allocator_purge_enabled() {
-            MemoryPurge::try_purge(memory_control, before_purge)
-        } else {
-            None
-        };
-        let after = match purge {
-            Some(purge) => purge.after,
-            None => before_purge,
-        };
+        let after = Self::purge_after(memory_control, before_purge);
+        let delta = MemoryDelta::between(before, after);
+        Self::log_report_debug(label, after, delta);
+    }
 
-        tracing::debug!(
-            label,
-            allocator = memory_control.allocator_name(),
-            allocator_purge_enabled = memory_control.allocator_purge_enabled(),
-            allocator_purged = purge.is_some(),
-            stats = %after,
-            "allocation info"
-        );
-
-        if let Some(purge) = purge {
-            tracing::debug!(
-                label,
-                purge = %purge,
-                "purge stats"
-            );
+    fn purge_after(memory_control: &dyn MemoryControl, before_purge: MemoryStats) -> MemoryStats {
+        if !memory_control.allocator_purge_enabled() {
+            return before_purge;
         }
+
+        MemoryPurge::try_purge(memory_control, before_purge)
+            .map(|purge| purge.after)
+            .unwrap_or(before_purge)
+    }
+
+    fn log_report_debug(label: &'static str, after: MemoryStats, delta: MemoryDelta) {
+        tracing::debug!(
+            target: "rg_lsp_engine::memory",
+            label,
+            allocated = %format_memory_report_field(after.allocated, delta.allocated),
+            active = %format_memory_report_field(after.active, delta.active),
+            resident = %format_memory_report_field(after.resident, delta.resident),
+            mapped = %format_memory_report_field(after.mapped, delta.mapped),
+            "memory report"
+        );
+    }
+
+    fn log_report_info(label: &'static str, after: MemoryStats, delta: MemoryDelta) {
+        tracing::info!(
+            target: "rg_lsp_engine::memory",
+            label,
+            allocated = %format_memory_report_field(after.allocated, delta.allocated),
+            active = %format_memory_report_field(after.active, delta.active),
+            resident = %format_memory_report_field(after.resident, delta.resident),
+            mapped = %format_memory_report_field(after.mapped, delta.mapped),
+            "memory report"
+        );
     }
 }

--- a/crates/lsp/proto/src/error.rs
+++ b/crates/lsp/proto/src/error.rs
@@ -2,9 +2,10 @@ use serde::{Deserialize, Serialize};
 
 /// Shallow engine-side failure transported over the LSP/engine RPC boundary.
 ///
-/// The cache and analysis layers already carry detailed context in their display strings. For now
-/// the protocol only needs a stable error envelope; we can split this into typed variants later if
-/// callers need recovery decisions instead of user-facing messages.
+/// The cache and analysis layers attach useful context through `anyhow`, but `anyhow::Error` only
+/// displays the outermost context by default. The protocol keeps a stable string envelope and
+/// preserves the full chain when converting from `anyhow` so the server does not lose the root
+/// cause before it can log or surface the failure.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
 #[error("{message}")]
 pub struct EngineError {
@@ -21,6 +22,29 @@ impl EngineError {
 
 impl From<anyhow::Error> for EngineError {
     fn from(error: anyhow::Error) -> Self {
-        Self::new(error.to_string())
+        Self::new(format!("{error:#}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EngineError;
+
+    #[test]
+    fn anyhow_conversion_preserves_context_chain() {
+        let error = anyhow::anyhow!("body data is unavailable")
+            .context("while loading body IR")
+            .context("while executing query");
+
+        let message = EngineError::from(error).to_string();
+
+        assert_eq!(
+            message,
+            "while executing query: while loading body IR: body data is unavailable",
+        );
+        assert!(
+            !message.contains('\n'),
+            "alternate anyhow display should keep context chains on one line",
+        );
     }
 }

--- a/crates/lsp/server/src/backend.rs
+++ b/crates/lsp/server/src/backend.rs
@@ -149,7 +149,7 @@ impl LanguageServer for Backend {
 
     #[tracing::instrument(
         skip_all,
-        fields(rg.method = "didOpen", rg.uri = ?params.text_document.uri)
+        fields(rg.method = "didOpen", rg.uri = %params.text_document.uri.as_str())
     )]
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
         let Some(path) = methods::uri_to_path(&params.text_document.uri) else {
@@ -173,7 +173,7 @@ impl LanguageServer for Backend {
 
     #[tracing::instrument(
         skip_all,
-        fields(rg.method = "didChange", rg.uri = ?params.text_document.uri)
+        fields(rg.method = "didChange", rg.uri = %params.text_document.uri.as_str())
     )]
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         let Some(context) = self
@@ -189,7 +189,7 @@ impl LanguageServer for Backend {
 
     #[tracing::instrument(
         skip_all,
-        fields(rg.method = "didSave", rg.uri = ?params.text_document.uri)
+        fields(rg.method = "didSave", rg.uri = %params.text_document.uri.as_str())
     )]
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
         let Some(path) = methods::uri_to_path(&params.text_document.uri) else {
@@ -218,7 +218,7 @@ impl LanguageServer for Backend {
 
     #[tracing::instrument(
         skip_all,
-        fields(rg.method = "didClose", rg.uri = ?params.text_document.uri)
+        fields(rg.method = "didClose", rg.uri = %params.text_document.uri.as_str())
     )]
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         let Some(path) = methods::uri_to_path(&params.text_document.uri) else {
@@ -244,7 +244,7 @@ impl LanguageServer for Backend {
         skip_all,
         fields(
             rg.method = "gotoDefinition",
-            rg.uri = ?params.text_document_position_params.text_document.uri
+            rg.uri = %params.text_document_position_params.text_document.uri.as_str()
         )
     )]
     async fn goto_definition(
@@ -264,7 +264,7 @@ impl LanguageServer for Backend {
         skip_all,
         fields(
             rg.method = "gotoTypeDefinition",
-            rg.uri = ?params.text_document_position_params.text_document.uri
+            rg.uri = %params.text_document_position_params.text_document.uri.as_str()
         )
     )]
     async fn goto_type_definition(
@@ -284,7 +284,7 @@ impl LanguageServer for Backend {
         skip_all,
         fields(
             rg.method = "gotoImplementation",
-            rg.uri = ?params.text_document_position_params.text_document.uri
+            rg.uri = %params.text_document_position_params.text_document.uri.as_str()
         )
     )]
     async fn goto_implementation(
@@ -304,7 +304,7 @@ impl LanguageServer for Backend {
         skip_all,
         fields(
             rg.method = "references",
-            rg.uri = ?params.text_document_position.text_document.uri
+            rg.uri = %params.text_document_position.text_document.uri.as_str()
         )
     )]
     async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
@@ -321,7 +321,7 @@ impl LanguageServer for Backend {
         skip_all,
         fields(
             rg.method = "prepareRename",
-            rg.uri = ?params.text_document.uri
+            rg.uri = %params.text_document.uri.as_str()
         )
     )]
     async fn prepare_rename(
@@ -338,7 +338,7 @@ impl LanguageServer for Backend {
         skip_all,
         fields(
             rg.method = "rename",
-            rg.uri = ?params.text_document_position.text_document.uri
+            rg.uri = %params.text_document_position.text_document.uri.as_str()
         )
     )]
     async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
@@ -355,7 +355,7 @@ impl LanguageServer for Backend {
         skip_all,
         fields(
             rg.method = "documentHighlight",
-            rg.uri = ?params.text_document_position_params.text_document.uri
+            rg.uri = %params.text_document_position_params.text_document.uri.as_str()
         )
     )]
     async fn document_highlight(
@@ -375,7 +375,7 @@ impl LanguageServer for Backend {
         skip_all,
         fields(
             rg.method = "hover",
-            rg.uri = ?params.text_document_position_params.text_document.uri
+            rg.uri = %params.text_document_position_params.text_document.uri.as_str()
         )
     )]
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
@@ -392,7 +392,7 @@ impl LanguageServer for Backend {
         skip_all,
         fields(
             rg.method = "completion",
-            rg.uri = ?params.text_document_position.text_document.uri
+            rg.uri = %params.text_document_position.text_document.uri.as_str()
         )
     )]
     async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
@@ -407,7 +407,7 @@ impl LanguageServer for Backend {
 
     #[tracing::instrument(
         skip_all,
-        fields(rg.method = "formatting", rg.uri = ?params.text_document.uri)
+        fields(rg.method = "formatting", rg.uri = %params.text_document.uri.as_str())
     )]
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
         let Some(context) = self.method_context_for(&params.text_document.uri).await? else {
@@ -418,7 +418,7 @@ impl LanguageServer for Backend {
 
     #[tracing::instrument(
         skip_all,
-        fields(rg.method = "documentSymbol", rg.uri = ?params.text_document.uri)
+        fields(rg.method = "documentSymbol", rg.uri = %params.text_document.uri.as_str())
     )]
     async fn document_symbol(
         &self,
@@ -432,7 +432,7 @@ impl LanguageServer for Backend {
 
     #[tracing::instrument(
         skip_all,
-        fields(rg.method = "inlayHint", rg.uri = ?params.text_document.uri)
+        fields(rg.method = "inlayHint", rg.uri = %params.text_document.uri.as_str())
     )]
     async fn inlay_hint(&self, params: InlayHintParams) -> Result<Option<Vec<InlayHint>>> {
         let Some(context) = self.method_context_for(&params.text_document.uri).await? else {

--- a/crates/lsp/server/src/engine_client.rs
+++ b/crates/lsp/server/src/engine_client.rs
@@ -47,6 +47,7 @@ impl EngineClient {
         Fut: Future<Output = Result<EngineResult<T>, TarpcRpcError>>,
     {
         if let Err(error) = self.call(operation, request).await {
+            let error = format!("{error:#}");
             tracing::debug!(operation, error = %error, "engine notification failed");
         }
     }

--- a/crates/lsp/server/src/methods/mod.rs
+++ b/crates/lsp/server/src/methods/mod.rs
@@ -41,7 +41,7 @@ pub(crate) async fn shutdown(ctx: MethodContext) -> anyhow::Result<()> {
 pub(crate) fn internal_error(error: anyhow::Error) -> Error {
     Error {
         code: ErrorCode::InternalError,
-        message: Cow::Owned(error.to_string()),
+        message: Cow::Owned(format!("{error:#}")),
         data: None,
     }
 }
@@ -58,8 +58,26 @@ pub(crate) fn uri_to_path(uri: &Uri) -> Option<PathBuf> {
 mod tests {
     use std::str::FromStr;
 
-    use super::uri_to_path;
+    use super::{internal_error, uri_to_path};
     use tower_lsp_server::ls_types::Uri;
+
+    #[test]
+    fn internal_error_preserves_context_chain() {
+        let error = anyhow::anyhow!("engine response channel closed")
+            .context("while receiving engine response")
+            .context("while handling hover");
+
+        let message = internal_error(error).message;
+
+        assert_eq!(
+            message.as_ref(),
+            "while handling hover: while receiving engine response: engine response channel closed",
+        );
+        assert!(
+            !message.contains('\n'),
+            "alternate anyhow display should keep context chains on one line",
+        );
+    }
 
     #[test]
     fn uri_to_path_accepts_only_file_uris() {

--- a/crates/rust-glancer/src/memory.rs
+++ b/crates/rust-glancer/src/memory.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use rg_lsp_engine::{AllocatorPurgeResult, AllocatorStats, MemoryControl};
+use rg_lsp_engine::{AllocatorStats, MemoryControl};
 use rg_project::{ProjectMemoryHooks, ProjectMemoryPurgePoint};
 
 const JEMALLOC_PURGE_AFTER_BUILD_ENV: &str = "RUST_GLANCER_PURGE_MEMORY_AFTER_BUILD";
@@ -31,7 +31,7 @@ impl MemoryControl for ProcessMemoryControl {
         Self::allocator_stats()
     }
 
-    fn try_purge_allocator(&self) -> Option<AllocatorPurgeResult> {
+    fn try_purge_allocator(&self) -> bool {
         Self::try_purge_allocator()
     }
 }
@@ -53,7 +53,7 @@ struct ProjectProcessMemoryHooks {
 
 impl ProjectMemoryHooks for ProjectProcessMemoryHooks {
     fn purge(&self, _point: ProjectMemoryPurgePoint) {
-        let _ = self.memory_control.try_purge_allocator();
+        self.memory_control.try_purge_allocator();
     }
 }
 
@@ -85,19 +85,20 @@ impl ProcessMemoryControl {
             .unwrap_or(true) // Enabled by default
     }
 
-    pub(crate) fn try_purge_allocator() -> Option<AllocatorPurgeResult> {
+    pub(crate) fn try_purge_allocator() -> bool {
         if !Self::allocator_purge_enabled() {
-            return None;
+            return false;
         }
 
         #[cfg(all(feature = "jemalloc-stats", not(target_env = "msvc")))]
         {
-            Some(jemalloc_stats::purge())
+            jemalloc_stats::purge();
+            true
         }
 
         #[cfg(not(all(feature = "jemalloc-stats", not(target_env = "msvc"))))]
         {
-            None
+            false
         }
     }
 }
@@ -153,19 +154,14 @@ mod jemalloc_stats {
         CString::new(name).expect("jemalloc mallctl name should not contain NUL")
     }
 
-    pub(super) fn purge() -> rg_lsp_engine::AllocatorPurgeResult {
+    pub(super) fn purge() {
         // The engine builds analysis on a dedicated thread, so flushing this thread's tcache first
         // makes recently freed indexing allocations visible to the arena purge below.
-        let tcache_flushed = mallctl_void("thread.tcache.flush");
+        mallctl_void("thread.tcache.flush");
 
         // 4096 is jemalloc's documented MALLCTL_ARENAS_ALL constant. It lets one mallctl target all
         // arenas instead of discovering and iterating arena indexes manually.
-        let arenas_purged = mallctl_void("arena.4096.purge");
-
-        rg_lsp_engine::AllocatorPurgeResult {
-            tcache_flushed,
-            arenas_purged,
-        }
+        mallctl_void("arena.4096.purge");
     }
 
     fn mallctl_void(name: &'static str) -> bool {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -31,6 +31,19 @@
           ".rs"
         ],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "rust-glancer-log",
+        "aliases": [
+          "Rust Glancer Log"
+        ]
+      }
+    ],
+    "grammars": [
+      {
+        "language": "rust-glancer-log",
+        "scopeName": "source.rust-glancer-log",
+        "path": "./syntaxes/rust-glancer-log.tmLanguage.json"
       }
     ],
     "commands": [

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -9,42 +9,39 @@ import * as vscode from "vscode";
 import { EXTENSION_COMMANDS } from "./commands";
 import { ExtensionController } from "./extension-controller";
 import { registerHoverActionCommands } from "./features/hover-actions";
-import { ServerOutputChannel } from "./logging/server-output-channel";
+import { createServerOutputChannel, isExtensionTestMode } from "./logging/server-output-channel";
 import { StatusView } from "./status/status-view";
-import {
-  RecordingLogOutputChannel,
-  RecordingOutputChannel,
-} from "./test-support/recording-output-channel";
+import { RecordingLogOutputChannel } from "./test-support/recording-output-channel";
 
 let controller: ExtensionController | undefined;
 
-const EXTENSION_TEST_ENV = "RUST_GLANCER_EXTENSION_TEST";
-
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  const testMode = isExtensionTestMode();
   const rawExtensionLog = vscode.window.createOutputChannel("Rust Glancer Extension", {
     log: true,
   });
-  const rawServerLog = vscode.window.createOutputChannel("Rust Glancer Language Server", "log");
-  const recordingExtensionLog =
-    process.env[EXTENSION_TEST_ENV] === "1"
-      ? new RecordingLogOutputChannel(rawExtensionLog)
-      : undefined;
-  const recordingServerLog =
-    process.env[EXTENSION_TEST_ENV] === "1" ? new RecordingOutputChannel(rawServerLog) : undefined;
+  const recordingExtensionLog = testMode
+    ? new RecordingLogOutputChannel(rawExtensionLog)
+    : undefined;
   const extensionLog = recordingExtensionLog ?? rawExtensionLog;
-  const serverOutput = new ServerOutputChannel(recordingServerLog ?? rawServerLog);
+  const serverOutput = createServerOutputChannel();
   const status = new StatusView();
-  controller = new ExtensionController(extensionLog, serverOutput, status, context.extensionUri);
+  controller = new ExtensionController(
+    extensionLog,
+    serverOutput.output,
+    status,
+    context.extensionUri,
+  );
 
   // Extension-host tests need a stable synchronization point. Keep this command out of the
   // package manifest so it is available only when the test runner opts in through the environment.
-  if (process.env[EXTENSION_TEST_ENV] === "1") {
+  if (testMode) {
     context.subscriptions.push(
       vscode.commands.registerCommand(EXTENSION_COMMANDS.testGetState, () =>
         controller?.snapshot(),
       ),
       vscode.commands.registerCommand(EXTENSION_COMMANDS.testGetOutput, () =>
-        [recordingExtensionLog?.snapshot(), recordingServerLog?.snapshot()]
+        [recordingExtensionLog?.snapshot(), serverOutput.recording?.snapshot()]
           .filter((output): output is string => output !== undefined)
           .join(""),
       ),
@@ -53,7 +50,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   context.subscriptions.push(
     extensionLog,
-    serverOutput,
+    serverOutput.output,
     status,
     controller,
     registerHoverActionCommands(extensionLog),

--- a/editors/code/src/logging/server-log.ts
+++ b/editors/code/src/logging/server-log.ts
@@ -20,7 +20,7 @@ export interface ServerLogRecord {
 }
 
 export function formatServerLogLine(record: ServerLogRecord, date = new Date()): string {
-  return `${formatTimestamp(date)} [${record.level}] ${formatServerLogRecord(record)}`;
+  return `${formatTimestamp(date)} ${formatServerLogRecord(record)}`;
 }
 
 export function formatRawServerLogLine(
@@ -28,7 +28,7 @@ export function formatRawServerLogLine(
   message: string,
   date = new Date(),
 ): string {
-  return `${formatTimestamp(date)} [${level}] ${message}`;
+  return `${formatTimestamp(date)} [${logLevelCode(level)}/raw] ${message}`;
 }
 
 export type ParsedServerLogLine =
@@ -77,13 +77,28 @@ export function formatServerLogRecord(record: ServerLogRecord): string {
   const source = logSource(record);
   const prefix =
     record.target !== undefined && record.target.length > 0
-      ? `[${source}/${record.target}]`
-      : `[${source}]`;
+      ? `[${logLevelCode(record.level)}/${source}/${record.target}]`
+      : `[${logLevelCode(record.level)}/${source}]`;
   const fields = formatFields(record.fields);
 
   return fields.length === 0
     ? `${prefix} ${record.message}`
     : `${prefix} ${record.message} ${fields}`;
+}
+
+function logLevelCode(level: ServerLogLevel): string {
+  switch (level) {
+    case "trace":
+      return "t";
+    case "debug":
+      return "d";
+    case "info":
+      return "i";
+    case "warn":
+      return "w";
+    case "error":
+      return "e";
+  }
 }
 
 function logSource(record: ServerLogRecord): string {

--- a/editors/code/src/logging/server-log.ts
+++ b/editors/code/src/logging/server-log.ts
@@ -74,18 +74,24 @@ export function parseServerLogLine(line: string): ParsedServerLogLine {
 }
 
 export function formatServerLogRecord(record: ServerLogRecord): string {
-  const source =
-    record.component === "engine" && record.engine !== undefined
-      ? `${record.component}:${record.engine}`
-      : record.component;
-  const prefixParts =
-    record.target !== undefined && record.target.length > 0 ? [record.target, source] : [source];
-  const prefix = prefixParts.map((part) => `[${part}]`).join(" ");
+  const source = logSource(record);
+  const prefix =
+    record.target !== undefined && record.target.length > 0
+      ? `[${source}/${record.target}]`
+      : `[${source}]`;
   const fields = formatFields(record.fields);
 
   return fields.length === 0
     ? `${prefix} ${record.message}`
     : `${prefix} ${record.message} ${fields}`;
+}
+
+function logSource(record: ServerLogRecord): string {
+  if (record.component === "engine" && record.engine !== undefined) {
+    return record.engine;
+  }
+
+  return record.component;
 }
 
 function parseJsonObject(line: string): Record<string, unknown> | undefined {
@@ -150,19 +156,16 @@ function formatFieldValue(value: unknown): string {
 }
 
 function quoteIfNeeded(value: string): string {
-  return /^[A-Za-z0-9_./:-]+$/.test(value) ? value : JSON.stringify(value);
+  return /^[A-Za-z0-9_./:+()%-]+$/.test(value) ? value : JSON.stringify(value);
 }
 
 function formatTimestamp(date: Date): string {
-  const year = date.getFullYear();
-  const month = pad(date.getMonth() + 1, 2);
-  const day = pad(date.getDate(), 2);
   const hours = pad(date.getHours(), 2);
   const minutes = pad(date.getMinutes(), 2);
   const seconds = pad(date.getSeconds(), 2);
   const milliseconds = pad(date.getMilliseconds(), 3);
 
-  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}.${milliseconds}`;
+  return `${hours}:${minutes}:${seconds}.${milliseconds}`;
 }
 
 function pad(value: number, length: number): string {

--- a/editors/code/src/logging/server-output-channel.ts
+++ b/editors/code/src/logging/server-output-channel.ts
@@ -6,11 +6,48 @@ import {
   formatServerLogLine,
   parseServerLogLine,
 } from "./server-log";
+import { RecordingOutputChannel } from "../test-support/recording-output-channel";
 
-/// Adapts stderr text from `vscode-languageclient` into the server output channel.
-///
-/// The Rust side emits one structured JSON log event per line. Cargo startup output, panics, and
-/// other non-JSON stderr still remain visible through the raw-line fallback.
+const EXTENSION_TEST_ENV = "RUST_GLANCER_EXTENSION_TEST";
+const SERVER_LOG_LANGUAGE_ID = "rust-glancer-log";
+const SERVER_LOG_CHANNEL_NAME = "Rust Glancer Language Server";
+
+export interface CreatedServerOutputChannel {
+  readonly output: ServerOutputChannel;
+  readonly recording?: RecordingOutputChannel;
+}
+
+export function createServerOutputChannel(): CreatedServerOutputChannel {
+  const raw = vscode.window.createOutputChannel(SERVER_LOG_CHANNEL_NAME, SERVER_LOG_LANGUAGE_ID);
+  const recording = isExtensionTestMode() ? new RecordingOutputChannel(raw) : undefined;
+
+  return {
+    output: new ServerOutputChannel(recording ?? raw),
+    recording,
+  };
+}
+
+export function isExtensionTestMode(): boolean {
+  return process.env[EXTENSION_TEST_ENV] === "1";
+}
+
+/**
+ * Defines the editor-facing log format for the Rust language server.
+ *
+ * We use a custom output language instead of VS Code's generic `log` grammar because the default
+ * grammar is not flexible enough for compact structured logs. A normal line looks like this:
+ *
+ * `09:39:29.210 [d/rust-glancer/rg_lsp_engine::memory] memory report active=23.2MiB(+96.0KiB)`
+ *
+ * The prefix is `[level/source/target]`: `t/d/i/w/e` for trace/debug/info/warn/error, then the
+ * server or engine name, then the Rust tracing target when one exists. Everything after the
+ * message is `key=value` fields. The `rust-glancer-log` grammar colors those pieces and treats
+ * each field value as one token, so paths, URIs, and memory values stay visually consistent.
+ *
+ * The Rust side still writes structured JSON lines to stderr. `server-log.ts` is the entrypoint
+ * that parses those records, keeps raw stderr visible as a fallback, and formats both into this
+ * compact display language.
+ */
 export class ServerOutputChannel implements vscode.OutputChannel {
   private bufferedText = "";
 

--- a/editors/code/syntaxes/rust-glancer-log.tmLanguage.json
+++ b/editors/code/syntaxes/rust-glancer-log.tmLanguage.json
@@ -6,19 +6,7 @@
       "include": "#timestamp"
     },
     {
-      "include": "#prefix-trace"
-    },
-    {
-      "include": "#prefix-debug"
-    },
-    {
-      "include": "#prefix-info"
-    },
-    {
-      "include": "#prefix-warn"
-    },
-    {
-      "include": "#prefix-error"
+      "include": "#prefix"
     },
     {
       "include": "#quoted-field"
@@ -32,8 +20,8 @@
       "match": "^\\d{2}:\\d{2}:\\d{2}\\.\\d{3}",
       "name": "constant.numeric.timestamp.rust-glancer-log"
     },
-    "prefix-trace": {
-      "match": "(\\[)(t)(/)([^/\\]\\s]+)(?:(/)([^\\]\\s]+))?(\\])",
+    "prefix": {
+      "match": "(\\[)(?:(t)|(d)|(i)|(w)|(e))(/)([^/\\]\\s]+)(?:(/)([^\\]\\s]+))?(\\])",
       "captures": {
         "1": {
           "name": "punctuation.definition.bracket.begin.rust-glancer-log"
@@ -42,122 +30,30 @@
           "name": "comment.line.level.trace.rust-glancer-log"
         },
         "3": {
-          "name": "punctuation.separator.source.rust-glancer-log"
-        },
-        "4": {
-          "name": "comment.line.source.rust-glancer-log"
-        },
-        "5": {
-          "name": "punctuation.separator.target.rust-glancer-log"
-        },
-        "6": {
-          "name": "comment.line.target.rust-glancer-log"
-        },
-        "7": {
-          "name": "punctuation.definition.bracket.end.rust-glancer-log"
-        }
-      }
-    },
-    "prefix-debug": {
-      "match": "(\\[)(d)(/)([^/\\]\\s]+)(?:(/)([^\\]\\s]+))?(\\])",
-      "captures": {
-        "1": {
-          "name": "punctuation.definition.bracket.begin.rust-glancer-log"
-        },
-        "2": {
           "name": "constant.language.level.debug.rust-glancer-log"
         },
-        "3": {
-          "name": "punctuation.separator.source.rust-glancer-log"
-        },
         "4": {
-          "name": "comment.line.source.rust-glancer-log"
-        },
-        "5": {
-          "name": "punctuation.separator.target.rust-glancer-log"
-        },
-        "6": {
-          "name": "comment.line.target.rust-glancer-log"
-        },
-        "7": {
-          "name": "punctuation.definition.bracket.end.rust-glancer-log"
-        }
-      }
-    },
-    "prefix-info": {
-      "match": "(\\[)(i)(/)([^/\\]\\s]+)(?:(/)([^\\]\\s]+))?(\\])",
-      "captures": {
-        "1": {
-          "name": "punctuation.definition.bracket.begin.rust-glancer-log"
-        },
-        "2": {
           "name": "support.type.level.info.rust-glancer-log"
         },
-        "3": {
-          "name": "punctuation.separator.source.rust-glancer-log"
-        },
-        "4": {
-          "name": "comment.line.source.rust-glancer-log"
-        },
         "5": {
-          "name": "punctuation.separator.target.rust-glancer-log"
-        },
-        "6": {
-          "name": "comment.line.target.rust-glancer-log"
-        },
-        "7": {
-          "name": "punctuation.definition.bracket.end.rust-glancer-log"
-        }
-      }
-    },
-    "prefix-warn": {
-      "match": "(\\[)(w)(/)([^/\\]\\s]+)(?:(/)([^\\]\\s]+))?(\\])",
-      "captures": {
-        "1": {
-          "name": "punctuation.definition.bracket.begin.rust-glancer-log"
-        },
-        "2": {
           "name": "markup.warning.level.warn.rust-glancer-log"
         },
-        "3": {
-          "name": "punctuation.separator.source.rust-glancer-log"
-        },
-        "4": {
-          "name": "comment.line.source.rust-glancer-log"
-        },
-        "5": {
-          "name": "punctuation.separator.target.rust-glancer-log"
-        },
         "6": {
-          "name": "comment.line.target.rust-glancer-log"
-        },
-        "7": {
-          "name": "punctuation.definition.bracket.end.rust-glancer-log"
-        }
-      }
-    },
-    "prefix-error": {
-      "match": "(\\[)(e)(/)([^/\\]\\s]+)(?:(/)([^\\]\\s]+))?(\\])",
-      "captures": {
-        "1": {
-          "name": "punctuation.definition.bracket.begin.rust-glancer-log"
-        },
-        "2": {
           "name": "invalid.illegal.level.error.rust-glancer-log"
         },
-        "3": {
+        "7": {
           "name": "punctuation.separator.source.rust-glancer-log"
         },
-        "4": {
+        "8": {
           "name": "comment.line.source.rust-glancer-log"
         },
-        "5": {
+        "9": {
           "name": "punctuation.separator.target.rust-glancer-log"
         },
-        "6": {
+        "10": {
           "name": "comment.line.target.rust-glancer-log"
         },
-        "7": {
+        "11": {
           "name": "punctuation.definition.bracket.end.rust-glancer-log"
         }
       }

--- a/editors/code/syntaxes/rust-glancer-log.tmLanguage.json
+++ b/editors/code/syntaxes/rust-glancer-log.tmLanguage.json
@@ -1,0 +1,194 @@
+{
+  "name": "Rust Glancer Log",
+  "scopeName": "source.rust-glancer-log",
+  "patterns": [
+    {
+      "include": "#timestamp"
+    },
+    {
+      "include": "#prefix-trace"
+    },
+    {
+      "include": "#prefix-debug"
+    },
+    {
+      "include": "#prefix-info"
+    },
+    {
+      "include": "#prefix-warn"
+    },
+    {
+      "include": "#prefix-error"
+    },
+    {
+      "include": "#quoted-field"
+    },
+    {
+      "include": "#unquoted-field"
+    }
+  ],
+  "repository": {
+    "timestamp": {
+      "match": "^\\d{2}:\\d{2}:\\d{2}\\.\\d{3}",
+      "name": "constant.numeric.timestamp.rust-glancer-log"
+    },
+    "prefix-trace": {
+      "match": "(\\[)(t)(/)([^/\\]\\s]+)(?:(/)([^\\]\\s]+))?(\\])",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.bracket.begin.rust-glancer-log"
+        },
+        "2": {
+          "name": "comment.line.level.trace.rust-glancer-log"
+        },
+        "3": {
+          "name": "punctuation.separator.source.rust-glancer-log"
+        },
+        "4": {
+          "name": "comment.line.source.rust-glancer-log"
+        },
+        "5": {
+          "name": "punctuation.separator.target.rust-glancer-log"
+        },
+        "6": {
+          "name": "comment.line.target.rust-glancer-log"
+        },
+        "7": {
+          "name": "punctuation.definition.bracket.end.rust-glancer-log"
+        }
+      }
+    },
+    "prefix-debug": {
+      "match": "(\\[)(d)(/)([^/\\]\\s]+)(?:(/)([^\\]\\s]+))?(\\])",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.bracket.begin.rust-glancer-log"
+        },
+        "2": {
+          "name": "constant.language.level.debug.rust-glancer-log"
+        },
+        "3": {
+          "name": "punctuation.separator.source.rust-glancer-log"
+        },
+        "4": {
+          "name": "comment.line.source.rust-glancer-log"
+        },
+        "5": {
+          "name": "punctuation.separator.target.rust-glancer-log"
+        },
+        "6": {
+          "name": "comment.line.target.rust-glancer-log"
+        },
+        "7": {
+          "name": "punctuation.definition.bracket.end.rust-glancer-log"
+        }
+      }
+    },
+    "prefix-info": {
+      "match": "(\\[)(i)(/)([^/\\]\\s]+)(?:(/)([^\\]\\s]+))?(\\])",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.bracket.begin.rust-glancer-log"
+        },
+        "2": {
+          "name": "support.type.level.info.rust-glancer-log"
+        },
+        "3": {
+          "name": "punctuation.separator.source.rust-glancer-log"
+        },
+        "4": {
+          "name": "comment.line.source.rust-glancer-log"
+        },
+        "5": {
+          "name": "punctuation.separator.target.rust-glancer-log"
+        },
+        "6": {
+          "name": "comment.line.target.rust-glancer-log"
+        },
+        "7": {
+          "name": "punctuation.definition.bracket.end.rust-glancer-log"
+        }
+      }
+    },
+    "prefix-warn": {
+      "match": "(\\[)(w)(/)([^/\\]\\s]+)(?:(/)([^\\]\\s]+))?(\\])",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.bracket.begin.rust-glancer-log"
+        },
+        "2": {
+          "name": "markup.warning.level.warn.rust-glancer-log"
+        },
+        "3": {
+          "name": "punctuation.separator.source.rust-glancer-log"
+        },
+        "4": {
+          "name": "comment.line.source.rust-glancer-log"
+        },
+        "5": {
+          "name": "punctuation.separator.target.rust-glancer-log"
+        },
+        "6": {
+          "name": "comment.line.target.rust-glancer-log"
+        },
+        "7": {
+          "name": "punctuation.definition.bracket.end.rust-glancer-log"
+        }
+      }
+    },
+    "prefix-error": {
+      "match": "(\\[)(e)(/)([^/\\]\\s]+)(?:(/)([^\\]\\s]+))?(\\])",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.bracket.begin.rust-glancer-log"
+        },
+        "2": {
+          "name": "invalid.illegal.level.error.rust-glancer-log"
+        },
+        "3": {
+          "name": "punctuation.separator.source.rust-glancer-log"
+        },
+        "4": {
+          "name": "comment.line.source.rust-glancer-log"
+        },
+        "5": {
+          "name": "punctuation.separator.target.rust-glancer-log"
+        },
+        "6": {
+          "name": "comment.line.target.rust-glancer-log"
+        },
+        "7": {
+          "name": "punctuation.definition.bracket.end.rust-glancer-log"
+        }
+      }
+    },
+    "quoted-field": {
+      "match": "\\b([A-Za-z_][A-Za-z0-9_.-]*)(=)(\"(?:\\\\.|[^\"\\\\])*\")",
+      "captures": {
+        "1": {
+          "name": "variable.parameter.field.rust-glancer-log"
+        },
+        "2": {
+          "name": "keyword.operator.assignment.rust-glancer-log"
+        },
+        "3": {
+          "name": "string.quoted.double.field-value.rust-glancer-log"
+        }
+      }
+    },
+    "unquoted-field": {
+      "match": "\\b([A-Za-z_][A-Za-z0-9_.-]*)(=)([^\\s]+)",
+      "captures": {
+        "1": {
+          "name": "variable.parameter.field.rust-glancer-log"
+        },
+        "2": {
+          "name": "keyword.operator.assignment.rust-glancer-log"
+        },
+        "3": {
+          "name": "string.unquoted.field-value.rust-glancer-log"
+        }
+      }
+    }
+  }
+}

--- a/editors/code/unit/server-log.test.ts
+++ b/editors/code/unit/server-log.test.ts
@@ -32,7 +32,7 @@ describe("server log parsing", () => {
       assert.equal(parsed.record.engine, "simple_crate");
       assert.equal(
         formatServerLogRecord(parsed.record),
-        "[rg_lsp_engine::engine::worker] [engine:simple_crate] workspace indexing finished elapsed_ms=7630 workspace_root=/workspace/simple_crate",
+        "[simple_crate/rg_lsp_engine::engine::worker] workspace indexing finished elapsed_ms=7630 workspace_root=/workspace/simple_crate",
       );
     }
   });
@@ -54,7 +54,7 @@ describe("server log parsing", () => {
       assert.equal(parsed.record.level, "trace");
       assert.equal(
         formatServerLogRecord(parsed.record),
-        "[rg_lsp_server::backend] [server] request received",
+        "[server/rg_lsp_server::backend] request received",
       );
     }
   });
@@ -73,7 +73,25 @@ describe("server log parsing", () => {
         },
         new Date(2026, 4, 13, 22, 23, 58, 537),
       ),
-      "2026-05-13 22:23:58.537 [trace] [rg_lsp_server::backend] [server] request received method=hover",
+      "22:23:58.537 [trace] [server/rg_lsp_server::backend] request received method=hover",
+    );
+  });
+
+  it("keeps compact memory fields unquoted", () => {
+    assert.equal(
+      formatServerLogRecord({
+        level: "debug",
+        component: "engine",
+        engine: "simple_crate",
+        target: "rg_lsp_engine::memory",
+        message: "memory report",
+        fields: {
+          label: "inlay_hint",
+          allocated: "9.2MiB(-2.0MiB)",
+          resident: "35.4MiB(+0B)",
+        },
+      }),
+      "[simple_crate/rg_lsp_engine::memory] memory report label=inlay_hint allocated=9.2MiB(-2.0MiB) resident=35.4MiB(+0B)",
     );
   });
 
@@ -84,7 +102,7 @@ describe("server log parsing", () => {
         "error: failed to compile",
         new Date(2026, 4, 13, 22, 23, 58, 537),
       ),
-      "2026-05-13 22:23:58.537 [error] error: failed to compile",
+      "22:23:58.537 [error] error: failed to compile",
     );
   });
 

--- a/editors/code/unit/server-log.test.ts
+++ b/editors/code/unit/server-log.test.ts
@@ -32,7 +32,7 @@ describe("server log parsing", () => {
       assert.equal(parsed.record.engine, "simple_crate");
       assert.equal(
         formatServerLogRecord(parsed.record),
-        "[simple_crate/rg_lsp_engine::engine::worker] workspace indexing finished elapsed_ms=7630 workspace_root=/workspace/simple_crate",
+        "[i/simple_crate/rg_lsp_engine::engine::worker] workspace indexing finished elapsed_ms=7630 workspace_root=/workspace/simple_crate",
       );
     }
   });
@@ -54,7 +54,7 @@ describe("server log parsing", () => {
       assert.equal(parsed.record.level, "trace");
       assert.equal(
         formatServerLogRecord(parsed.record),
-        "[server/rg_lsp_server::backend] request received",
+        "[t/server/rg_lsp_server::backend] request received",
       );
     }
   });
@@ -73,7 +73,7 @@ describe("server log parsing", () => {
         },
         new Date(2026, 4, 13, 22, 23, 58, 537),
       ),
-      "22:23:58.537 [trace] [server/rg_lsp_server::backend] request received method=hover",
+      "22:23:58.537 [t/server/rg_lsp_server::backend] request received method=hover",
     );
   });
 
@@ -91,7 +91,7 @@ describe("server log parsing", () => {
           resident: "35.4MiB(+0B)",
         },
       }),
-      "[simple_crate/rg_lsp_engine::memory] memory report label=inlay_hint allocated=9.2MiB(-2.0MiB) resident=35.4MiB(+0B)",
+      "[d/simple_crate/rg_lsp_engine::memory] memory report label=inlay_hint allocated=9.2MiB(-2.0MiB) resident=35.4MiB(+0B)",
     );
   });
 
@@ -102,7 +102,7 @@ describe("server log parsing", () => {
         "error: failed to compile",
         new Date(2026, 4, 13, 22, 23, 58, 537),
       ),
-      "22:23:58.537 [error] error: failed to compile",
+      "22:23:58.537 [e/raw] error: failed to compile",
     );
   });
 
@@ -114,7 +114,7 @@ describe("server log parsing", () => {
         message: "server started",
         fields: {},
       }),
-      "[server] server started",
+      "[i/server] server started",
     );
   });
 


### PR DESCRIPTION
- Remove `RefMutability` and `PatMutability` that were confusing
- Cache semantic index (it gives 3x performance for some queries and removes some ugly fallbacks)
- Preserve error context chain in logs so that we don't see only the latest (usually generic and useless) message
- Improve logging overall

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for highlighting Rust Glancer log files in the editor.
  * Improved log output formatting for clearer, more compact traces and diagnostics.

* **Bug Fixes**
  * Made code navigation, completion, hover, and related lookups more reliable by using precomputed resolution data.
  * Improved reference and mutability handling across type and pattern analysis.
  * Updated cache and memory reporting behavior for more consistent diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->