### PR TITLE
feat: Support imported enum variants

### DIFF
--- a/crates/engine/body-ir/src/build/body_def_map.rs
+++ b/crates/engine/body-ir/src/build/body_def_map.rs
@@ -14,8 +14,8 @@ use rg_ir_storage::{
     DefMap, DefMapBuilder, DefMapSource, GlobImportSource, ImportBinding, ImportData, ImportKind,
     ImportPath, ImportSourcePath, LocalDefData, LocalDefKind, LocalEnumVariantData,
     LocalEnumVariantEntry, LocalImplData, MacroDefinitionEnv, MacroDefinitionView, ModuleData,
-    ModuleOrigin, ModuleScope, ModuleScopeBuilder, Namespace, ScopeResolver, ScopeBinding,
-    ScopeBindingOrigin, ScopeEntryRef, ScopeResolutionEnv, TargetResolutionEnv,
+    ModuleOrigin, ModuleScope, ModuleScopeBuilder, Namespace, ScopeBinding, ScopeBindingOrigin,
+    ScopeEntryRef, ScopeResolutionEnv, ScopeResolver, TargetResolutionEnv,
 };
 use rg_package_store::PackageStoreError;
 use rg_text::Name;

--- a/crates/engine/body-ir/src/build/body_def_map.rs
+++ b/crates/engine/body-ir/src/build/body_def_map.rs
@@ -127,12 +127,8 @@ impl<'body> BodyDefMapCollector<'body> {
         item_id: ItemTreeId,
         item: &ItemNode,
     ) -> Option<rg_ir_model::LocalDefId> {
-        let Some(kind) = LocalDefKind::from_item_tag(item.kind.tag()) else {
-            return None;
-        };
-        let Some(name) = item.name.clone() else {
-            return None;
-        };
+        let kind = LocalDefKind::from_item_tag(item.kind.tag())?;
+        let name = item.name.clone()?;
         let namespace = kind.namespace();
 
         let local_def = self.builder.alloc_local_def(LocalDefData {

--- a/crates/engine/body-ir/src/build/body_def_map.rs
+++ b/crates/engine/body-ir/src/build/body_def_map.rs
@@ -11,11 +11,11 @@ use rg_ir_model::{
     hir::source::{BodyItemSourceRef, ItemSource},
 };
 use rg_ir_storage::{
-    DefMap, DefMapBuilder, DefMapSource, GlobImportSource, ImportBinding, ImportData, ImportKind,
-    ImportPath, ImportSourcePath, LocalDefData, LocalDefKind, LocalEnumVariantData,
-    LocalEnumVariantEntry, LocalImplData, MacroDefinitionEnv, MacroDefinitionView, ModuleData,
-    ModuleOrigin, ModuleScope, ModuleScopeBuilder, Namespace, ScopeBinding, ScopeBindingOrigin,
-    ScopeEntryRef, ScopeResolutionEnv, ScopeResolver, TargetResolutionEnv,
+    DefMap, DefMapBuilder, DefMapSource, ImportBinding, ImportData, ImportKind, ImportPath,
+    ImportSourcePath, LocalDefData, LocalDefKind, LocalEnumVariantData, LocalEnumVariantEntry,
+    LocalImplData, MacroDefinitionEnv, MacroDefinitionView, ModuleData, ModuleOrigin, ModuleScope,
+    ModuleScopeBuilder, Namespace, ScopeBinding, ScopeBindingOrigin, ScopeEntryRef,
+    ScopeResolutionEnv, ScopeResolver, TargetResolutionEnv,
 };
 use rg_package_store::PackageStoreError;
 use rg_text::Name;
@@ -404,37 +404,16 @@ impl BodyDefMapBuildState {
                         let target_scope = next_scopes
                             .get_mut(import.module.0)
                             .expect("target scope should exist for body import");
+                        let source_scope =
+                            resolver.visible_glob_source_scope(importing_module, glob_source)?;
 
-                        match glob_source {
-                            GlobImportSource::Module(source_module) => {
-                                let source_scope =
-                                    resolver.visible_scope(importing_module, source_module)?;
-
-                                for (name, entry) in source_scope.entries() {
-                                    target_scope.copy_visible_bindings(
-                                        name,
-                                        entry,
-                                        import.visibility.clone(),
-                                        importing_module,
-                                    );
-                                }
-                            }
-                            GlobImportSource::Enum(enum_def) => {
-                                for (name, binding) in resolver
-                                    .visible_enum_variant_bindings(importing_module, enum_def)?
-                                {
-                                    target_scope.insert_binding(
-                                        &name,
-                                        Namespace::Values,
-                                        ScopeBinding {
-                                            def: binding.def,
-                                            visibility: import.visibility.clone(),
-                                            owner: importing_module,
-                                            origin: ScopeBindingOrigin::Import,
-                                        },
-                                    );
-                                }
-                            }
+                        for (name, entry) in source_scope.entries() {
+                            target_scope.copy_visible_bindings(
+                                name,
+                                entry,
+                                import.visibility.clone(),
+                                importing_module,
+                            );
                         }
                     }
                 }
@@ -540,10 +519,7 @@ where
             return Ok(self.state.builder.partial().module(module_ref.module));
         }
 
-        Ok(self
-            .def_maps
-            .def_map_for_origin(module_ref.origin)?
-            .and_then(|def_map| def_map.module(module_ref.module)))
+        self.def_maps.module_data(module_ref)
     }
 
     fn module_scope_entry<'a>(
@@ -600,10 +576,7 @@ where
                 .local_def(local_def_ref.local_def));
         }
 
-        Ok(self
-            .def_maps
-            .def_map_for_origin(local_def_ref.origin)?
-            .and_then(|def_map| def_map.local_def(local_def_ref.local_def)))
+        self.def_maps.local_def_data(local_def_ref)
     }
 
     fn local_enum_variant_entries_for_enum<'a>(
@@ -619,13 +592,7 @@ where
                 .collect());
         }
 
-        let Some(def_map) = self.def_maps.def_map_for_origin(enum_def.origin)? else {
-            return Ok(Vec::new());
-        };
-
-        Ok(def_map
-            .local_enum_variant_entries_for_enum(enum_def.local_def)
-            .collect())
+        self.def_maps.local_enum_variant_entries_for_enum(enum_def)
     }
 }
 

--- a/crates/engine/body-ir/src/build/body_def_map.rs
+++ b/crates/engine/body-ir/src/build/body_def_map.rs
@@ -402,7 +402,7 @@ impl BodyDefMapBuildState {
             match import.kind {
                 ImportKind::Glob => {
                     let glob_sources =
-                        resolver.import_glob_sources_from_module(importing_module, &import.path)?;
+                        resolver.import_glob_sources(importing_module, &import.path)?;
 
                     for glob_source in glob_sources {
                         let target_scope = next_scopes
@@ -443,8 +443,7 @@ impl BodyDefMapBuildState {
                     }
                 }
                 ImportKind::Named | ImportKind::SelfImport => {
-                    let resolved_defs =
-                        resolver.import_defs_from_module(importing_module, &import.path)?;
+                    let resolved_defs = resolver.import_defs(importing_module, &import.path)?;
                     let Some(binding_name) = import.binding_name() else {
                         continue;
                     };
@@ -494,10 +493,10 @@ impl BodyDefMapBuildState {
             let importing_module = self.importing_module(import.module);
             let is_unresolved = match import.kind {
                 ImportKind::Glob => resolver
-                    .import_glob_sources_from_module(importing_module, &import.path)?
+                    .import_glob_sources(importing_module, &import.path)?
                     .is_empty(),
                 ImportKind::Named | ImportKind::SelfImport => resolver
-                    .import_defs_from_module(importing_module, &import.path)?
+                    .import_defs(importing_module, &import.path)?
                     .is_empty(),
             };
             if is_unresolved {

--- a/crates/engine/body-ir/src/build/body_def_map.rs
+++ b/crates/engine/body-ir/src/build/body_def_map.rs
@@ -4,18 +4,18 @@
 //! resolved in a fixed-point loop before the final DefMap is frozen.
 
 use rg_ir_model::items::{
-    Documentation, ImportAlias, ItemKind, ItemNode, ItemTreeId, ModuleSource,
+    Documentation, EnumItem, ImportAlias, ItemKind, ItemNode, ItemTreeId, ModuleSource,
 };
 use rg_ir_model::{
     BodyRef, DefId, DefMapRef, LocalDefRef, ModuleId, ModuleRef, TargetRef,
     hir::source::{BodyItemSourceRef, ItemSource},
 };
 use rg_ir_storage::{
-    DefMap, DefMapBuilder, DefMapSource, ImportBinding, ImportData, ImportKind, ImportPath,
-    ImportSourcePath, LocalDefData, LocalDefKind, LocalImplData, MacroDefinitionEnv,
-    MacroDefinitionView, ModuleData, ModuleOrigin, ModuleScope, ModuleScopeBuilder, Namespace,
-    PathResolver, ScopeBinding, ScopeBindingOrigin, ScopeEntryRef, ScopeResolutionEnv,
-    TargetResolutionEnv,
+    DefMap, DefMapBuilder, DefMapSource, GlobImportSource, ImportBinding, ImportData, ImportKind,
+    ImportPath, ImportSourcePath, LocalDefData, LocalDefKind, LocalEnumVariantData,
+    LocalEnumVariantEntry, LocalImplData, MacroDefinitionEnv, MacroDefinitionView, ModuleData,
+    ModuleOrigin, ModuleScope, ModuleScopeBuilder, Namespace, PathResolver, ScopeBinding,
+    ScopeBindingOrigin, ScopeEntryRef, ScopeResolutionEnv, TargetResolutionEnv,
 };
 use rg_package_store::PackageStoreError;
 use rg_text::Name;
@@ -109,21 +109,29 @@ impl<'body> BodyDefMapCollector<'body> {
             ItemKind::Module(module_item) => self.collect_module(module, item, module_item),
             ItemKind::Use(use_item) => self.collect_use(module, item_id, item, use_item),
             ItemKind::Impl(_) => self.collect_local_impl(module, item_id, item),
+            ItemKind::Enum(enum_item) => self.collect_enum(module, item_id, item, enum_item),
             ItemKind::MacroCall(_)
             | ItemKind::MacroDefinition(_)
             | ItemKind::ExternCrate(_)
             | ItemKind::ExternBlock
             | ItemKind::AsmExpr => {}
-            _ => self.collect_local_def(module, item_id, item),
+            _ => {
+                self.collect_local_def(module, item_id, item);
+            }
         }
     }
 
-    fn collect_local_def(&mut self, module: ModuleId, item_id: ItemTreeId, item: &ItemNode) {
+    fn collect_local_def(
+        &mut self,
+        module: ModuleId,
+        item_id: ItemTreeId,
+        item: &ItemNode,
+    ) -> Option<rg_ir_model::LocalDefId> {
         let Some(kind) = LocalDefKind::from_item_tag(item.kind.tag()) else {
-            return;
+            return None;
         };
         let Some(name) = item.name.clone() else {
-            return;
+            return None;
         };
         let namespace = kind.namespace();
 
@@ -161,6 +169,32 @@ impl<'body> BodyDefMapCollector<'body> {
                     origin: ScopeBindingOrigin::Direct,
                 },
             );
+        Some(local_def)
+    }
+
+    fn collect_enum(
+        &mut self,
+        module: ModuleId,
+        item_id: ItemTreeId,
+        item: &ItemNode,
+        enum_item: &EnumItem,
+    ) {
+        let Some(local_def) = self.collect_local_def(module, item_id, item) else {
+            return;
+        };
+
+        for (index, variant) in enum_item.variants.iter().enumerate() {
+            self.builder.alloc_local_enum_variant(LocalEnumVariantData {
+                module,
+                enum_def: local_def,
+                name: variant.name.clone(),
+                index,
+                visibility: item.visibility.clone(),
+                file_id: item.file_id,
+                name_span: variant.name_span,
+                span: variant.span,
+            });
+        }
     }
 
     fn collect_local_impl(&mut self, module: ModuleId, item_id: ItemTreeId, item: &ItemNode) {
@@ -367,23 +401,44 @@ impl BodyDefMapBuildState {
             let importing_module = self.importing_module(import.module);
             match import.kind {
                 ImportKind::Glob => {
-                    let source_modules =
-                        resolver.import_modules_from_module(importing_module, &import.path)?;
+                    let glob_sources =
+                        resolver.import_glob_sources_from_module(importing_module, &import.path)?;
 
-                    for source_module in source_modules {
-                        let source_scope =
-                            resolver.visible_scope(importing_module, source_module)?;
+                    for glob_source in glob_sources {
                         let target_scope = next_scopes
                             .get_mut(import.module.0)
                             .expect("target scope should exist for body import");
 
-                        for (name, entry) in source_scope.entries() {
-                            target_scope.copy_visible_bindings(
-                                name,
-                                entry,
-                                import.visibility.clone(),
-                                importing_module,
-                            );
+                        match glob_source {
+                            GlobImportSource::Module(source_module) => {
+                                let source_scope =
+                                    resolver.visible_scope(importing_module, source_module)?;
+
+                                for (name, entry) in source_scope.entries() {
+                                    target_scope.copy_visible_bindings(
+                                        name,
+                                        entry,
+                                        import.visibility.clone(),
+                                        importing_module,
+                                    );
+                                }
+                            }
+                            GlobImportSource::Enum(enum_def) => {
+                                for (name, binding) in resolver
+                                    .visible_enum_variant_bindings(importing_module, enum_def)?
+                                {
+                                    target_scope.insert_binding(
+                                        &name,
+                                        Namespace::Values,
+                                        ScopeBinding {
+                                            def: binding.def,
+                                            visibility: import.visibility.clone(),
+                                            owner: importing_module,
+                                            origin: ScopeBindingOrigin::Import,
+                                        },
+                                    );
+                                }
+                            }
                         }
                     }
                 }
@@ -439,7 +494,7 @@ impl BodyDefMapBuildState {
             let importing_module = self.importing_module(import.module);
             let is_unresolved = match import.kind {
                 ImportKind::Glob => resolver
-                    .import_modules_from_module(importing_module, &import.path)?
+                    .import_glob_sources_from_module(importing_module, &import.path)?
                     .is_empty(),
                 ImportKind::Named | ImportKind::SelfImport => resolver
                     .import_defs_from_module(importing_module, &import.path)?
@@ -554,6 +609,28 @@ where
             .def_maps
             .def_map_for_origin(local_def_ref.origin)?
             .and_then(|def_map| def_map.local_def(local_def_ref.local_def)))
+    }
+
+    fn local_enum_variant_entries_for_enum<'a>(
+        &'a self,
+        enum_def: LocalDefRef,
+    ) -> Result<Vec<LocalEnumVariantEntry<'a>>, Self::Error> {
+        if self.is_active_body_origin(enum_def.origin) {
+            return Ok(self
+                .state
+                .builder
+                .partial()
+                .local_enum_variant_entries_for_enum(enum_def.local_def)
+                .collect());
+        }
+
+        let Some(def_map) = self.def_maps.def_map_for_origin(enum_def.origin)? else {
+            return Ok(Vec::new());
+        };
+
+        Ok(def_map
+            .local_enum_variant_entries_for_enum(enum_def.local_def)
+            .collect())
     }
 }
 

--- a/crates/engine/body-ir/src/build/body_def_map.rs
+++ b/crates/engine/body-ir/src/build/body_def_map.rs
@@ -14,7 +14,7 @@ use rg_ir_storage::{
     DefMap, DefMapBuilder, DefMapSource, GlobImportSource, ImportBinding, ImportData, ImportKind,
     ImportPath, ImportSourcePath, LocalDefData, LocalDefKind, LocalEnumVariantData,
     LocalEnumVariantEntry, LocalImplData, MacroDefinitionEnv, MacroDefinitionView, ModuleData,
-    ModuleOrigin, ModuleScope, ModuleScopeBuilder, Namespace, PathResolver, ScopeBinding,
+    ModuleOrigin, ModuleScope, ModuleScopeBuilder, Namespace, ScopeResolver, ScopeBinding,
     ScopeBindingOrigin, ScopeEntryRef, ScopeResolutionEnv, TargetResolutionEnv,
 };
 use rg_package_store::PackageStoreError;
@@ -396,7 +396,7 @@ impl BodyDefMapBuildState {
     where
         S: DefMapSource<Error = PackageStoreError> + Copy,
     {
-        let resolver = PathResolver::new(env);
+        let resolver = ScopeResolver::new(env);
         for import in self.builder.partial().imports() {
             let importing_module = self.importing_module(import.module);
             match import.kind {
@@ -487,7 +487,7 @@ impl BodyDefMapBuildState {
             state: self,
             current_scopes: final_scopes,
         };
-        let resolver = PathResolver::new(&env);
+        let resolver = ScopeResolver::new(&env);
 
         for (import_id, import) in self.builder.partial().imports_with_ids() {
             let importing_module = self.importing_module(import.module);

--- a/crates/engine/body-ir/src/resolution/pass/pattern_binding.rs
+++ b/crates/engine/body-ir/src/resolution/pass/pattern_binding.rs
@@ -513,6 +513,7 @@ where
         };
         let def_maps = self.context().def_map_query();
         let body_defs = def_maps
+            .scope_resolver()
             .resolve_lexical_path(from, path, NameResolutionFilter::ValuesOnly)?
             .resolved;
         if self.semantic_items_include_const_like(body_defs)? {
@@ -520,7 +521,10 @@ where
         }
 
         let owner_module = self.body.owner_module();
-        let owner_defs = def_maps.resolve_path(owner_module, path)?.resolved;
+        let owner_defs = def_maps
+            .scope_resolver()
+            .resolve_path(owner_module, path, NameResolutionFilter::AllNamespaces)?
+            .resolved;
         if self.semantic_items_include_const_like(owner_defs)? {
             return Ok(true);
         }
@@ -530,7 +534,10 @@ where
             return Ok(false);
         }
 
-        let fallback_defs = def_maps.resolve_path(fallback_module, path)?.resolved;
+        let fallback_defs = def_maps
+            .scope_resolver()
+            .resolve_path(fallback_module, path, NameResolutionFilter::AllNamespaces)?
+            .resolved;
         self.semantic_items_include_const_like(fallback_defs)
     }
 

--- a/crates/engine/body-ir/src/resolution/query/type_path.rs
+++ b/crates/engine/body-ir/src/resolution/query/type_path.rs
@@ -129,11 +129,11 @@ where
             origin: DefMapRef::Body(self.context.body_ref()),
             module: ModuleId(scope.0),
         };
-        let result = self.context.def_map_query().resolve_lexical_path(
-            from,
-            path,
-            NameResolutionFilter::TypesOnly,
-        )?;
+        let result = self
+            .context
+            .def_map_query()
+            .scope_resolver()
+            .resolve_lexical_path(from, path, NameResolutionFilter::TypesOnly)?;
 
         self.semantic_items_for_defs(result.resolved)
     }
@@ -145,7 +145,11 @@ where
         path: &Path,
     ) -> Result<UniqueVec<SemanticItemRef>, PackageStoreError> {
         let def_maps = self.context.def_map_query();
-        let result = def_maps.resolve_path_in_type_namespace(module, path)?;
+        let result = def_maps.scope_resolver().resolve_path(
+            module,
+            path,
+            NameResolutionFilter::TypesOnly,
+        )?;
         let items = self.semantic_items_for_defs(result.resolved)?;
         if !items.is_empty() {
             return Ok(items);
@@ -158,7 +162,11 @@ where
             return Ok(items);
         }
 
-        let result = def_maps.resolve_path_in_type_namespace(fallback_module, path)?;
+        let result = def_maps.scope_resolver().resolve_path(
+            fallback_module,
+            path,
+            NameResolutionFilter::TypesOnly,
+        )?;
         self.semantic_items_for_defs(result.resolved)
     }
 

--- a/crates/engine/body-ir/src/resolution/query/type_ref.rs
+++ b/crates/engine/body-ir/src/resolution/query/type_ref.rs
@@ -156,7 +156,7 @@ where
         type_contexts.nominal_self_ty_for_context(context)
     }
 
-    /// Ask the path resolver that matches the current anchor kind.
+    /// Ask the scope resolver that matches the current anchor kind.
     fn resolve_type_path(
         &self,
         anchor: TypeRefAnchor,

--- a/crates/engine/body-ir/src/resolution/query/value_path.rs
+++ b/crates/engine/body-ir/src/resolution/query/value_path.rs
@@ -1,15 +1,16 @@
 //! Value-path lookup.
 
 use rg_ir_model::{
-    BindingId, ConstRef, DefId, DefMapRef, ModuleId, ModuleRef, Path, ScopeId, SemanticItemRef,
-    StaticRef, TypePathResolution, identity::DeclarationRef,
+    BindingId, ConstRef, DefId, DefMapRef, EnumVariantRef, FunctionRef, LocalDefRef,
+    LocalEnumVariantRef, ModuleId, ModuleRef, Path, ScopeId, SemanticItemRef, StaticRef,
+    TypePathResolution, identity::DeclarationRef,
 };
 use rg_ir_storage::{
     DefMapSource, ItemStoreSource, NameResolutionFilter, ResolvePathResult, TypePathContext,
 };
 use rg_package_store::PackageStoreError;
 use rg_std::{ExpectedUnique, UniqueVec};
-use rg_ty::{ExpectedNominalTyExt, ExpectedTyExt, NominalTy, Ty};
+use rg_ty::{ExpectedNominalTyExt, ExpectedTyExt, GenericArg, NominalTy, Ty};
 
 use crate::ir::resolved::BodyResolution;
 use crate::resolution::{BodyResolutionContext, TypeRefUseSite};
@@ -23,7 +24,16 @@ pub struct BodyValuePathQuery<'query, D, I> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum BodyValueName {
     Binding(BindingId),
-    SemanticItems(UniqueVec<SemanticItemRef>),
+    Candidates(UniqueVec<BodyValueCandidate>),
+}
+
+/// Resolved value candidate after DefMap names have been projected through semantic item data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum BodyValueCandidate {
+    Function(FunctionRef),
+    Const(ConstRef),
+    Static(StaticRef),
+    EnumVariant(EnumVariantRef, Ty),
 }
 
 impl<'query, D, I> BodyValuePathQuery<'query, D, I>
@@ -207,7 +217,7 @@ where
                     name,
                     NameResolutionFilter::ValuesOnly,
                 )?;
-            let value_name = BodyValueName::SemanticItems(self.semantic_items_for_defs(defs)?);
+            let value_name = BodyValueName::Candidates(self.value_candidates_for_defs(defs)?);
             if let Some(resolution) = self.value_name_resolution(value_name)? {
                 return Ok(Some(resolution));
             }
@@ -257,39 +267,53 @@ where
             .def_map_query()
             .resolve_lexical_path(from, path, NameResolutionFilter::ValuesOnly)?
             .resolved;
-        self.value_name_resolution(BodyValueName::SemanticItems(
-            self.semantic_items_for_defs(defs)?,
+        self.value_name_resolution(BodyValueName::Candidates(
+            self.value_candidates_for_defs(defs)?,
         ))
     }
 
-    /// Keep only semantic items that belong to the value namespace.
-    fn semantic_items_for_defs(
+    /// Keep only definitions that can be used as value expressions.
+    fn value_candidates_for_defs(
         &self,
-        defs: Vec<DefId>,
-    ) -> Result<UniqueVec<SemanticItemRef>, PackageStoreError> {
-        let mut items = UniqueVec::new();
+        defs: impl IntoIterator<Item = DefId>,
+    ) -> Result<UniqueVec<BodyValueCandidate>, PackageStoreError> {
+        let mut candidates = UniqueVec::new();
         for def in defs {
-            let DefId::Local(local_def) = def else {
-                continue;
-            };
-            let Some(item) = self
-                .context
-                .item_query()
-                .semantic_item_for_local_def(local_def)?
-            else {
-                continue;
-            };
-            if matches!(
-                item,
-                SemanticItemRef::Function(_)
-                    | SemanticItemRef::Const(_)
-                    | SemanticItemRef::Static(_)
-            ) {
-                items.push(item);
+            match def {
+                DefId::Local(local_def) => {
+                    let Some(item) = self
+                        .context
+                        .item_query()
+                        .semantic_item_for_local_def(local_def)?
+                    else {
+                        continue;
+                    };
+                    match item {
+                        SemanticItemRef::Function(function) => {
+                            candidates.push(BodyValueCandidate::Function(function));
+                        }
+                        SemanticItemRef::Const(const_ref) => {
+                            candidates.push(BodyValueCandidate::Const(const_ref));
+                        }
+                        SemanticItemRef::Static(static_ref) => {
+                            candidates.push(BodyValueCandidate::Static(static_ref));
+                        }
+                        SemanticItemRef::TypeDef(_)
+                        | SemanticItemRef::Trait(_)
+                        | SemanticItemRef::Impl(_)
+                        | SemanticItemRef::TypeAlias(_) => {}
+                    }
+                }
+                DefId::EnumVariant(variant_def) => {
+                    if let Some(candidate) = self.enum_variant_candidate(variant_def)? {
+                        candidates.push(candidate);
+                    }
+                }
+                DefId::Module(_) => {}
             }
         }
 
-        Ok(items)
+        Ok(candidates)
     }
 
     /// Convert one value-namespace match into body resolution and type.
@@ -302,28 +326,28 @@ where
                 let ty = self.context.body().binding_ty_unchecked(binding).clone();
                 Ok(Some((BodyResolution::Binding(binding), ty)))
             }
-            BodyValueName::SemanticItems(items) => {
+            BodyValueName::Candidates(candidates) => {
                 let mut functions = UniqueVec::new();
                 let mut declarations = UniqueVec::new();
                 let mut tys = ExpectedUnique::new();
 
-                for item in items {
-                    match item {
-                        SemanticItemRef::Function(function) => {
+                for candidate in candidates {
+                    match candidate {
+                        BodyValueCandidate::Function(function) => {
                             functions.push(DeclarationRef::from(function));
                         }
-                        SemanticItemRef::Const(const_ref) => {
+                        BodyValueCandidate::Const(const_ref) => {
                             declarations.push(DeclarationRef::from(const_ref));
                             tys.push(self.semantic_const_ty(const_ref)?);
                         }
-                        SemanticItemRef::Static(static_ref) => {
+                        BodyValueCandidate::Static(static_ref) => {
                             declarations.push(DeclarationRef::from(static_ref));
                             tys.push(self.semantic_static_ty(static_ref)?);
                         }
-                        SemanticItemRef::TypeDef(_)
-                        | SemanticItemRef::Trait(_)
-                        | SemanticItemRef::Impl(_)
-                        | SemanticItemRef::TypeAlias(_) => {}
+                        BodyValueCandidate::EnumVariant(variant_ref, ty) => {
+                            declarations.push(DeclarationRef::EnumVariant(variant_ref));
+                            tys.push(ty);
+                        }
                     }
                 }
 
@@ -347,52 +371,9 @@ where
         &self,
         defs: &[DefId],
     ) -> Result<Option<(BodyResolution, Ty)>, PackageStoreError> {
-        let mut functions = UniqueVec::new();
-        let mut declarations = UniqueVec::new();
-        let mut tys = ExpectedUnique::new();
-
-        for def in defs {
-            let DefId::Local(local_def) = *def else {
-                continue;
-            };
-            let Some(item) = self
-                .context
-                .item_query()
-                .semantic_item_for_local_def(local_def)?
-            else {
-                continue;
-            };
-
-            match item {
-                SemanticItemRef::Function(_) => {
-                    functions.push(DeclarationRef::from(*def));
-                }
-                SemanticItemRef::Const(const_ref) => {
-                    declarations.push(DeclarationRef::from(const_ref));
-                    tys.push(self.semantic_const_ty(const_ref)?);
-                }
-                SemanticItemRef::Static(static_ref) => {
-                    declarations.push(DeclarationRef::from(static_ref));
-                    tys.push(self.semantic_static_ty(static_ref)?);
-                }
-                SemanticItemRef::TypeDef(_)
-                | SemanticItemRef::Trait(_)
-                | SemanticItemRef::Impl(_)
-                | SemanticItemRef::TypeAlias(_) => {}
-            }
-        }
-
-        if !declarations.is_empty() {
-            return Ok(Some((
-                BodyResolution::Declarations(declarations),
-                tys.into_ty(),
-            )));
-        }
-        if !functions.is_empty() {
-            return Ok(Some((BodyResolution::Declarations(functions), Ty::Unknown)));
-        }
-
-        Ok(None)
+        self.value_name_resolution(BodyValueName::Candidates(
+            self.value_candidates_for_defs(defs.iter().copied())?,
+        ))
     }
 
     /// Resolve the declared type of a const item.
@@ -428,6 +409,47 @@ where
             .resolve(ty)
     }
 
+    /// Build the constructor-like value type for an imported enum variant.
+    fn enum_variant_candidate(
+        &self,
+        variant_def: LocalEnumVariantRef,
+    ) -> Result<Option<BodyValueCandidate>, PackageStoreError> {
+        let def_maps = self.context.def_map_query();
+        let item_query = self.context.item_query();
+        if let Some(variant_def_data) = def_maps.local_enum_variant_data(variant_def)?
+            && let Some(variant_ref) = item_query.enum_variant_ref_for_local_def_index(
+                LocalDefRef {
+                    origin: variant_def.origin,
+                    local_def: variant_def_data.enum_def,
+                },
+                variant_def_data.index,
+                Some(variant_def_data.name.as_str()),
+            )?
+            && let Some(variant_data) = item_query.enum_variant_data(variant_ref)?
+        {
+            let args = item_query
+                .generic_params_for_type_def(variant_data.owner)?
+                .map(|generics| {
+                    generics
+                        .types
+                        .iter()
+                        .map(|_| GenericArg::Type(Box::new(Ty::Unknown)))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            Ok(Some(BodyValueCandidate::EnumVariant(
+                variant_ref,
+                Ty::nominal(NominalTy {
+                    def: variant_data.owner,
+                    args,
+                }),
+            )))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Turn constructor-capable type defs into value declarations and their nominal type.
     fn constructor_resolution_from_defs(
         &self,
@@ -453,7 +475,7 @@ where
             {
                 continue;
             }
-            declarations.push(DeclarationRef::from(*def));
+            declarations.push(DeclarationRef::LocalDef(*local_def));
             type_defs.push(NominalTy::bare(type_def));
         }
 

--- a/crates/engine/body-ir/src/resolution/query/value_path.rs
+++ b/crates/engine/body-ir/src/resolution/query/value_path.rs
@@ -211,6 +211,7 @@ where
             let defs = self
                 .context
                 .def_map_query()
+                .scope_resolver()
                 .resolve_lexical_name_in_module(
                     from,
                     module,
@@ -234,10 +235,12 @@ where
         path: &Path,
     ) -> Result<ResolvePathResult, PackageStoreError> {
         let owner_module = self.context.body().owner_module();
-        let result = self
-            .context
-            .def_map_query()
-            .resolve_path(owner_module, path)?;
+        let def_maps = self.context.def_map_query();
+        let result = def_maps.scope_resolver().resolve_path(
+            owner_module,
+            path,
+            NameResolutionFilter::AllNamespaces,
+        )?;
         if !result.resolved.is_empty() {
             return Ok(result);
         }
@@ -247,9 +250,11 @@ where
             return Ok(result);
         }
 
-        self.context
-            .def_map_query()
-            .resolve_path(fallback_module, path)
+        def_maps.scope_resolver().resolve_path(
+            fallback_module,
+            path,
+            NameResolutionFilter::AllNamespaces,
+        )
     }
 
     /// Resolve a multi-segment value path through the body def map.
@@ -265,6 +270,7 @@ where
         let defs = self
             .context
             .def_map_query()
+            .scope_resolver()
             .resolve_lexical_path(from, path, NameResolutionFilter::ValuesOnly)?
             .resolved;
         self.value_name_resolution(BodyValueName::Candidates(
@@ -414,9 +420,11 @@ where
         &self,
         variant_def: LocalEnumVariantRef,
     ) -> Result<Option<BodyValueCandidate>, PackageStoreError> {
-        let def_maps = self.context.def_map_query();
+        let def_maps = self.context.def_map_source();
         let item_query = self.context.item_query();
-        if let Some(variant_def_data) = def_maps.local_enum_variant_data(variant_def)?
+        if let Some(variant_def_data) = def_maps
+            .def_map_for_origin(variant_def.origin)?
+            .and_then(|def_map| def_map.local_enum_variant(variant_def.local_enum_variant))
             && let Some(variant_ref) = item_query.enum_variant_ref_for_local_def_index(
                 LocalDefRef {
                     origin: variant_def.origin,

--- a/crates/engine/body-ir/src/resolution/query/value_path.rs
+++ b/crates/engine/body-ir/src/resolution/query/value_path.rs
@@ -1,9 +1,9 @@
 //! Value-path lookup.
 
 use rg_ir_model::{
-    BindingId, ConstRef, DefId, DefMapRef, EnumVariantRef, FunctionRef, LocalDefRef,
-    LocalEnumVariantRef, ModuleId, ModuleRef, Path, ScopeId, SemanticItemRef, StaticRef,
-    TypePathResolution, identity::DeclarationRef,
+    BindingId, ConstRef, DefId, DefMapRef, EnumVariantRef, FunctionRef, LocalEnumVariantRef,
+    ModuleId, ModuleRef, Path, ScopeId, SemanticItemRef, StaticRef, TypePathResolution,
+    identity::DeclarationRef,
 };
 use rg_ir_storage::{
     DefMapSource, ItemStoreSource, NameResolutionFilter, ResolvePathResult, TypePathContext,
@@ -422,17 +422,9 @@ where
     ) -> Result<Option<BodyValueCandidate>, PackageStoreError> {
         let def_maps = self.context.def_map_source();
         let item_query = self.context.item_query();
-        if let Some(variant_def_data) = def_maps
-            .def_map_for_origin(variant_def.origin)?
-            .and_then(|def_map| def_map.local_enum_variant(variant_def.local_enum_variant))
-            && let Some(variant_ref) = item_query.enum_variant_ref_for_local_def_index(
-                LocalDefRef {
-                    origin: variant_def.origin,
-                    local_def: variant_def_data.enum_def,
-                },
-                variant_def_data.index,
-                Some(variant_def_data.name.as_str()),
-            )?
+        if let Some(variant_def_data) = def_maps.local_enum_variant_data(variant_def)?
+            && let Some(variant_ref) =
+                item_query.enum_variant_ref_for_local_enum_variant(variant_def, variant_def_data)?
             && let Some(variant_data) = item_query.enum_variant_data(variant_ref)?
         {
             let args = item_query

--- a/crates/engine/body-ir/src/resolution/source/context.rs
+++ b/crates/engine/body-ir/src/resolution/source/context.rs
@@ -63,6 +63,10 @@ where
         DefMapQuery::new(self.source)
     }
 
+    pub(crate) fn def_map_source(&self) -> BodyQuerySource<'a, D, I> {
+        self.source
+    }
+
     pub(crate) fn item_query(&self) -> ItemStoreQuery<'a, BodyQuerySource<'a, D, I>> {
         ItemStoreQuery::new(self.source)
     }

--- a/crates/engine/body-ir/src/tests/body_local_items.rs
+++ b/crates/engine/body-ir/src/tests/body_local_items.rs
@@ -753,7 +753,7 @@ pub fn use_it() {
               tail
                 expr e1 call => nominal struct body_more_local_items_fixture[lib]::crate::GlobalId @ 23:13-23:21
                   callee
-                    expr e0 path helper -> item fn fn body_more_local_items_fixture[lib]::crate::use_it::helper => <unknown> @ 23:13-23:19
+                    expr e0 path helper -> fn fn body_more_local_items_fixture[lib]::crate::use_it::helper => <unknown> @ 23:13-23:19
         "#]],
     );
 }

--- a/crates/engine/body-ir/src/tests/expressions.rs
+++ b/crates/engine/body-ir/src/tests/expressions.rs
@@ -80,7 +80,7 @@ impl User {
                 initializer
                   expr e6 call => nominal struct body_expr_fixture[lib]::crate::UserId @ 15:30-15:42
                     callee
-                      expr e4 path identity -> item fn body_expr_fixture[lib]::crate::identity => <unknown> @ 15:30-15:38
+                      expr e4 path identity -> fn body_expr_fixture[lib]::crate::identity => <unknown> @ 15:30-15:38
                     arg
                       expr e5 path id -> local v1 => nominal struct body_expr_fixture[lib]::crate::UserId @ 15:39-15:41
               stmt s3 let v5 @ 16:9-16:29
@@ -1048,7 +1048,7 @@ pub fn use_it(mut pair: (u8, u8), mut slots: [u8; 3], value: u8, user: User) {
                   value
                     expr e64 call => ! @ 26:12-26:19
                       callee
-                        expr e63 path never -> item fn body_common_expr_fixture[lib]::crate::never => <unknown> @ 26:12-26:17
+                        expr e63 path never -> fn body_common_expr_fixture[lib]::crate::never => <unknown> @ 26:12-26:17
         "#]],
     );
 }

--- a/crates/engine/body-ir/src/tests/inference.rs
+++ b/crates/engine/body-ir/src/tests/inference.rs
@@ -60,11 +60,11 @@ pub fn use_it(user: User) {
                 initializer
                   expr e3 call => nominal struct body_assignment_inference_fixture[lib]::crate::User @ 7:21-7:34
                     callee
-                      expr e0 path id -> item fn body_assignment_inference_fixture[lib]::crate::id => <unknown> @ 7:21-7:23
+                      expr e0 path id -> fn body_assignment_inference_fixture[lib]::crate::id => <unknown> @ 7:21-7:23
                     arg
                       expr e2 call => nominal struct body_assignment_inference_fixture[lib]::crate::User @ 7:24-7:33
                         callee
-                          expr e1 path missing -> item fn body_assignment_inference_fixture[lib]::crate::missing => <unknown> @ 7:24-7:31
+                          expr e1 path missing -> fn body_assignment_inference_fixture[lib]::crate::missing => <unknown> @ 7:24-7:31
               stmt s1 expr; @ 8:5-8:18
                 expr e6 assign = => () @ 8:5-8:17
                   target
@@ -73,6 +73,62 @@ pub fn use_it(user: User) {
                     expr e5 path user -> local v0 => nominal struct body_assignment_inference_fixture[lib]::crate::User @ 8:13-8:17
               stmt s2 expr; @ 9:5-9:11
                 expr e7 path value -> local v1 => nominal struct body_assignment_inference_fixture[lib]::crate::User @ 9:5-9:10
+        "#]],
+    );
+}
+
+#[test]
+fn infers_imported_enum_variant_constructors() {
+    check_project_body_ir(
+        r#"
+//- /Cargo.toml
+[package]
+name = "body_imported_enum_variant_inference"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub enum Option<T> {
+    Some(T),
+    None,
+}
+
+use Option::{Some, None};
+
+pub fn use_it() {
+    let value = Some(10u8);
+    let absent: Option<u8> = None;
+    value;
+    absent;
+}
+"#,
+        expect![[r#"
+            package body_imported_enum_variant_inference
+
+            body_imported_enum_variant_inference [lib]
+            body b0 fn body_imported_enum_variant_inference[lib]::crate::use_it @ 8:1-13:2
+            scopes
+            - s0 parent <none>: <none>
+            - s1 parent s0: v0, v1
+            bindings
+            - v0 let value `value` => nominal enum body_imported_enum_variant_inference[lib]::crate::Option<u8> @ 9:9-9:14
+            - v1 let absent `absent`: Option<u8> => nominal enum body_imported_enum_variant_inference[lib]::crate::Option<u8> @ 10:9-10:15
+            body
+            expr e6 block s1 => () @ 8:17-13:2
+              stmt s0 let v0 @ 9:5-9:28
+                initializer
+                  expr e2 call => nominal enum body_imported_enum_variant_inference[lib]::crate::Option<u8> @ 9:17-9:27
+                    callee
+                      expr e0 path Some -> variant enum body_imported_enum_variant_inference[lib]::crate::Option::Some => nominal enum body_imported_enum_variant_inference[lib]::crate::Option<<unknown>> @ 9:17-9:21
+                    arg
+                      expr e1 literal int `10u8` => u8 @ 9:22-9:26
+              stmt s1 let v1: Option<u8> @ 10:5-10:35
+                initializer
+                  expr e3 path None -> variant enum body_imported_enum_variant_inference[lib]::crate::Option::None => nominal enum body_imported_enum_variant_inference[lib]::crate::Option<<unknown>> @ 10:30-10:34
+              stmt s2 expr; @ 11:5-11:11
+                expr e4 path value -> local v0 => nominal enum body_imported_enum_variant_inference[lib]::crate::Option<u8> @ 11:5-11:10
+              stmt s3 expr; @ 12:5-12:12
+                expr e5 path absent -> local v1 => nominal enum body_imported_enum_variant_inference[lib]::crate::Option<u8> @ 12:5-12:11
         "#]],
     );
 }
@@ -429,7 +485,7 @@ pub fn unrelated_collect(iter: NotIterator<User>) {
               tail
                 expr e1 call => <unknown> @ 18:9-18:18
                   callee
-                    expr e0 path missing -> item fn body_conservative_trait_obligation_solving[lib]::crate::missing => <unknown> @ 18:9-18:16
+                    expr e0 path missing -> fn body_conservative_trait_obligation_solving[lib]::crate::missing => <unknown> @ 18:9-18:16
 
 
             body b4 fn impl NotIterator<T>::collect @ 27:5-29:6
@@ -443,7 +499,7 @@ pub fn unrelated_collect(iter: NotIterator<User>) {
               tail
                 expr e1 call => <unknown> @ 28:9-28:18
                   callee
-                    expr e0 path missing -> item fn body_conservative_trait_obligation_solving[lib]::crate::missing => <unknown> @ 28:9-28:16
+                    expr e0 path missing -> fn body_conservative_trait_obligation_solving[lib]::crate::missing => <unknown> @ 28:9-28:16
         "#]],
     );
 }

--- a/crates/engine/body-ir/src/tests/macro_expansion.rs
+++ b/crates/engine/body-ir/src/tests/macro_expansion.rs
@@ -634,7 +634,7 @@ pub mod prelude {
               tail
                 expr e1 call => i32 @ 11:5-11:19
                   callee
-                    expr e0 path $crate::dep_value -> item fn dep[lib]::crate::dep_value => <unknown> @ 11:5-11:19
+                    expr e0 path $crate::dep_value -> fn dep[lib]::crate::dep_value => <unknown> @ 11:5-11:19
 
 
             body b1 fn app[lib]::crate::via_cfg_select @ 14:1-16:2
@@ -647,7 +647,7 @@ pub mod prelude {
               tail
                 expr e1 call => i32 @ 15:5-15:26
                   callee
-                    expr e0 path $crate::dep_value -> item fn dep[lib]::crate::dep_value => <unknown> @ 15:5-15:26
+                    expr e0 path $crate::dep_value -> fn dep[lib]::crate::dep_value => <unknown> @ 15:5-15:26
 
 
             package core

--- a/crates/engine/body-ir/src/tests/targets.rs
+++ b/crates/engine/body-ir/src/tests/targets.rs
@@ -61,7 +61,7 @@ fn main() {
                 initializer
                   expr e1 call => nominal struct body_bin_fixture[lib]::crate::Api @ 2:38-2:62
                     callee
-                      expr e0 path body_bin_fixture::make -> item fn body_bin_fixture[lib]::crate::make => <unknown> @ 2:38-2:60
+                      expr e0 path body_bin_fixture::make -> fn body_bin_fixture[lib]::crate::make => <unknown> @ 2:38-2:60
               stmt s1 let v1: body_bin_fixture::Api @ 3:5-3:44
                 initializer
                   expr e2 path api -> local v0 => nominal struct body_bin_fixture[lib]::crate::Api @ 3:40-3:43

--- a/crates/engine/body-ir/src/tests/utils.rs
+++ b/crates/engine/body-ir/src/tests/utils.rs
@@ -1093,6 +1093,35 @@ impl TargetBodyIrSnapshot<'_> {
         match def {
             DefId::Module(module_ref) => format!("module {}", self.render_module_ref(module_ref)),
             DefId::Local(local_def) => self.render_local_def(local_def),
+            DefId::EnumVariant(variant_def) => {
+                let variant_data = match variant_def.origin {
+                    DefMapRef::Target(target) => {
+                        self.project.resident_def_map(target).and_then(|def_map| {
+                            def_map.local_enum_variant(variant_def.local_enum_variant)
+                        })
+                    }
+                    DefMapRef::Body(body) => {
+                        self.project
+                            .resident_body_def_map(body)
+                            .and_then(|def_map| {
+                                def_map.local_enum_variant(variant_def.local_enum_variant)
+                            })
+                    }
+                };
+                if let Some(variant_data) = variant_data
+                    && let Some(items) = self.project.resident_item_store(variant_def.origin)
+                    && let Some(ItemId::Enum(enum_id)) =
+                        items.item_for_local_def(variant_data.enum_def)
+                {
+                    self.render_enum_variant_ref(EnumVariantRef {
+                        origin: variant_def.origin,
+                        enum_id,
+                        index: variant_data.index,
+                    })
+                } else {
+                    "variant <unresolved>".to_string()
+                }
+            }
         }
     }
 

--- a/crates/engine/def-map/src/build/collect.rs
+++ b/crates/engine/def-map/src/build/collect.rs
@@ -18,13 +18,15 @@ use rg_cfg_eval::{CfgEvaluator, CfgOptions};
 use rg_ir_model::{DefId, DefMapRef, LocalDefId, LocalDefRef, ModuleId, ModuleRef, TargetRef};
 use rg_ir_storage::{
     DefMapBuilder, ImportBinding, ImportData, ImportKind, ImportPath, ImportSourcePath,
-    LocalDefData, LocalDefKind, LocalImplData, MacroDefinitionData, ModuleData, ModuleOrigin,
-    ModuleScope, ModuleScopeBuilder, Namespace, ScopeBinding, ScopeBindingOrigin,
+    LocalDefData, LocalDefKind, LocalEnumVariantData, LocalImplData, MacroDefinitionData,
+    ModuleData, ModuleOrigin, ModuleScope, ModuleScopeBuilder, Namespace, ScopeBinding,
+    ScopeBindingOrigin,
 };
 use rg_item_tree::{
-    Documentation, ExternCrateItem, ItemKind, ItemNode, ItemTreeDb, ItemTreeId, ItemTreeRef,
-    MacroCallItem, MacroDefinitionAttrs, MacroDefinitionItem, MacroUseAttr, MacroUseSelector,
-    ModuleItem, ModuleSource, Package as ItemTreePackage, UseImport, UseItem, VisibilityLevel,
+    Documentation, EnumItem, ExternCrateItem, ItemKind, ItemNode, ItemTreeDb, ItemTreeId,
+    ItemTreeRef, MacroCallItem, MacroDefinitionAttrs, MacroDefinitionItem, MacroUseAttr,
+    MacroUseSelector, ModuleItem, ModuleSource, Package as ItemTreePackage, UseImport, UseItem,
+    VisibilityLevel,
 };
 use rg_parse::{Package, Target};
 use rg_text::Name;
@@ -307,6 +309,9 @@ impl<'db> TargetScopeCollector<'db> {
                 ItemKind::MacroDefinition(macro_definition) => {
                     self.collect_macro_definition(module_id, item, source, macro_definition, order);
                 }
+                ItemKind::Enum(enum_item) => {
+                    self.collect_enum(module_id, item, source, enum_item);
+                }
                 _ => {
                     self.collect_local_def(module_id, item, source);
                 }
@@ -366,6 +371,35 @@ impl<'db> TargetScopeCollector<'db> {
                 },
             );
         Some(local_def_id)
+    }
+
+    /// Records enum variants as value-namespace import targets without injecting them into the
+    /// enclosing module scope. Variants become bare names only through explicit/prelude/glob
+    /// imports, while `Enum::Variant` is handled by path resolution against this table.
+    fn collect_enum(
+        &mut self,
+        module_id: ModuleId,
+        item: &ItemNode,
+        source: ItemTreeRef,
+        enum_item: &EnumItem,
+    ) {
+        let Some(local_def_id) = self.collect_local_def(module_id, item, source) else {
+            return;
+        };
+
+        for (index, variant) in enum_item.variants.iter().enumerate() {
+            self.def_map_builder
+                .alloc_local_enum_variant(LocalEnumVariantData {
+                    module: module_id,
+                    enum_def: local_def_id,
+                    name: variant.name.clone(),
+                    index,
+                    visibility: item.visibility.clone(),
+                    file_id: item.file_id,
+                    name_span: variant.name_span,
+                    span: variant.span,
+                });
+        }
     }
 
     /// Records a macro definition both as a normal macro-namespace binding and as macro payload

--- a/crates/engine/def-map/src/build/finalize/mod.rs
+++ b/crates/engine/def-map/src/build/finalize/mod.rs
@@ -17,7 +17,7 @@ use rg_ir_model::{
 use rg_ir_storage::{
     DefMap, ImportPath, LocalDefData, LocalEnumVariantEntry, MacroDefinitionEnv,
     MacroDefinitionView, ModuleData, ModuleScopeBuilder, PackageDefMaps as DefMapPackage,
-    PathResolver, ScopeEntryRef, ScopeResolutionEnv, TargetData, TargetResolutionEnv,
+    ScopeResolver, ScopeEntryRef, ScopeResolutionEnv, TargetData, TargetResolutionEnv,
 };
 use rg_item_tree::ItemTreeDb;
 use rg_macro_runtime::{MacroExpansionPerformancePreference, MacroExpansionRuntime};
@@ -556,7 +556,7 @@ fn select_preludes(
 
             for prelude_path in prelude_paths.into_iter().flatten() {
                 let root_module = ModuleRef::target(state.target, state.root_module);
-                prelude_module = PathResolver::new(&env)
+                prelude_module = ScopeResolver::new(&env)
                     .import_modules(root_module, &prelude_path)?
                     .into_iter()
                     .next();

--- a/crates/engine/def-map/src/build/finalize/mod.rs
+++ b/crates/engine/def-map/src/build/finalize/mod.rs
@@ -555,8 +555,9 @@ fn select_preludes(
             ];
 
             for prelude_path in prelude_paths.into_iter().flatten() {
+                let root_module = ModuleRef::target(state.target, state.root_module);
                 prelude_module = PathResolver::new(&env)
-                    .import_modules(state.target, state.root_module, &prelude_path)?
+                    .import_modules(root_module, &prelude_path)?
                     .into_iter()
                     .next();
                 if prelude_module.is_some() {

--- a/crates/engine/def-map/src/build/finalize/mod.rs
+++ b/crates/engine/def-map/src/build/finalize/mod.rs
@@ -11,13 +11,11 @@ mod rebuild;
 
 use anyhow::Context as _;
 
-use rg_ir_model::{
-    DefId, DefMapRef, LocalDefRef, ModuleId, ModuleRef, TargetRef,
-};
+use rg_ir_model::{DefId, DefMapRef, LocalDefRef, ModuleId, ModuleRef, TargetRef};
 use rg_ir_storage::{
     DefMap, ImportPath, LocalDefData, LocalEnumVariantEntry, MacroDefinitionEnv,
     MacroDefinitionView, ModuleData, ModuleScopeBuilder, PackageDefMaps as DefMapPackage,
-    ScopeResolver, ScopeEntryRef, ScopeResolutionEnv, TargetData, TargetResolutionEnv,
+    ScopeEntryRef, ScopeResolutionEnv, ScopeResolver, TargetData, TargetResolutionEnv,
 };
 use rg_item_tree::ItemTreeDb;
 use rg_macro_runtime::{MacroExpansionPerformancePreference, MacroExpansionRuntime};

--- a/crates/engine/def-map/src/build/finalize/mod.rs
+++ b/crates/engine/def-map/src/build/finalize/mod.rs
@@ -11,11 +11,13 @@ mod rebuild;
 
 use anyhow::Context as _;
 
-use rg_ir_model::{DefId, DefMapRef, LocalDefRef, ModuleId, ModuleRef, TargetRef};
+use rg_ir_model::{
+    DefId, DefMapRef, LocalDefRef, ModuleId, ModuleRef, TargetRef,
+};
 use rg_ir_storage::{
-    DefMap, ImportPath, LocalDefData, MacroDefinitionEnv, MacroDefinitionView, ModuleData,
-    ModuleScopeBuilder, PackageDefMaps as DefMapPackage, PathResolver, ScopeEntryRef,
-    ScopeResolutionEnv, TargetData, TargetResolutionEnv,
+    DefMap, ImportPath, LocalDefData, LocalEnumVariantEntry, MacroDefinitionEnv,
+    MacroDefinitionView, ModuleData, ModuleScopeBuilder, PackageDefMaps as DefMapPackage,
+    PathResolver, ScopeEntryRef, ScopeResolutionEnv, TargetData, TargetResolutionEnv,
 };
 use rg_item_tree::ItemTreeDb;
 use rg_macro_runtime::{MacroExpansionPerformancePreference, MacroExpansionRuntime};
@@ -309,6 +311,32 @@ impl ScopeResolutionEnv for FinalizeResolutionEnv<'_> {
             })
             .transpose()
             .map(Option::flatten)
+    }
+
+    fn local_enum_variant_entries_for_enum<'a>(
+        &'a self,
+        enum_def: LocalDefRef,
+    ) -> Result<Vec<LocalEnumVariantEntry<'a>>, rg_package_store::PackageStoreError> {
+        if let Some(target) = enum_def.origin.as_target_ref()
+            && let Some(state) = self.states.target(target)
+        {
+            return Ok(state
+                .def_map_builder
+                .partial()
+                .local_enum_variant_entries_for_enum(enum_def.local_def)
+                .collect());
+        }
+
+        if let Some(target) = enum_def.origin.as_target_ref()
+            && let Some(old) = self.old
+            && let Some(def_map) = old.def_map(target)?
+        {
+            Ok(def_map
+                .local_enum_variant_entries_for_enum(enum_def.local_def)
+                .collect())
+        } else {
+            Ok(Vec::new())
+        }
     }
 }
 

--- a/crates/engine/def-map/src/build/imports.rs
+++ b/crates/engine/def-map/src/build/imports.rs
@@ -7,8 +7,7 @@
 
 use rg_ir_model::{ImportId, ModuleRef, TargetRef};
 use rg_ir_storage::{
-    GlobImportSource, ImportKind, Namespace, ScopeBinding, ScopeBindingOrigin, ScopeResolver,
-    TargetResolutionEnv,
+    ImportKind, ScopeBinding, ScopeBindingOrigin, ScopeResolver, TargetResolutionEnv,
 };
 
 use super::{
@@ -84,39 +83,18 @@ pub(super) fn apply_imports(
                     let target_scope = next_scopes
                         .module_scope_mut(state.target, import.module)
                         .expect("target scope should exist for every import");
+                    let source_scope =
+                        resolver.visible_glob_source_scope(import_owner, glob_source)?;
 
-                    match glob_source {
-                        GlobImportSource::Module(source_module) => {
-                            let source_scope =
-                                resolver.visible_scope(import_owner, source_module)?;
-
-                            // Visibility is attached to the binding introduced by the glob import,
-                            // not to the original definition.
-                            for (name, entry) in source_scope.entries() {
-                                target_scope.copy_visible_bindings(
-                                    name,
-                                    entry,
-                                    import.visibility.clone(),
-                                    import_owner,
-                                );
-                            }
-                        }
-                        GlobImportSource::Enum(enum_def) => {
-                            for (name, binding) in
-                                resolver.visible_enum_variant_bindings(import_owner, enum_def)?
-                            {
-                                target_scope.insert_binding(
-                                    &name,
-                                    Namespace::Values,
-                                    ScopeBinding {
-                                        def: binding.def,
-                                        visibility: import.visibility.clone(),
-                                        owner: import_owner,
-                                        origin: ScopeBindingOrigin::Import,
-                                    },
-                                );
-                            }
-                        }
+                    // Visibility is attached to the binding introduced by the glob import,
+                    // not to the original definition.
+                    for (name, entry) in source_scope.entries() {
+                        target_scope.copy_visible_bindings(
+                            name,
+                            entry,
+                            import.visibility.clone(),
+                            import_owner,
+                        );
                     }
                 }
             }

--- a/crates/engine/def-map/src/build/imports.rs
+++ b/crates/engine/def-map/src/build/imports.rs
@@ -7,7 +7,7 @@
 
 use rg_ir_model::{ImportId, ModuleRef, TargetRef};
 use rg_ir_storage::{
-    GlobImportSource, ImportKind, Namespace, ScopeResolver, ScopeBinding, ScopeBindingOrigin,
+    GlobImportSource, ImportKind, Namespace, ScopeBinding, ScopeBindingOrigin, ScopeResolver,
     TargetResolutionEnv,
 };
 
@@ -139,13 +139,13 @@ pub(super) fn apply_imports(
                     target_scope.insert_binding(
                         &binding_name,
                         namespace,
-                            ScopeBinding {
-                                def: resolved_def,
-                                visibility: import.visibility.clone(),
-                                owner: import_owner,
-                                origin: ScopeBindingOrigin::Import,
-                            },
-                        );
+                        ScopeBinding {
+                            def: resolved_def,
+                            visibility: import.visibility.clone(),
+                            owner: import_owner,
+                            origin: ScopeBindingOrigin::Import,
+                        },
+                    );
                 }
             }
         }
@@ -167,9 +167,9 @@ fn unresolved_imports_for_target(
             ImportKind::Glob => resolver
                 .import_glob_sources(import_owner, &import.path)?
                 .is_empty(),
-            ImportKind::Named | ImportKind::SelfImport => resolver
-                .import_defs(import_owner, &import.path)?
-                .is_empty(),
+            ImportKind::Named | ImportKind::SelfImport => {
+                resolver.import_defs(import_owner, &import.path)?.is_empty()
+            }
         };
         if is_unresolved {
             module_imports

--- a/crates/engine/def-map/src/build/imports.rs
+++ b/crates/engine/def-map/src/build/imports.rs
@@ -7,7 +7,8 @@
 
 use rg_ir_model::{DefMapRef, ImportId, ModuleRef, TargetRef};
 use rg_ir_storage::{
-    ImportKind, PathResolver, ScopeBinding, ScopeBindingOrigin, TargetResolutionEnv,
+    GlobImportSource, ImportKind, Namespace, PathResolver, ScopeBinding, ScopeBindingOrigin,
+    TargetResolutionEnv,
 };
 
 use super::{
@@ -76,28 +77,50 @@ pub(super) fn apply_imports(
     for import in state.def_map_builder.partial().imports().iter() {
         match import.kind {
             ImportKind::Glob => {
-                let source_modules =
-                    resolver.import_modules(state.target, import.module, &import.path)?;
+                let glob_sources =
+                    resolver.import_glob_sources(state.target, import.module, &import.path)?;
 
-                for source_module in source_modules {
+                for glob_source in glob_sources {
                     let import_owner = ModuleRef {
                         origin: DefMapRef::Target(state.target),
                         module: import.module,
                     };
-                    let source_scope = resolver.visible_scope(import_owner, source_module)?;
                     let target_scope = next_scopes
                         .module_scope_mut(state.target, import.module)
                         .expect("target scope should exist for every import");
 
-                    // Visibility is attached to the binding introduced by the glob import, not to
-                    // the original definition.
-                    for (name, entry) in source_scope.entries() {
-                        target_scope.copy_visible_bindings(
-                            name,
-                            entry,
-                            import.visibility.clone(),
-                            import_owner,
-                        );
+                    match glob_source {
+                        GlobImportSource::Module(source_module) => {
+                            let source_scope =
+                                resolver.visible_scope(import_owner, source_module)?;
+
+                            // Visibility is attached to the binding introduced by the glob import,
+                            // not to the original definition.
+                            for (name, entry) in source_scope.entries() {
+                                target_scope.copy_visible_bindings(
+                                    name,
+                                    entry,
+                                    import.visibility.clone(),
+                                    import_owner,
+                                );
+                            }
+                        }
+                        GlobImportSource::Enum(enum_def) => {
+                            for (name, binding) in
+                                resolver.visible_enum_variant_bindings(import_owner, enum_def)?
+                            {
+                                target_scope.insert_binding(
+                                    &name,
+                                    Namespace::Values,
+                                    ScopeBinding {
+                                        def: binding.def,
+                                        visibility: import.visibility.clone(),
+                                        owner: import_owner,
+                                        origin: ScopeBindingOrigin::Import,
+                                    },
+                                );
+                            }
+                        }
                     }
                 }
             }
@@ -149,7 +172,7 @@ fn unresolved_imports_for_target(
     for (import_id, import) in state.def_map_builder.partial().imports_with_ids() {
         let is_unresolved = match import.kind {
             ImportKind::Glob => resolver
-                .import_modules(state.target, import.module, &import.path)?
+                .import_glob_sources(state.target, import.module, &import.path)?
                 .is_empty(),
             ImportKind::Named | ImportKind::SelfImport => resolver
                 .import_defs(state.target, import.module, &import.path)?

--- a/crates/engine/def-map/src/build/imports.rs
+++ b/crates/engine/def-map/src/build/imports.rs
@@ -5,7 +5,7 @@
 //! the imported bindings into the next scope snapshot, and recording imports that still fail once
 //! the fixed point has stabilized.
 
-use rg_ir_model::{DefMapRef, ImportId, ModuleRef, TargetRef};
+use rg_ir_model::{ImportId, ModuleRef, TargetRef};
 use rg_ir_storage::{
     GlobImportSource, ImportKind, Namespace, PathResolver, ScopeBinding, ScopeBindingOrigin,
     TargetResolutionEnv,
@@ -75,16 +75,12 @@ pub(super) fn apply_imports(
 ) -> anyhow::Result<()> {
     let resolver = PathResolver::new(env);
     for import in state.def_map_builder.partial().imports().iter() {
+        let import_owner = ModuleRef::target(state.target, import.module);
         match import.kind {
             ImportKind::Glob => {
-                let glob_sources =
-                    resolver.import_glob_sources(state.target, import.module, &import.path)?;
+                let glob_sources = resolver.import_glob_sources(import_owner, &import.path)?;
 
                 for glob_source in glob_sources {
-                    let import_owner = ModuleRef {
-                        origin: DefMapRef::Target(state.target),
-                        module: import.module,
-                    };
                     let target_scope = next_scopes
                         .module_scope_mut(state.target, import.module)
                         .expect("target scope should exist for every import");
@@ -125,8 +121,7 @@ pub(super) fn apply_imports(
                 }
             }
             ImportKind::Named | ImportKind::SelfImport => {
-                let resolved_defs =
-                    resolver.import_defs(state.target, import.module, &import.path)?;
+                let resolved_defs = resolver.import_defs(import_owner, &import.path)?;
 
                 let Some(binding_name) = import.binding_name() else {
                     continue;
@@ -144,16 +139,13 @@ pub(super) fn apply_imports(
                     target_scope.insert_binding(
                         &binding_name,
                         namespace,
-                        ScopeBinding {
-                            def: resolved_def,
-                            visibility: import.visibility.clone(),
-                            owner: ModuleRef {
-                                origin: DefMapRef::Target(state.target),
-                                module: import.module,
+                            ScopeBinding {
+                                def: resolved_def,
+                                visibility: import.visibility.clone(),
+                                owner: import_owner,
+                                origin: ScopeBindingOrigin::Import,
                             },
-                            origin: ScopeBindingOrigin::Import,
-                        },
-                    );
+                        );
                 }
             }
         }
@@ -170,12 +162,13 @@ fn unresolved_imports_for_target(
     let resolver = PathResolver::new(env);
 
     for (import_id, import) in state.def_map_builder.partial().imports_with_ids() {
+        let import_owner = ModuleRef::target(state.target, import.module);
         let is_unresolved = match import.kind {
             ImportKind::Glob => resolver
-                .import_glob_sources(state.target, import.module, &import.path)?
+                .import_glob_sources(import_owner, &import.path)?
                 .is_empty(),
             ImportKind::Named | ImportKind::SelfImport => resolver
-                .import_defs(state.target, import.module, &import.path)?
+                .import_defs(import_owner, &import.path)?
                 .is_empty(),
         };
         if is_unresolved {

--- a/crates/engine/def-map/src/build/imports.rs
+++ b/crates/engine/def-map/src/build/imports.rs
@@ -7,7 +7,7 @@
 
 use rg_ir_model::{ImportId, ModuleRef, TargetRef};
 use rg_ir_storage::{
-    GlobImportSource, ImportKind, Namespace, PathResolver, ScopeBinding, ScopeBindingOrigin,
+    GlobImportSource, ImportKind, Namespace, ScopeResolver, ScopeBinding, ScopeBindingOrigin,
     TargetResolutionEnv,
 };
 
@@ -73,7 +73,7 @@ pub(super) fn apply_imports(
     env: &impl TargetResolutionEnv<Error = rg_package_store::PackageStoreError>,
     next_scopes: &mut ScopeMatrix,
 ) -> anyhow::Result<()> {
-    let resolver = PathResolver::new(env);
+    let resolver = ScopeResolver::new(env);
     for import in state.def_map_builder.partial().imports().iter() {
         let import_owner = ModuleRef::target(state.target, import.module);
         match import.kind {
@@ -159,7 +159,7 @@ fn unresolved_imports_for_target(
     env: &impl TargetResolutionEnv<Error = rg_package_store::PackageStoreError>,
 ) -> anyhow::Result<Vec<Vec<ImportId>>> {
     let mut module_imports = vec![Vec::new(); state.def_map_builder.partial().module_count()];
-    let resolver = PathResolver::new(env);
+    let resolver = ScopeResolver::new(env);
 
     for (import_id, import) in state.def_map_builder.partial().imports_with_ids() {
         let import_owner = ModuleRef::target(state.target, import.module);

--- a/crates/engine/def-map/src/build/macros/resolve.rs
+++ b/crates/engine/def-map/src/build/macros/resolve.rs
@@ -75,8 +75,10 @@ where
 
         // Qualified calls follow ordinary path resolution for the prefix, then keep the final macro
         // binding so order filtering can distinguish direct definitions from exports/imports.
-        let resolved_bindings =
-            PathResolver::new(self.env).macro_bindings(self.state.target, call.module, path)?;
+        let resolved_bindings = PathResolver::new(self.env).macro_bindings(
+            ModuleRef::target(self.state.target, call.module),
+            path,
+        )?;
         let mut macros = Vec::new();
 
         for binding in resolved_bindings {

--- a/crates/engine/def-map/src/build/macros/resolve.rs
+++ b/crates/engine/def-map/src/build/macros/resolve.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 
 use rg_ir_model::{DefId, DefMapRef, LocalDefRef, ModuleRef, TargetRef};
 use rg_ir_storage::{
-    ImportPath, LocalDefData, MacroDefinitionData, MacroDefinitionEnv, PathResolver, ScopeBinding,
+    ImportPath, LocalDefData, MacroDefinitionData, MacroDefinitionEnv, ScopeResolver, ScopeBinding,
     ScopeBindingOrigin, TargetResolutionEnv,
 };
 use rg_std::ExpectedUnique;
@@ -39,7 +39,7 @@ impl Eq for ResolvedMacroDefinition<'_> {}
 /// Macro calls are mostly path-shaped, but one-segment calls have extra Rust-specific behavior:
 /// textual `macro_rules!` definitions can shadow namespace bindings, legacy `#[macro_use]` imports
 /// are a fallback, and resolved compiler builtin definitions need to carry their builtin identity
-/// into expansion dispatch. This resolver keeps that policy together while reusing `PathResolver`
+/// into expansion dispatch. This resolver keeps that policy together while reusing `ScopeResolver`
 /// for the ordinary namespace work.
 pub(super) struct ItemMacroResolver<'a, E: ?Sized> {
     env: &'a E,
@@ -75,7 +75,7 @@ where
 
         // Qualified calls follow ordinary path resolution for the prefix, then keep the final macro
         // binding so order filtering can distinguish direct definitions from exports/imports.
-        let resolved_bindings = PathResolver::new(self.env).macro_bindings(
+        let resolved_bindings = ScopeResolver::new(self.env).macro_bindings(
             ModuleRef::target(self.state.target, call.module),
             path,
         )?;
@@ -125,7 +125,7 @@ where
             origin: DefMapRef::Target(self.state.target),
             module: call.module,
         };
-        let bindings = PathResolver::new(self.env).visible_unqualified_macro_bindings(
+        let bindings = ScopeResolver::new(self.env).visible_unqualified_macro_bindings(
             importing_module,
             [importing_module],
             name,
@@ -203,7 +203,7 @@ where
                 origin: DefMapRef::Target(self.state.target),
                 module: macro_use.module,
             };
-            for binding in PathResolver::new(self.env).visible_macro_bindings(
+            for binding in ScopeResolver::new(self.env).visible_macro_bindings(
                 import_owner,
                 macro_use.source_module,
                 name,

--- a/crates/engine/def-map/src/build/macros/resolve.rs
+++ b/crates/engine/def-map/src/build/macros/resolve.rs
@@ -7,8 +7,8 @@ use anyhow::Result;
 
 use rg_ir_model::{DefId, DefMapRef, LocalDefRef, ModuleRef, TargetRef};
 use rg_ir_storage::{
-    ImportPath, LocalDefData, MacroDefinitionData, MacroDefinitionEnv, ScopeResolver, ScopeBinding,
-    ScopeBindingOrigin, TargetResolutionEnv,
+    ImportPath, LocalDefData, MacroDefinitionData, MacroDefinitionEnv, ScopeBinding,
+    ScopeBindingOrigin, ScopeResolver, TargetResolutionEnv,
 };
 use rg_std::ExpectedUnique;
 use rg_text::Name;
@@ -75,10 +75,8 @@ where
 
         // Qualified calls follow ordinary path resolution for the prefix, then keep the final macro
         // binding so order filtering can distinguish direct definitions from exports/imports.
-        let resolved_bindings = ScopeResolver::new(self.env).macro_bindings(
-            ModuleRef::target(self.state.target, call.module),
-            path,
-        )?;
+        let resolved_bindings = ScopeResolver::new(self.env)
+            .macro_bindings(ModuleRef::target(self.state.target, call.module), path)?;
         let mut macros = Vec::new();
 
         for binding in resolved_bindings {

--- a/crates/engine/def-map/src/macro_expansion/body/mod.rs
+++ b/crates/engine/def-map/src/macro_expansion/body/mod.rs
@@ -7,7 +7,7 @@
 use anyhow::Context as _;
 
 use rg_ir_model::{DefMapRef, ModuleId, ModuleRef, TargetRef, items::BuiltinMacroKind};
-use rg_ir_storage::{DefMapQuery, ImportPath, MacroDefinitionView, PathResolver};
+use rg_ir_storage::{DefMapQuery, ImportPath, MacroDefinitionView, ScopeResolver};
 use rg_macro_runtime::{CfgSelect, ExpansionParseKind, ExpansionSyntax, MacroExpansionRuntime};
 use rg_std::ExpectedUnique;
 use rg_syntax::{AstNode, Parse, SyntaxNode, ast};
@@ -288,7 +288,7 @@ impl<'db, 'txn> BodyMacroExpander<'db, 'txn> {
             return Self::resolve_single_name_macro(query, target, module.module, name);
         }
 
-        let bindings = PathResolver::new(query)
+        let bindings = ScopeResolver::new(query)
             .macro_bindings(module, path)
             .context("while attempting to resolve qualified body macro path")?;
         let mut macros = ExpectedUnique::new();
@@ -336,7 +336,7 @@ impl<'db, 'txn> BodyMacroExpander<'db, 'txn> {
                 .and_then(|module| module.parent);
         }
 
-        let bindings = PathResolver::new(query)
+        let bindings = ScopeResolver::new(query)
             .visible_unqualified_macro_bindings(importing_module, module_scope_modules, name)
             .context("while attempting to resolve unqualified body macro")?;
 

--- a/crates/engine/def-map/src/macro_expansion/body/mod.rs
+++ b/crates/engine/def-map/src/macro_expansion/body/mod.rs
@@ -7,7 +7,7 @@
 use anyhow::Context as _;
 
 use rg_ir_model::{DefMapRef, ModuleId, ModuleRef, TargetRef, items::BuiltinMacroKind};
-use rg_ir_storage::{DefMapQuery, ImportPath, MacroDefinitionView, ScopeResolver};
+use rg_ir_storage::{DefMapQuery, ImportPath, MacroDefinitionView, ScopeResolutionEnv};
 use rg_macro_runtime::{CfgSelect, ExpansionParseKind, ExpansionSyntax, MacroExpansionRuntime};
 use rg_std::ExpectedUnique;
 use rg_syntax::{AstNode, Parse, SyntaxNode, ast};
@@ -288,7 +288,8 @@ impl<'db, 'txn> BodyMacroExpander<'db, 'txn> {
             return Self::resolve_single_name_macro(query, target, module.module, name);
         }
 
-        let bindings = ScopeResolver::new(query)
+        let bindings = query
+            .scope_resolver()
             .macro_bindings(module, path)
             .context("while attempting to resolve qualified body macro path")?;
         let mut macros = ExpectedUnique::new();
@@ -330,13 +331,13 @@ impl<'db, 'txn> BodyMacroExpander<'db, 'txn> {
             };
             module_scope_modules.push(module_ref);
 
-            current = query
-                .module_data(module_ref)
+            current = ScopeResolutionEnv::module_data(query, module_ref)
                 .context("while attempting to fetch parent module for body macro lookup")?
                 .and_then(|module| module.parent);
         }
 
-        let bindings = ScopeResolver::new(query)
+        let bindings = query
+            .scope_resolver()
             .visible_unqualified_macro_bindings(importing_module, module_scope_modules, name)
             .context("while attempting to resolve unqualified body macro")?;
 

--- a/crates/engine/def-map/src/macro_expansion/body/mod.rs
+++ b/crates/engine/def-map/src/macro_expansion/body/mod.rs
@@ -289,7 +289,7 @@ impl<'db, 'txn> BodyMacroExpander<'db, 'txn> {
         }
 
         let bindings = PathResolver::new(query)
-            .macro_bindings(target, module.module, path)
+            .macro_bindings(module, path)
             .context("while attempting to resolve qualified body macro path")?;
         let mut macros = ExpectedUnique::new();
         for binding in bindings {

--- a/crates/engine/def-map/src/tests/imports.rs
+++ b/crates/engine/def-map/src/tests/imports.rs
@@ -90,6 +90,45 @@ use bar::work as _;
 }
 
 #[test]
+fn imports_enum_variants_as_values() {
+    utils::check_project_def_map(
+        r#"
+//- /Cargo.toml
+[package]
+name = "enum_variant_import_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub enum Maybe<T> {
+    Some(T),
+    None,
+}
+
+pub enum Result<T, E> {
+    Ok(T),
+    Err(E),
+}
+
+use Maybe::{Some, None as Nothing};
+use Result::*;
+"#,
+        expect![[r#"
+            package enum_variant_import_fixture
+
+            enum_variant_import_fixture [lib]
+            crate
+            - Err : value [variant enum_variant_import_fixture[lib]::crate::Result::Err]
+            - Maybe : type [pub enum enum_variant_import_fixture[lib]::crate::Maybe]
+            - Nothing : value [variant enum_variant_import_fixture[lib]::crate::Maybe::None]
+            - Ok : value [variant enum_variant_import_fixture[lib]::crate::Result::Ok]
+            - Result : type [pub enum enum_variant_import_fixture[lib]::crate::Result]
+            - Some : value [variant enum_variant_import_fixture[lib]::crate::Maybe::Some]
+        "#]],
+    );
+}
+
+#[test]
 fn records_unresolved_named_and_glob_imports() {
     utils::check_project_def_map(
         r#"

--- a/crates/engine/def-map/src/tests/utils.rs
+++ b/crates/engine/def-map/src/tests/utils.rs
@@ -279,6 +279,7 @@ impl<'a> FixtureEntry<'a> {
         let origin = match binding.def {
             DefId::Module(module_ref) => module_ref.origin,
             DefId::Local(local_def_ref) => local_def_ref.origin,
+            DefId::EnumVariant(variant_ref) => variant_ref.origin,
         };
         let target_ref = origin.as_target_ref()?;
         self.db.parse_db().packages().get(target_ref.package.0)?;
@@ -686,6 +687,7 @@ impl<'a> TargetDefMapSnapshot<'a> {
         let origin = match binding.def {
             DefId::Module(module_ref) => module_ref.origin,
             DefId::Local(local_def_ref) => local_def_ref.origin,
+            DefId::EnumVariant(variant_ref) => variant_ref.origin,
         };
         let target_ref = origin.as_target_ref()?;
         self.project
@@ -804,6 +806,29 @@ impl ResolvedDefOrigin<'_> {
                 });
 
                 format!("{} {}::{}", local_def.kind, module_path, local_def.name)
+            }
+            DefId::EnumVariant(variant_ref) => {
+                let variant = self
+                    .project
+                    .resident_def_map(variant_ref.origin.origin_target())
+                    .expect("target def map should exist while dumping")
+                    .local_enum_variant(variant_ref.local_enum_variant)
+                    .expect("enum variant id should exist while dumping");
+                let enum_def = self
+                    .project
+                    .resident_def_map(variant_ref.origin.origin_target())
+                    .expect("target def map should exist while dumping")
+                    .local_def(variant.enum_def)
+                    .expect("enum def id should exist while dumping");
+                let module_path = self.render_module_path(ModuleRef {
+                    origin: variant_ref.origin,
+                    module: variant.module,
+                });
+
+                format!(
+                    "variant {}::{}::{}",
+                    module_path, enum_def.name, variant.name
+                )
             }
         }
     }

--- a/crates/engine/def-map/src/tests/utils.rs
+++ b/crates/engine/def-map/src/tests/utils.rs
@@ -5,7 +5,10 @@ use rg_ir_model::{
     DefId, DefMapRef, ModuleId, ModuleRef, Path, PathSegment, TargetRef,
     hir::source::{ItemSource, ItemSourceKind},
 };
-use rg_ir_storage::{DefMap, ImportData, ImportKind, ResolvePathResult, ScopeBinding, ScopeEntry};
+use rg_ir_storage::{
+    DefMap, ImportData, ImportKind, NameResolutionFilter, ResolvePathResult, ScopeBinding,
+    ScopeEntry,
+};
 use rg_item_tree::VisibilityLevel;
 use rg_package_store::PackageLoader;
 use rg_parse::{FileId, Package, ParseDb, Target};
@@ -384,12 +387,14 @@ impl<'a> ProjectPathResolutionSnapshot<'a> {
             .def_map_db()
             .read_txn(PackageLoader::resident_only("def-map fixture query"));
         let result = rg_ir_storage::DefMapQuery::new(&def_map)
+            .scope_resolver()
             .resolve_path(
                 ModuleRef {
                     origin: DefMapRef::Target(target_ref),
                     module: module_id,
                 },
                 &path,
+                NameResolutionFilter::AllNamespaces,
             )
             .expect("path resolution fixture should load def-map packages");
 

--- a/crates/engine/ir-model/src/ids/def_map.rs
+++ b/crates/engine/ir-model/src/ids/def_map.rs
@@ -12,6 +12,9 @@ declare_id! {
     /// Stable identifier of one local definition inside a target map.
     pub struct LocalDefId;
 
+    /// Stable identifier of one enum variant inside a target map.
+    pub struct LocalEnumVariantId;
+
     /// Stable identifier of one impl block inside a target map.
     pub struct LocalImplId;
 
@@ -78,6 +81,14 @@ pub struct LocalDefRef {
     pub local_def: LocalDefId,
 }
 
+/// Stable reference to one enum variant across the whole project analysis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SchemaRead, SchemaWrite, MemorySize, Shrink)]
+#[shrink(leaf)]
+pub struct LocalEnumVariantRef {
+    pub origin: DefMapRef,
+    pub local_enum_variant: LocalEnumVariantId,
+}
+
 /// Stable reference to one impl block across the whole project analysis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SchemaRead, SchemaWrite, MemorySize, Shrink)]
 #[shrink(leaf)]
@@ -100,4 +111,5 @@ pub struct ImportRef {
 pub enum DefId {
     Module(ModuleRef),
     Local(LocalDefRef),
+    EnumVariant(LocalEnumVariantRef),
 }

--- a/crates/engine/ir-model/src/ids/def_map.rs
+++ b/crates/engine/ir-model/src/ids/def_map.rs
@@ -73,6 +73,15 @@ pub struct ModuleRef {
     pub module: ModuleId,
 }
 
+impl ModuleRef {
+    pub fn target(target: TargetRef, module: ModuleId) -> Self {
+        Self {
+            origin: DefMapRef::Target(target),
+            module,
+        }
+    }
+}
+
 /// Stable reference to one local definition across the whole project analysis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SchemaRead, SchemaWrite, MemorySize, Shrink)]
 #[shrink(leaf)]

--- a/crates/engine/ir-model/src/ids/identity.rs
+++ b/crates/engine/ir-model/src/ids/identity.rs
@@ -139,21 +139,16 @@ impl DeclarationRef {
         Self::LocalDef(local_def)
     }
 
-    pub fn from_def(def: DefId) -> Self {
+    pub fn try_from_def(def: DefId) -> Option<Self> {
         match def {
-            DefId::Module(module) => Self::Module(module),
-            DefId::Local(local_def) => Self::LocalDef(local_def),
+            DefId::Module(module) => Some(Self::Module(module)),
+            DefId::Local(local_def) => Some(Self::LocalDef(local_def)),
+            DefId::EnumVariant(_) => None,
         }
     }
 
     pub fn body_binding(binding: BodyBindingRef) -> Self {
         Self::BodyBinding(binding)
-    }
-}
-
-impl From<DefId> for DeclarationRef {
-    fn from(def: DefId) -> Self {
-        Self::from_def(def)
     }
 }
 

--- a/crates/engine/ir-model/src/lib.rs
+++ b/crates/engine/ir-model/src/lib.rs
@@ -24,8 +24,8 @@ pub use self::ids::{
     TargetId,
     body::{BindingId, BodyBindingRef, BodyId, BodyRef, ExprId, PatId, ScopeId, StmtId},
     def_map::{
-        DefId, DefMapRef, ImportId, ImportRef, LocalDefId, LocalDefRef, LocalImplId, LocalImplRef,
-        ModuleId, ModuleRef, TargetRef,
+        DefId, DefMapRef, ImportId, ImportRef, LocalDefId, LocalDefRef, LocalEnumVariantId,
+        LocalEnumVariantRef, LocalImplId, LocalImplRef, ModuleId, ModuleRef, TargetRef,
     },
     identity,
     semantic::{

--- a/crates/engine/ir-storage/src/def_map/local.rs
+++ b/crates/engine/ir-storage/src/def_map/local.rs
@@ -1,7 +1,10 @@
 use rg_ir_model::items::{
     BuiltinMacroKind, Documentation, ItemTag, MacroDefinitionItem, VisibilityLevel,
 };
-use rg_ir_model::{LocalDefRef, ModuleId, TargetRef, hir::source::ItemSource};
+use rg_ir_model::{
+    DefMapRef, LocalDefId, LocalDefRef, LocalEnumVariantId, LocalEnumVariantRef, ModuleId,
+    TargetRef, hir::source::ItemSource,
+};
 use rg_parse::{FileId, Span};
 use rg_std::{MemorySize, Shrink};
 use rg_text::Name;
@@ -22,6 +25,46 @@ pub struct LocalDefData {
     pub file_id: FileId,
     pub name_span: Option<Span>,
     pub span: Span,
+}
+
+/// One enum variant that can be named through imports and value paths.
+///
+/// Variants stay semantically owned by `EnumData`, but def-map import resolution runs earlier than
+/// semantic lowering. This record gives the name resolver a small, source-shaped handle that can
+/// later be projected to `EnumVariantRef`.
+#[derive(Debug, Clone, PartialEq, Eq, SchemaRead, SchemaWrite, MemorySize, Shrink)]
+pub struct LocalEnumVariantData {
+    pub module: ModuleId,
+    pub enum_def: LocalDefId,
+    pub name: Name,
+    pub index: usize,
+    pub visibility: VisibilityLevel,
+    pub file_id: FileId,
+    pub name_span: Span,
+    pub span: Span,
+}
+
+/// Borrowed enum variant table entry paired with its stable def-map ref.
+#[derive(Debug, Clone, Copy)]
+pub struct LocalEnumVariantEntry<'a> {
+    pub variant_ref: LocalEnumVariantRef,
+    pub data: &'a LocalEnumVariantData,
+}
+
+impl<'a> LocalEnumVariantEntry<'a> {
+    pub fn new(
+        origin: DefMapRef,
+        local_enum_variant: LocalEnumVariantId,
+        data: &'a LocalEnumVariantData,
+    ) -> Self {
+        Self {
+            variant_ref: LocalEnumVariantRef {
+                origin,
+                local_enum_variant,
+            },
+            data,
+        }
+    }
 }
 
 /// Macro definition facts retained after def-map freezing.

--- a/crates/engine/ir-storage/src/def_map/mod.rs
+++ b/crates/engine/ir-storage/src/def_map/mod.rs
@@ -10,14 +10,14 @@ mod visible;
 pub use self::{
     import::{ImportBinding, ImportData, ImportKind, ImportPath, ImportSourcePath},
     local::{
-        LocalDefData, LocalDefKind, LocalImplData, MacroDefinitionData, MacroDefinitionPayload,
-        MacroDefinitionView,
+        LocalDefData, LocalDefKind, LocalEnumVariantData, LocalEnumVariantEntry, LocalImplData,
+        MacroDefinitionData, MacroDefinitionPayload, MacroDefinitionView,
     },
     module::{ModuleData, ModuleOrigin},
     package::{PackageDefMaps, TargetData},
     query::{
-        DefMapQuery, DefMapSource, MacroDefinitionEnv, NameResolutionFilter, PathResolver,
-        ResolvePathResult, ScopeResolutionEnv, TargetResolutionEnv,
+        DefMapQuery, DefMapSource, GlobImportSource, MacroDefinitionEnv, NameResolutionFilter,
+        PathResolver, ResolvePathResult, ScopeResolutionEnv, TargetResolutionEnv,
     },
     scope::{
         ModuleScope, ModuleScopeBuilder, Namespace, ScopeBinding, ScopeBindingOrigin, ScopeEntry,

--- a/crates/engine/ir-storage/src/def_map/mod.rs
+++ b/crates/engine/ir-storage/src/def_map/mod.rs
@@ -17,7 +17,7 @@ pub use self::{
     package::{PackageDefMaps, TargetData},
     query::{
         DefMapQuery, DefMapSource, GlobImportSource, MacroDefinitionEnv, NameResolutionFilter,
-        PathResolver, ResolvePathResult, ScopeResolutionEnv, TargetResolutionEnv,
+        ScopeResolver, ResolvePathResult, ScopeResolutionEnv, TargetResolutionEnv,
     },
     scope::{
         ModuleScope, ModuleScopeBuilder, Namespace, ScopeBinding, ScopeBindingOrigin, ScopeEntry,

--- a/crates/engine/ir-storage/src/def_map/mod.rs
+++ b/crates/engine/ir-storage/src/def_map/mod.rs
@@ -17,7 +17,7 @@ pub use self::{
     package::{PackageDefMaps, TargetData},
     query::{
         DefMapQuery, DefMapSource, GlobImportSource, MacroDefinitionEnv, NameResolutionFilter,
-        ScopeResolver, ResolvePathResult, ScopeResolutionEnv, TargetResolutionEnv,
+        ResolvePathResult, ScopeResolutionEnv, ScopeResolver, TargetResolutionEnv,
     },
     scope::{
         ModuleScope, ModuleScopeBuilder, Namespace, ScopeBinding, ScopeBindingOrigin, ScopeEntry,

--- a/crates/engine/ir-storage/src/def_map/query/def_map_query.rs
+++ b/crates/engine/ir-storage/src/def_map/query/def_map_query.rs
@@ -3,7 +3,9 @@
 //! DefMaps only know about one scope graph. This query object adds the routing layer that decides
 //! which graph owns a `DefMapRef`, then reuses the private path resolver for the actual lookup.
 
-use rg_ir_model::{DefId, DefMapRef, LocalDefRef, LocalImplRef, ModuleRef, Path, TargetRef};
+use rg_ir_model::{
+    DefId, DefMapRef, LocalDefRef, LocalEnumVariantRef, LocalImplRef, ModuleRef, Path, TargetRef,
+};
 use rg_text::Name;
 
 use super::{
@@ -12,9 +14,9 @@ use super::{
 };
 
 use super::super::{
-    DefMap, LocalDefData, LocalImplData, MacroDefinitionView, ModuleData, ModuleScopeBuilder,
-    Namespace, ScopeEntryRef, ScopeNamespace, VisibleScopeDef, VisibleScopeDefs,
-    VisibleScopeOrigin,
+    DefMap, LocalDefData, LocalEnumVariantData, LocalEnumVariantEntry, LocalImplData,
+    MacroDefinitionView, ModuleData, ModuleScopeBuilder, Namespace, ScopeEntryRef, ScopeNamespace,
+    VisibleScopeDef, VisibleScopeDefs, VisibleScopeOrigin,
 };
 
 /// Routes DefMap-origin refs and target-level facts to concrete storage.
@@ -179,6 +181,31 @@ where
             .and_then(|def_map| def_map.local_impl(local_impl_ref.local_impl)))
     }
 
+    pub fn local_enum_variant_data(
+        &self,
+        local_enum_variant_ref: LocalEnumVariantRef,
+    ) -> Result<Option<&LocalEnumVariantData>, S::Error> {
+        Ok(self
+            .source
+            .def_map_for_origin(local_enum_variant_ref.origin)?
+            .and_then(|def_map| {
+                def_map.local_enum_variant(local_enum_variant_ref.local_enum_variant)
+            }))
+    }
+
+    pub fn local_enum_variant_entries_for_enum(
+        &self,
+        enum_def: LocalDefRef,
+    ) -> Result<Vec<LocalEnumVariantEntry<'_>>, S::Error> {
+        let Some(def_map) = self.source.def_map_for_origin(enum_def.origin)? else {
+            return Ok(Vec::new());
+        };
+
+        Ok(def_map
+            .local_enum_variant_entries_for_enum(enum_def.local_def)
+            .collect())
+    }
+
     /// Classify a resolved definition as a declarative macro and borrow its expansion payload.
     pub fn macro_definition_view(
         &self,
@@ -308,6 +335,13 @@ where
         local_def_ref: LocalDefRef,
     ) -> Result<Option<&LocalDefData>, Self::Error> {
         DefMapQuery::local_def_data(self, local_def_ref)
+    }
+
+    fn local_enum_variant_entries_for_enum<'a>(
+        &'a self,
+        enum_def: LocalDefRef,
+    ) -> Result<Vec<LocalEnumVariantEntry<'a>>, Self::Error> {
+        DefMapQuery::local_enum_variant_entries_for_enum(self, enum_def)
     }
 }
 

--- a/crates/engine/ir-storage/src/def_map/query/def_map_query.rs
+++ b/crates/engine/ir-storage/src/def_map/query/def_map_query.rs
@@ -1,22 +1,20 @@
-//! Shared path queries over DefMap storage.
+//! Higher-level queries over routed DefMap storage.
 //!
-//! DefMaps only know about one scope graph. This query object adds the routing layer that decides
-//! which graph owns a `DefMapRef`, then reuses the private scope resolver for the actual lookup.
+//! DefMaps only know about one scope graph. `DefMapSource` routes origin and target refs to the
+//! concrete storage that owns them; this query object keeps the operations that compose those raw
+//! maps into language-shaped answers.
 
-use rg_ir_model::{
-    DefId, DefMapRef, LocalDefRef, LocalEnumVariantRef, LocalImplRef, ModuleRef, Path, TargetRef,
-};
+use rg_ir_model::{DefId, DefMapRef, LocalDefRef, ModuleRef, TargetRef};
 use rg_text::Name;
 
 use super::{
-    path_resolution::{NameResolutionFilter, ScopeResolver, ResolvePathResult},
+    path_resolution::ScopeResolver,
     resolution_env::{MacroDefinitionEnv, ScopeResolutionEnv, TargetResolutionEnv},
 };
 
 use super::super::{
-    DefMap, LocalDefData, LocalEnumVariantData, LocalEnumVariantEntry, LocalImplData,
-    MacroDefinitionView, ModuleData, ModuleScopeBuilder, Namespace, ScopeEntryRef, ScopeNamespace,
-    VisibleScopeDef, VisibleScopeDefs, VisibleScopeOrigin,
+    DefMap, LocalDefData, LocalEnumVariantEntry, MacroDefinitionView, ModuleData, ScopeEntryRef,
+    ScopeNamespace, VisibleScopeDef, VisibleScopeDefs, VisibleScopeOrigin,
 };
 
 /// Routes DefMap-origin refs and target-level facts to concrete storage.
@@ -61,7 +59,7 @@ impl<T: DefMapSource + ?Sized> DefMapSource for &T {
     }
 }
 
-/// Common DefMap lookup API over any source that can route origins to DefMaps.
+/// Composed DefMap queries over any source that can route origins to DefMaps.
 #[derive(Clone)]
 pub struct DefMapQuery<S> {
     source: S,
@@ -75,59 +73,9 @@ where
         Self { source }
     }
 
-    /// Resolves a value-position path using normal Rust module lookup rules.
-    pub fn resolve_path(
-        &self,
-        from: ModuleRef,
-        path: &Path,
-    ) -> Result<ResolvePathResult, S::Error> {
-        ScopeResolver::new(self).resolve_path(from, path, NameResolutionFilter::AllNamespaces)
-    }
-
-    /// Resolves a type-position path using normal Rust module lookup rules.
-    pub fn resolve_path_in_type_namespace(
-        &self,
-        from: ModuleRef,
-        path: &Path,
-    ) -> Result<ResolvePathResult, S::Error> {
-        ScopeResolver::new(self).resolve_path(from, path, NameResolutionFilter::TypesOnly)
-    }
-
-    /// Resolves a path through lexical scopes represented as synthetic modules.
-    pub fn resolve_lexical_path(
-        &self,
-        from: ModuleRef,
-        path: &Path,
-        filter: NameResolutionFilter,
-    ) -> Result<ResolvePathResult, S::Error> {
-        ScopeResolver::new(self).resolve_lexical_path(from, path, filter)
-    }
-
-    /// Resolves one name inside a concrete lexical module without walking parents.
-    pub fn resolve_lexical_name_in_module(
-        &self,
-        from: ModuleRef,
-        module: ModuleRef,
-        name: &str,
-        filter: NameResolutionFilter,
-    ) -> Result<Vec<rg_ir_model::DefId>, S::Error> {
-        ScopeResolver::new(self).resolve_lexical_name_in_module(from, module, name, filter)
-    }
-
-    pub fn module_data(&self, module_ref: ModuleRef) -> Result<Option<&ModuleData>, S::Error> {
-        Ok(self
-            .source
-            .def_map_for_origin(module_ref.origin)?
-            .and_then(|def_map| def_map.module(module_ref.module)))
-    }
-
-    /// Lists modules recorded in one target DefMap without exposing the concrete store.
-    pub fn module_refs(&self, target: TargetRef) -> Result<Vec<ModuleRef>, S::Error> {
-        Ok(self
-            .source
-            .def_map_for_origin(DefMapRef::Target(target))?
-            .map(|def_map| def_map.module_refs().collect())
-            .unwrap_or_default())
+    /// Construct a scope resolver over this routed DefMap source.
+    pub fn scope_resolver(&self) -> ScopeResolver<'_, Self> {
+        ScopeResolver::new(self)
     }
 
     /// Returns targets whose DefMap roots are visible from `root`.
@@ -161,85 +109,20 @@ where
         Ok(visible_targets)
     }
 
-    pub fn local_def_data(
-        &self,
-        local_def_ref: LocalDefRef,
-    ) -> Result<Option<&LocalDefData>, S::Error> {
-        Ok(self
-            .source
-            .def_map_for_origin(local_def_ref.origin)?
-            .and_then(|def_map| def_map.local_def(local_def_ref.local_def)))
-    }
-
-    pub fn local_impl_data(
-        &self,
-        local_impl_ref: LocalImplRef,
-    ) -> Result<Option<&LocalImplData>, S::Error> {
-        Ok(self
-            .source
-            .def_map_for_origin(local_impl_ref.origin)?
-            .and_then(|def_map| def_map.local_impl(local_impl_ref.local_impl)))
-    }
-
-    pub fn local_enum_variant_data(
-        &self,
-        local_enum_variant_ref: LocalEnumVariantRef,
-    ) -> Result<Option<&LocalEnumVariantData>, S::Error> {
-        Ok(self
-            .source
-            .def_map_for_origin(local_enum_variant_ref.origin)?
-            .and_then(|def_map| {
-                def_map.local_enum_variant(local_enum_variant_ref.local_enum_variant)
-            }))
-    }
-
-    pub fn local_enum_variant_entries_for_enum(
-        &self,
-        enum_def: LocalDefRef,
-    ) -> Result<Vec<LocalEnumVariantEntry<'_>>, S::Error> {
-        let Some(def_map) = self.source.def_map_for_origin(enum_def.origin)? else {
-            return Ok(Vec::new());
-        };
-
-        Ok(def_map
-            .local_enum_variant_entries_for_enum(enum_def.local_def)
-            .collect())
-    }
-
     /// Classify a resolved definition as a declarative macro and borrow its expansion payload.
     pub fn macro_definition_view(
         &self,
         def: DefId,
     ) -> Result<Option<MacroDefinitionView<'_>>, S::Error> {
-        let DefId::Local(def_ref) = def else {
-            return Ok(None);
-        };
-        let Some(local_def) = self.local_def_data(def_ref)? else {
-            return Ok(None);
-        };
-        let Some(data) = self
-            .source
-            .def_map_for_origin(def_ref.origin)?
-            .and_then(|def_map| def_map.macro_definition(def_ref.local_def))
-        else {
-            return Ok(None);
-        };
-
-        Ok(MacroDefinitionView::new(def_ref, local_def, data))
-    }
-
-    /// Returns the namespace occupied by one resolved definition.
-    pub fn namespace_for_def(&self, def: DefId) -> Result<Option<Namespace>, S::Error> {
-        ScopeResolver::new(self).namespace_for_def(def)
-    }
-
-    /// Builds the visibility-filtered scope observed from `importing_module`.
-    pub fn visible_scope(
-        &self,
-        importing_module: ModuleRef,
-        source_module: ModuleRef,
-    ) -> Result<ModuleScopeBuilder, S::Error> {
-        ScopeResolver::new(self).visible_scope(importing_module, source_module)
+        if let DefId::Local(def_ref) = def
+            && let Some(def_map) = self.source.def_map_for_origin(def_ref.origin)?
+            && let Some(local_def) = def_map.local_def(def_ref.local_def)
+            && let Some(data) = def_map.macro_definition(def_ref.local_def)
+        {
+            Ok(MacroDefinitionView::new(def_ref, local_def, data))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Returns definitions from `source_module` that are visible from `importing_module`.
@@ -248,7 +131,9 @@ where
         importing_module: ModuleRef,
         source_module: ModuleRef,
     ) -> Result<VisibleScopeDefs, S::Error> {
-        let scope = self.visible_scope(importing_module, source_module)?;
+        let scope = self
+            .scope_resolver()
+            .visible_scope(importing_module, source_module)?;
         let mut defs = VisibleScopeDefs::new(&scope, VisibleScopeOrigin::ModuleScope, false);
         defs.sort();
         Ok(defs)
@@ -259,7 +144,7 @@ where
         &self,
         importing_module: ModuleRef,
     ) -> Result<VisibleScopeDefs, S::Error> {
-        let resolver = ScopeResolver::new(self);
+        let resolver = self.scope_resolver();
 
         // First-segment resolution checks the current module scope before extern roots and the
         // standard prelude. Completion follows the same namespace-specific shadowing order.
@@ -300,7 +185,10 @@ where
     type Error = S::Error;
 
     fn module_data(&self, module_ref: ModuleRef) -> Result<Option<&ModuleData>, Self::Error> {
-        DefMapQuery::module_data(self, module_ref)
+        Ok(self
+            .source
+            .def_map_for_origin(module_ref.origin)?
+            .and_then(|def_map| def_map.module(module_ref.module)))
     }
 
     fn module_scope_entry<'a>(
@@ -308,8 +196,7 @@ where
         module_ref: ModuleRef,
         name: &str,
     ) -> Result<Option<ScopeEntryRef<'a>>, Self::Error> {
-        Ok(self
-            .module_data(module_ref)?
+        Ok(<Self as ScopeResolutionEnv>::module_data(self, module_ref)?
             .and_then(|module| module.scope.entry(name))
             .map(|entry| entry.as_ref()))
     }
@@ -318,8 +205,7 @@ where
         &'a self,
         module_ref: ModuleRef,
     ) -> Result<Vec<(&'a Name, ScopeEntryRef<'a>)>, Self::Error> {
-        Ok(self
-            .module_data(module_ref)?
+        Ok(<Self as ScopeResolutionEnv>::module_data(self, module_ref)?
             .map(|module| {
                 module
                     .scope
@@ -334,14 +220,23 @@ where
         &self,
         local_def_ref: LocalDefRef,
     ) -> Result<Option<&LocalDefData>, Self::Error> {
-        DefMapQuery::local_def_data(self, local_def_ref)
+        Ok(self
+            .source
+            .def_map_for_origin(local_def_ref.origin)?
+            .and_then(|def_map| def_map.local_def(local_def_ref.local_def)))
     }
 
     fn local_enum_variant_entries_for_enum<'a>(
         &'a self,
         enum_def: LocalDefRef,
     ) -> Result<Vec<LocalEnumVariantEntry<'a>>, Self::Error> {
-        DefMapQuery::local_enum_variant_entries_for_enum(self, enum_def)
+        let Some(def_map) = self.source.def_map_for_origin(enum_def.origin)? else {
+            return Ok(Vec::new());
+        };
+
+        Ok(def_map
+            .local_enum_variant_entries_for_enum(enum_def.local_def)
+            .collect())
     }
 }
 

--- a/crates/engine/ir-storage/src/def_map/query/def_map_query.rs
+++ b/crates/engine/ir-storage/src/def_map/query/def_map_query.rs
@@ -4,7 +4,9 @@
 //! concrete storage that owns them; this query object keeps the operations that compose those raw
 //! maps into language-shaped answers.
 
-use rg_ir_model::{DefId, DefMapRef, LocalDefRef, ModuleRef, TargetRef};
+use rg_ir_model::{
+    DefId, DefMapRef, LocalDefRef, LocalEnumVariantRef, LocalImplRef, ModuleRef, TargetRef,
+};
 use rg_text::Name;
 
 use super::{
@@ -13,8 +15,9 @@ use super::{
 };
 
 use super::super::{
-    DefMap, LocalDefData, LocalEnumVariantEntry, MacroDefinitionView, ModuleData, ScopeEntryRef,
-    ScopeNamespace, VisibleScopeDef, VisibleScopeDefs, VisibleScopeOrigin,
+    DefMap, LocalDefData, LocalEnumVariantData, LocalEnumVariantEntry, LocalImplData,
+    MacroDefinitionView, ModuleData, ScopeEntryRef, ScopeNamespace, VisibleScopeDef,
+    VisibleScopeDefs, VisibleScopeOrigin,
 };
 
 /// Routes DefMap-origin refs and target-level facts to concrete storage.
@@ -25,6 +28,60 @@ pub trait DefMapSource {
     type Error;
 
     fn def_map_for_origin(&self, origin: DefMapRef) -> Result<Option<&DefMap>, Self::Error>;
+
+    fn module_data(&self, module_ref: ModuleRef) -> Result<Option<&ModuleData>, Self::Error> {
+        Ok(self
+            .def_map_for_origin(module_ref.origin)?
+            .and_then(|def_map| def_map.module(module_ref.module)))
+    }
+
+    fn module_refs(&self, target: TargetRef) -> Result<Vec<ModuleRef>, Self::Error> {
+        Ok(self
+            .def_map_for_origin(DefMapRef::Target(target))?
+            .map(|def_map| def_map.module_refs().collect())
+            .unwrap_or_default())
+    }
+
+    fn local_def_data(
+        &self,
+        local_def_ref: LocalDefRef,
+    ) -> Result<Option<&LocalDefData>, Self::Error> {
+        Ok(self
+            .def_map_for_origin(local_def_ref.origin)?
+            .and_then(|def_map| def_map.local_def(local_def_ref.local_def)))
+    }
+
+    fn local_impl_data(
+        &self,
+        local_impl_ref: LocalImplRef,
+    ) -> Result<Option<&LocalImplData>, Self::Error> {
+        Ok(self
+            .def_map_for_origin(local_impl_ref.origin)?
+            .and_then(|def_map| def_map.local_impl(local_impl_ref.local_impl)))
+    }
+
+    fn local_enum_variant_data(
+        &self,
+        variant_ref: LocalEnumVariantRef,
+    ) -> Result<Option<&LocalEnumVariantData>, Self::Error> {
+        Ok(self
+            .def_map_for_origin(variant_ref.origin)?
+            .and_then(|def_map| def_map.local_enum_variant(variant_ref.local_enum_variant)))
+    }
+
+    fn local_enum_variant_entries_for_enum<'a>(
+        &'a self,
+        enum_def: LocalDefRef,
+    ) -> Result<Vec<LocalEnumVariantEntry<'a>>, Self::Error> {
+        Ok(self
+            .def_map_for_origin(enum_def.origin)?
+            .map(|def_map| {
+                def_map
+                    .local_enum_variant_entries_for_enum(enum_def.local_def)
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
 
     fn extern_root(&self, target: TargetRef, name: &str) -> Result<Option<ModuleRef>, Self::Error>;
 
@@ -185,10 +242,7 @@ where
     type Error = S::Error;
 
     fn module_data(&self, module_ref: ModuleRef) -> Result<Option<&ModuleData>, Self::Error> {
-        Ok(self
-            .source
-            .def_map_for_origin(module_ref.origin)?
-            .and_then(|def_map| def_map.module(module_ref.module)))
+        self.source.module_data(module_ref)
     }
 
     fn module_scope_entry<'a>(
@@ -220,23 +274,14 @@ where
         &self,
         local_def_ref: LocalDefRef,
     ) -> Result<Option<&LocalDefData>, Self::Error> {
-        Ok(self
-            .source
-            .def_map_for_origin(local_def_ref.origin)?
-            .and_then(|def_map| def_map.local_def(local_def_ref.local_def)))
+        self.source.local_def_data(local_def_ref)
     }
 
     fn local_enum_variant_entries_for_enum<'a>(
         &'a self,
         enum_def: LocalDefRef,
     ) -> Result<Vec<LocalEnumVariantEntry<'a>>, Self::Error> {
-        let Some(def_map) = self.source.def_map_for_origin(enum_def.origin)? else {
-            return Ok(Vec::new());
-        };
-
-        Ok(def_map
-            .local_enum_variant_entries_for_enum(enum_def.local_def)
-            .collect())
+        self.source.local_enum_variant_entries_for_enum(enum_def)
     }
 }
 

--- a/crates/engine/ir-storage/src/def_map/query/def_map_query.rs
+++ b/crates/engine/ir-storage/src/def_map/query/def_map_query.rs
@@ -1,7 +1,7 @@
 //! Shared path queries over DefMap storage.
 //!
 //! DefMaps only know about one scope graph. This query object adds the routing layer that decides
-//! which graph owns a `DefMapRef`, then reuses the private path resolver for the actual lookup.
+//! which graph owns a `DefMapRef`, then reuses the private scope resolver for the actual lookup.
 
 use rg_ir_model::{
     DefId, DefMapRef, LocalDefRef, LocalEnumVariantRef, LocalImplRef, ModuleRef, Path, TargetRef,
@@ -9,7 +9,7 @@ use rg_ir_model::{
 use rg_text::Name;
 
 use super::{
-    path_resolution::{NameResolutionFilter, PathResolver, ResolvePathResult},
+    path_resolution::{NameResolutionFilter, ScopeResolver, ResolvePathResult},
     resolution_env::{MacroDefinitionEnv, ScopeResolutionEnv, TargetResolutionEnv},
 };
 
@@ -81,7 +81,7 @@ where
         from: ModuleRef,
         path: &Path,
     ) -> Result<ResolvePathResult, S::Error> {
-        PathResolver::new(self).resolve_path(from, path, NameResolutionFilter::AllNamespaces)
+        ScopeResolver::new(self).resolve_path(from, path, NameResolutionFilter::AllNamespaces)
     }
 
     /// Resolves a type-position path using normal Rust module lookup rules.
@@ -90,7 +90,7 @@ where
         from: ModuleRef,
         path: &Path,
     ) -> Result<ResolvePathResult, S::Error> {
-        PathResolver::new(self).resolve_path(from, path, NameResolutionFilter::TypesOnly)
+        ScopeResolver::new(self).resolve_path(from, path, NameResolutionFilter::TypesOnly)
     }
 
     /// Resolves a path through lexical scopes represented as synthetic modules.
@@ -100,7 +100,7 @@ where
         path: &Path,
         filter: NameResolutionFilter,
     ) -> Result<ResolvePathResult, S::Error> {
-        PathResolver::new(self).resolve_lexical_path(from, path, filter)
+        ScopeResolver::new(self).resolve_lexical_path(from, path, filter)
     }
 
     /// Resolves one name inside a concrete lexical module without walking parents.
@@ -111,7 +111,7 @@ where
         name: &str,
         filter: NameResolutionFilter,
     ) -> Result<Vec<rg_ir_model::DefId>, S::Error> {
-        PathResolver::new(self).resolve_lexical_name_in_module(from, module, name, filter)
+        ScopeResolver::new(self).resolve_lexical_name_in_module(from, module, name, filter)
     }
 
     pub fn module_data(&self, module_ref: ModuleRef) -> Result<Option<&ModuleData>, S::Error> {
@@ -230,7 +230,7 @@ where
 
     /// Returns the namespace occupied by one resolved definition.
     pub fn namespace_for_def(&self, def: DefId) -> Result<Option<Namespace>, S::Error> {
-        PathResolver::new(self).namespace_for_def(def)
+        ScopeResolver::new(self).namespace_for_def(def)
     }
 
     /// Builds the visibility-filtered scope observed from `importing_module`.
@@ -239,7 +239,7 @@ where
         importing_module: ModuleRef,
         source_module: ModuleRef,
     ) -> Result<ModuleScopeBuilder, S::Error> {
-        PathResolver::new(self).visible_scope(importing_module, source_module)
+        ScopeResolver::new(self).visible_scope(importing_module, source_module)
     }
 
     /// Returns definitions from `source_module` that are visible from `importing_module`.
@@ -259,7 +259,7 @@ where
         &self,
         importing_module: ModuleRef,
     ) -> Result<VisibleScopeDefs, S::Error> {
-        let resolver = PathResolver::new(self);
+        let resolver = ScopeResolver::new(self);
 
         // First-segment resolution checks the current module scope before extern roots and the
         // standard prelude. Completion follows the same namespace-specific shadowing order.

--- a/crates/engine/ir-storage/src/def_map/query/mod.rs
+++ b/crates/engine/ir-storage/src/def_map/query/mod.rs
@@ -6,6 +6,6 @@ mod resolution_env;
 
 pub use self::{
     def_map_query::{DefMapQuery, DefMapSource},
-    path_resolution::{GlobImportSource, NameResolutionFilter, ScopeResolver, ResolvePathResult},
+    path_resolution::{GlobImportSource, NameResolutionFilter, ResolvePathResult, ScopeResolver},
     resolution_env::{MacroDefinitionEnv, ScopeResolutionEnv, TargetResolutionEnv},
 };

--- a/crates/engine/ir-storage/src/def_map/query/mod.rs
+++ b/crates/engine/ir-storage/src/def_map/query/mod.rs
@@ -6,6 +6,6 @@ mod resolution_env;
 
 pub use self::{
     def_map_query::{DefMapQuery, DefMapSource},
-    path_resolution::{GlobImportSource, NameResolutionFilter, PathResolver, ResolvePathResult},
+    path_resolution::{GlobImportSource, NameResolutionFilter, ScopeResolver, ResolvePathResult},
     resolution_env::{MacroDefinitionEnv, ScopeResolutionEnv, TargetResolutionEnv},
 };

--- a/crates/engine/ir-storage/src/def_map/query/mod.rs
+++ b/crates/engine/ir-storage/src/def_map/query/mod.rs
@@ -6,6 +6,6 @@ mod resolution_env;
 
 pub use self::{
     def_map_query::{DefMapQuery, DefMapSource},
-    path_resolution::{NameResolutionFilter, PathResolver, ResolvePathResult},
+    path_resolution::{GlobImportSource, NameResolutionFilter, PathResolver, ResolvePathResult},
     resolution_env::{MacroDefinitionEnv, ScopeResolutionEnv, TargetResolutionEnv},
 };

--- a/crates/engine/ir-storage/src/def_map/query/path_resolution.rs
+++ b/crates/engine/ir-storage/src/def_map/query/path_resolution.rs
@@ -469,11 +469,7 @@ impl<E: TargetResolutionEnv + ?Sized> ScopeResolver<'_, E> {
         importing_module: ModuleRef,
         path: &ImportPath,
     ) -> Result<Vec<DefId>, E::Error> {
-        self.import_defs_with_filter(
-            importing_module,
-            path,
-            NameResolutionFilter::AllNamespaces,
-        )
+        self.import_defs_with_filter(importing_module, path, NameResolutionFilter::AllNamespaces)
     }
 
     /// Resolve an import path and keep only module results.
@@ -482,11 +478,8 @@ impl<E: TargetResolutionEnv + ?Sized> ScopeResolver<'_, E> {
         importing_module: ModuleRef,
         path: &ImportPath,
     ) -> Result<Vec<ModuleRef>, E::Error> {
-        let resolved_defs = self.import_defs_with_filter(
-            importing_module,
-            path,
-            NameResolutionFilter::TypesOnly,
-        )?;
+        let resolved_defs =
+            self.import_defs_with_filter(importing_module, path, NameResolutionFilter::TypesOnly)?;
 
         let mut modules = UniqueVec::new();
         for resolved_def in resolved_defs {
@@ -504,11 +497,8 @@ impl<E: TargetResolutionEnv + ?Sized> ScopeResolver<'_, E> {
         importing_module: ModuleRef,
         path: &ImportPath,
     ) -> Result<Vec<GlobImportSource>, E::Error> {
-        let resolved_defs = self.import_defs_with_filter(
-            importing_module,
-            path,
-            NameResolutionFilter::TypesOnly,
-        )?;
+        let resolved_defs =
+            self.import_defs_with_filter(importing_module, path, NameResolutionFilter::TypesOnly)?;
 
         let mut sources = UniqueVec::new();
         for resolved_def in resolved_defs {

--- a/crates/engine/ir-storage/src/def_map/query/path_resolution.rs
+++ b/crates/engine/ir-storage/src/def_map/query/path_resolution.rs
@@ -9,11 +9,15 @@
 //! construction, the same path-walking logic reads from frozen `DefMapDb` data.
 
 use rg_ir_model::items::VisibilityLevel;
-use rg_ir_model::{DefId, DefMapRef, ModuleId, ModuleRef, Path, PathSegment, TargetRef};
+use rg_ir_model::{
+    DefId, DefMapRef, LocalDefRef, ModuleId, ModuleRef, Path, PathSegment, TargetRef,
+};
 use rg_std::UniqueVec;
 use rg_text::Name;
 
-use super::super::{ImportPath, ModuleOrigin, ModuleScopeBuilder, Namespace, ScopeBinding};
+use super::super::{
+    ImportPath, LocalDefKind, ModuleOrigin, ModuleScopeBuilder, Namespace, ScopeBinding,
+};
 
 use super::resolution_env::{ScopeResolutionEnv, TargetResolutionEnv};
 
@@ -28,6 +32,13 @@ pub struct UnqualifiedMacroBindings {
 pub struct ResolvePathResult {
     pub resolved: Vec<DefId>,
     pub unresolved_at: Option<usize>,
+}
+
+/// Source accepted by a glob import.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlobImportSource {
+    Module(ModuleRef),
+    Enum(LocalDefRef),
 }
 
 /// Namespace buckets that may contribute definitions for a path terminal.
@@ -77,6 +88,7 @@ impl<E: ScopeResolutionEnv + ?Sized> PathResolver<'_, E> {
                 .env
                 .local_def_kind(local_def_ref)?
                 .map(|kind| kind.namespace())),
+            DefId::EnumVariant(_) => Ok(Some(Namespace::Values)),
         }
     }
 
@@ -185,18 +197,53 @@ impl<E: ScopeResolutionEnv + ?Sized> PathResolver<'_, E> {
         let mut next_defs = UniqueVec::new();
 
         for current_def in current_defs {
-            let DefId::Module(module_ref) = current_def else {
-                continue;
-            };
-
-            for resolved_def in
-                self.resolve_lexical_name_in_module(importing_module, module_ref, name, filter)?
-            {
-                next_defs.push(resolved_def);
+            match current_def {
+                DefId::Module(module_ref) => {
+                    for resolved_def in self.resolve_lexical_name_in_module(
+                        importing_module,
+                        module_ref,
+                        name,
+                        filter,
+                    )? {
+                        next_defs.push(resolved_def);
+                    }
+                }
+                DefId::Local(local_def_ref) => {
+                    if let Some(variant) =
+                        self.enum_variant_for_name(local_def_ref, name, filter)?
+                    {
+                        next_defs.push(DefId::EnumVariant(variant));
+                    }
+                }
+                DefId::EnumVariant(_) => {}
             }
         }
 
         Ok(next_defs.into_vec())
+    }
+
+    fn enum_variant_for_name(
+        &self,
+        enum_def: LocalDefRef,
+        name: &str,
+        filter: NameResolutionFilter,
+    ) -> Result<Option<rg_ir_model::LocalEnumVariantRef>, E::Error> {
+        if matches!(filter, NameResolutionFilter::TypesOnly) {
+            return Ok(None);
+        }
+        if !self
+            .env
+            .local_def_kind(enum_def)?
+            .is_some_and(|kind| kind == LocalDefKind::Enum)
+        {
+            return Ok(None);
+        }
+
+        Ok(self
+            .env
+            .local_enum_variant_entries_for_enum(enum_def)?
+            .into_iter()
+            .find_map(|entry| (entry.data.name == name).then_some(entry.variant_ref)))
     }
 
     fn first_name_in_lexical_scope(
@@ -415,6 +462,22 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
         )
     }
 
+    /// Resolves a glob import prefix to modules and enums that can export bindings.
+    pub fn import_glob_sources(
+        &self,
+        importing_target: TargetRef,
+        importing_module: ModuleId,
+        path: &ImportPath,
+    ) -> Result<Vec<GlobImportSource>, E::Error> {
+        self.import_glob_sources_from_module(
+            ModuleRef {
+                origin: DefMapRef::Target(importing_target),
+                module: importing_module,
+            },
+            path,
+        )
+    }
+
     /// Resolves an import path from a concrete module origin.
     ///
     /// Target-level imports delegate here, and body-local import finalization can use the same path
@@ -443,16 +506,94 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
             NameResolutionFilter::TypesOnly,
         )?;
 
-        let mut modules = Vec::new();
+        let mut modules = UniqueVec::new();
         for resolved_def in resolved_defs {
-            if let DefId::Module(module_ref) = resolved_def
-                && !modules.contains(&module_ref)
-            {
+            if let DefId::Module(module_ref) = resolved_def {
                 modules.push(module_ref);
             }
         }
 
-        Ok(modules)
+        Ok(modules.into_vec())
+    }
+
+    /// Resolves an import path from a concrete module origin and keeps glob-capable sources.
+    pub fn import_glob_sources_from_module(
+        &self,
+        importing_module: ModuleRef,
+        path: &ImportPath,
+    ) -> Result<Vec<GlobImportSource>, E::Error> {
+        let resolved_defs = self.import_defs_from_module_with_filter(
+            importing_module,
+            path,
+            NameResolutionFilter::TypesOnly,
+        )?;
+
+        let mut sources = UniqueVec::new();
+        for resolved_def in resolved_defs {
+            match resolved_def {
+                DefId::Module(module_ref) => {
+                    sources.push(GlobImportSource::Module(module_ref));
+                }
+                DefId::Local(local_def_ref)
+                    if self
+                        .env
+                        .local_def_kind(local_def_ref)?
+                        .is_some_and(|kind| kind == LocalDefKind::Enum) =>
+                {
+                    sources.push(GlobImportSource::Enum(local_def_ref));
+                }
+                DefId::Local(_) | DefId::EnumVariant(_) => {}
+            }
+        }
+
+        Ok(sources.into_vec())
+    }
+
+    /// Returns value bindings that a glob import from an enum should introduce.
+    pub fn visible_enum_variant_bindings(
+        &self,
+        importing_module: ModuleRef,
+        enum_def: LocalDefRef,
+    ) -> Result<Vec<(Name, ScopeBinding)>, E::Error> {
+        let Some(enum_data) = self.env.local_def_data(enum_def)? else {
+            return Ok(Vec::new());
+        };
+        if enum_data.kind != LocalDefKind::Enum {
+            return Ok(Vec::new());
+        }
+
+        let enum_binding = ScopeBinding {
+            def: DefId::Local(enum_def),
+            visibility: enum_data.visibility.clone(),
+            owner: ModuleRef {
+                origin: enum_def.origin,
+                module: enum_data.module,
+            },
+            origin: super::super::ScopeBindingOrigin::Direct,
+        };
+        if !self.binding_is_visible(importing_module, &enum_binding)? {
+            return Ok(Vec::new());
+        }
+
+        Ok(self
+            .env
+            .local_enum_variant_entries_for_enum(enum_def)?
+            .into_iter()
+            .map(|entry| {
+                (
+                    entry.data.name.clone(),
+                    ScopeBinding {
+                        def: DefId::EnumVariant(entry.variant_ref),
+                        visibility: entry.data.visibility.clone(),
+                        owner: ModuleRef {
+                            origin: enum_def.origin,
+                            module: entry.data.module,
+                        },
+                        origin: super::super::ScopeBindingOrigin::Direct,
+                    },
+                )
+            })
+            .collect())
     }
 
     /// Resolves a path whose terminal segment must be a macro binding.
@@ -647,32 +788,44 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
         let mut next_defs = UniqueVec::new();
 
         for current_def in current_defs {
-            let DefId::Module(module_ref) = current_def else {
-                continue;
-            };
-
-            match segment {
-                PathSegment::SelfKw => {
-                    next_defs.push(DefId::Module(module_ref));
-                }
-                PathSegment::SuperKw => {
-                    if let Some(parent) = self.env.parent_module(module_ref)? {
-                        next_defs.push(DefId::Module(parent));
+            match current_def {
+                DefId::Module(module_ref) => match segment {
+                    PathSegment::SelfKw => {
+                        next_defs.push(DefId::Module(module_ref));
                     }
-                }
-                PathSegment::CrateKw => {
-                    if let Some(root) = self.env.root_module(module_ref.origin.origin_target())? {
-                        next_defs.push(DefId::Module(root));
+                    PathSegment::SuperKw => {
+                        if let Some(parent) = self.env.parent_module(module_ref)? {
+                            next_defs.push(DefId::Module(parent));
+                        }
                     }
-                }
-                PathSegment::DollarCrate(_) => {}
-                PathSegment::Name(name) => {
-                    for resolved_def in
-                        self.name_in_module(importing_module, module_ref, name.as_str(), filter)?
+                    PathSegment::CrateKw => {
+                        if let Some(root) =
+                            self.env.root_module(module_ref.origin.origin_target())?
+                        {
+                            next_defs.push(DefId::Module(root));
+                        }
+                    }
+                    PathSegment::DollarCrate(_) => {}
+                    PathSegment::Name(name) => {
+                        for resolved_def in self.name_in_module(
+                            importing_module,
+                            module_ref,
+                            name.as_str(),
+                            filter,
+                        )? {
+                            next_defs.push(resolved_def);
+                        }
+                    }
+                },
+                DefId::Local(local_def_ref) => {
+                    if let PathSegment::Name(name) = segment
+                        && let Some(variant) =
+                            self.enum_variant_for_name(local_def_ref, name.as_str(), filter)?
                     {
-                        next_defs.push(resolved_def);
+                        next_defs.push(DefId::EnumVariant(variant));
                     }
                 }
+                DefId::EnumVariant(_) => {}
             }
         }
 

--- a/crates/engine/ir-storage/src/def_map/query/path_resolution.rs
+++ b/crates/engine/ir-storage/src/def_map/query/path_resolution.rs
@@ -1,12 +1,13 @@
-//! Helpers for resolving paths against def-map scopes.
+//! Scope-graph name lookup for DefMap-backed module scopes.
 //!
-//! Resolution here is intentionally narrow:
-//! - it works only with already-built module scopes
-//! - it understands module navigation (`self`, `super`, `crate`)
-//! - it can return multiple definitions because several namespaces may share one textual name
+//! DefMap finalization, body-local DefMap finalization, and ordinary queries all need the same
+//! lookup rules while reading from different storage. This module owns those shared rules:
+//! lexical/body lookup, module path lookup, import expansion, visibility filtering, and the small
+//! macro-namespace queries needed before macro-specific precedence is applied.
 //!
-//! During def-map construction this module reads from the fixed-point scope snapshot. After
-//! construction, the same path-walking logic reads from frozen `DefMapDb` data.
+//! The resolver does not own scopes. It reads through `ScopeResolutionEnv` and
+//! `TargetResolutionEnv`, so finalization can pass current fixed-point snapshots while frozen
+//! queries read persisted DefMaps.
 
 use rg_ir_model::items::VisibilityLevel;
 use rg_ir_model::{DefId, LocalDefRef, ModuleRef, Path, PathSegment};
@@ -19,27 +20,39 @@ use super::super::{
 
 use super::resolution_env::{ScopeResolutionEnv, TargetResolutionEnv};
 
-/// Privacy-visible macro bindings collected before Rust macro lookup precedence is applied.
+/// Macro candidates kept in the buckets required by Rust lookup precedence.
+///
+/// Callers try `module_scope` before `standard_prelude`; this type only preserves the split while
+/// sharing the visibility walk.
 pub struct UnqualifiedMacroBindings {
     pub module_scope: Vec<ScopeBinding>,
     pub standard_prelude: Vec<ScopeBinding>,
 }
 
-/// Result of resolving a path against the frozen def-map graph.
+/// Result of walking a path through the current scope graph.
+///
+/// `unresolved_at` points at the first segment that could not be resolved. Keeping that status
+/// explicit lets callers report partial resolution without inferring failure from `resolved`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvePathResult {
     pub resolved: Vec<DefId>,
     pub unresolved_at: Option<usize>,
 }
 
-/// Source accepted by a glob import.
+/// Item that can appear on the left side of a glob import.
+///
+/// Modules export visible scope bindings. Enums export visible variant constructors into the value
+/// namespace, as in `use Option::*`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GlobImportSource {
     Module(ModuleRef),
     Enum(LocalDefRef),
 }
 
-/// Namespace buckets that may contribute definitions for a path terminal.
+/// Namespace buckets considered for the current path segment.
+///
+/// Prefixes are always type-like because only modules and type definitions can be traversed. The
+/// caller chooses the terminal filter based on the use site.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NameResolutionFilter {
     /// Type, value, and macro namespaces.
@@ -60,12 +73,16 @@ impl NameResolutionFilter {
     }
 }
 
-/// Groups path lookup operations around one scope source.
-pub struct PathResolver<'env, E: ?Sized> {
+/// Applies name lookup rules over one abstract scope source.
+///
+/// `ScopeResolver` is storage-agnostic on purpose. During finalization the environment can expose
+/// partial builders plus the current fixed-point scope snapshot; after finalization the same lookup
+/// code reads frozen DefMaps through `DefMapQuery`.
+pub struct ScopeResolver<'env, E: ?Sized> {
     env: &'env E,
 }
 
-impl<'env, E: ?Sized> PathResolver<'env, E> {
+impl<'env, E: ?Sized> ScopeResolver<'env, E> {
     pub fn new(env: &'env E) -> Self {
         Self { env }
     }
@@ -78,7 +95,8 @@ impl<'env, E: ?Sized> PathResolver<'env, E> {
     }
 }
 
-impl<E: ScopeResolutionEnv + ?Sized> PathResolver<'_, E> {
+impl<E: ScopeResolutionEnv + ?Sized> ScopeResolver<'_, E> {
+    /// Return the namespace a resolved definition occupies when it is inserted through an import.
     pub fn namespace_for_def(&self, def: DefId) -> Result<Option<Namespace>, E::Error> {
         match def {
             DefId::Module(_) => Ok(Some(Namespace::Types)),
@@ -90,7 +108,10 @@ impl<E: ScopeResolutionEnv + ?Sized> PathResolver<'_, E> {
         }
     }
 
-    /// Walks a path through lexical scopes without module-keyword or target fallback rules.
+    /// Walk a path through lexical scopes without module-keyword or target fallback rules.
+    ///
+    /// Body-local paths use this form because synthetic modules represent nested lexical scopes,
+    /// not full Rust modules with extern roots and preludes.
     pub fn resolve_lexical_path(
         &self,
         importing_module: ModuleRef,
@@ -142,6 +163,7 @@ impl<E: ScopeResolutionEnv + ?Sized> PathResolver<'_, E> {
         })
     }
 
+    /// Resolve one name inside a single lexical module without walking parent scopes.
     pub fn resolve_lexical_name_in_module(
         &self,
         importing_module: ModuleRef,
@@ -270,6 +292,11 @@ impl<E: ScopeResolutionEnv + ?Sized> PathResolver<'_, E> {
         Ok(Vec::new())
     }
 
+    /// Visibility subset available to lexical-only lookup.
+    ///
+    /// Body lookup does not need target roots or extern/prelude fallback. That keeps this usable with
+    /// `ScopeResolutionEnv`, but also means target-relative `pub(in path)` restrictions are handled
+    /// only by target-aware lookup.
     fn lexical_binding_is_visible(
         &self,
         importing_module: ModuleRef,
@@ -298,6 +325,7 @@ impl<E: ScopeResolutionEnv + ?Sized> PathResolver<'_, E> {
         })
     }
 
+    /// Walk parent links inside one module origin to test Rust's ancestor-based visibility.
     fn module_is_descendant_of(
         &self,
         module: ModuleRef,
@@ -326,7 +354,10 @@ impl<E: ScopeResolutionEnv + ?Sized> PathResolver<'_, E> {
     }
 }
 
-impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
+impl<E: TargetResolutionEnv + ?Sized> ScopeResolver<'_, E> {
+    /// Build the source module scope as observed by `importing_module`.
+    ///
+    /// Glob imports use this to copy only bindings that pass visibility from the importer.
     pub fn visible_scope(
         &self,
         importing_module: ModuleRef,
@@ -414,6 +445,10 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
         self.visible_macro_bindings(importing_module, prelude_module, name)
     }
 
+    /// Resolve a normal Rust path from one module.
+    ///
+    /// This includes module keywords, the extern prelude, the selected standard prelude, and
+    /// namespace-specific shadowing for the first segment.
     pub fn resolve_path(
         &self,
         importing_module: ModuleRef,
@@ -428,7 +463,7 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
         )
     }
 
-    /// Resolves an import path to every definition it denotes from a concrete module origin.
+    /// Resolve an import path to every definition it denotes from the importing module.
     pub fn import_defs(
         &self,
         importing_module: ModuleRef,
@@ -441,7 +476,7 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
         )
     }
 
-    /// Resolves an import path and keeps only module results.
+    /// Resolve an import path and keep only module results.
     pub fn import_modules(
         &self,
         importing_module: ModuleRef,
@@ -463,7 +498,7 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
         Ok(modules.into_vec())
     }
 
-    /// Resolves a glob import prefix to modules and enums that can export bindings.
+    /// Resolve a glob import prefix to every source that can export bindings.
     pub fn import_glob_sources(
         &self,
         importing_module: ModuleRef,
@@ -496,7 +531,7 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
         Ok(sources.into_vec())
     }
 
-    /// Returns value bindings that a glob import from an enum should introduce.
+    /// Return value bindings that a glob import from an enum should introduce.
     pub fn visible_enum_variant_bindings(
         &self,
         importing_module: ModuleRef,
@@ -543,7 +578,7 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
             .collect())
     }
 
-    /// Resolves a path whose terminal segment must be a macro binding.
+    /// Resolve a macro path by walking any prefix and reading the terminal macro bucket.
     pub fn macro_bindings(
         &self,
         importing_module: ModuleRef,
@@ -603,7 +638,10 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
         Ok(result.resolved)
     }
 
-    /// Walks a path through one target-aware resolution environment.
+    /// Shared path walker for ordinary item paths and imports.
+    ///
+    /// The first segment chooses the initial search space. Each following segment is resolved inside
+    /// the modules or enum definitions produced by the previous step.
     fn resolve_path_segments(
         &self,
         importing_module: ModuleRef,
@@ -648,7 +686,7 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
         })
     }
 
-    /// Resolves the first path segment, which decides the starting search space.
+    /// Resolve the path head, where Rust allows roots, lexical lookup, and prelude fallback.
     fn first_segment(
         &self,
         importing_module: ModuleRef,
@@ -718,7 +756,10 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
         }
     }
 
-    /// Resolves every path segment after the first one.
+    /// Resolve a segment inside the containers produced by the previous segment.
+    ///
+    /// Modules expose ordinary scope entries. Enum definitions expose their variant constructors in
+    /// value positions.
     fn next_segment(
         &self,
         importing_module: ModuleRef,
@@ -887,7 +928,10 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
         })
     }
 
-    /// Resolves the module that anchors a `pub(in path)` visibility restriction.
+    /// Resolve the module that anchors a `pub(in path)` visibility restriction.
+    ///
+    /// Unsupported or unresolved restrictions stay hidden rather than becoming visible through a
+    /// partial guess.
     fn restricted_visibility_owner(
         &self,
         owner: ModuleRef,

--- a/crates/engine/ir-storage/src/def_map/query/path_resolution.rs
+++ b/crates/engine/ir-storage/src/def_map/query/path_resolution.rs
@@ -521,8 +521,30 @@ impl<E: TargetResolutionEnv + ?Sized> ScopeResolver<'_, E> {
         Ok(sources.into_vec())
     }
 
+    /// Build the visible bindings exported by one glob import source.
+    pub fn visible_glob_source_scope(
+        &self,
+        importing_module: ModuleRef,
+        glob_source: GlobImportSource,
+    ) -> Result<ModuleScopeBuilder, E::Error> {
+        match glob_source {
+            GlobImportSource::Module(source_module) => {
+                self.visible_scope(importing_module, source_module)
+            }
+            GlobImportSource::Enum(enum_def) => {
+                let mut visible_scope = ModuleScopeBuilder::default();
+                for (name, binding) in
+                    self.visible_enum_variant_bindings(importing_module, enum_def)?
+                {
+                    visible_scope.insert_binding(&name, Namespace::Values, binding);
+                }
+                Ok(visible_scope)
+            }
+        }
+    }
+
     /// Return value bindings that a glob import from an enum should introduce.
-    pub fn visible_enum_variant_bindings(
+    fn visible_enum_variant_bindings(
         &self,
         importing_module: ModuleRef,
         enum_def: LocalDefRef,

--- a/crates/engine/ir-storage/src/def_map/query/path_resolution.rs
+++ b/crates/engine/ir-storage/src/def_map/query/path_resolution.rs
@@ -9,9 +9,7 @@
 //! construction, the same path-walking logic reads from frozen `DefMapDb` data.
 
 use rg_ir_model::items::VisibilityLevel;
-use rg_ir_model::{
-    DefId, DefMapRef, LocalDefRef, ModuleId, ModuleRef, Path, PathSegment, TargetRef,
-};
+use rg_ir_model::{DefId, LocalDefRef, ModuleRef, Path, PathSegment};
 use rg_std::UniqueVec;
 use rg_text::Name;
 
@@ -430,77 +428,26 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
         )
     }
 
-    /// Resolves an import path to every definition it denotes in the current scope snapshot.
+    /// Resolves an import path to every definition it denotes from a concrete module origin.
     pub fn import_defs(
-        &self,
-        importing_target: TargetRef,
-        importing_module: ModuleId,
-        path: &ImportPath,
-    ) -> Result<Vec<DefId>, E::Error> {
-        self.import_defs_from_module(
-            ModuleRef {
-                origin: DefMapRef::Target(importing_target),
-                module: importing_module,
-            },
-            path,
-        )
-    }
-
-    /// Resolves a path and keeps only module results.
-    pub fn import_modules(
-        &self,
-        importing_target: TargetRef,
-        importing_module: ModuleId,
-        path: &ImportPath,
-    ) -> Result<Vec<ModuleRef>, E::Error> {
-        self.import_modules_from_module(
-            ModuleRef {
-                origin: DefMapRef::Target(importing_target),
-                module: importing_module,
-            },
-            path,
-        )
-    }
-
-    /// Resolves a glob import prefix to modules and enums that can export bindings.
-    pub fn import_glob_sources(
-        &self,
-        importing_target: TargetRef,
-        importing_module: ModuleId,
-        path: &ImportPath,
-    ) -> Result<Vec<GlobImportSource>, E::Error> {
-        self.import_glob_sources_from_module(
-            ModuleRef {
-                origin: DefMapRef::Target(importing_target),
-                module: importing_module,
-            },
-            path,
-        )
-    }
-
-    /// Resolves an import path from a concrete module origin.
-    ///
-    /// Target-level imports delegate here, and body-local import finalization can use the same path
-    /// rules without losing the body origin of the importing synthetic module.
-    pub fn import_defs_from_module(
         &self,
         importing_module: ModuleRef,
         path: &ImportPath,
     ) -> Result<Vec<DefId>, E::Error> {
-        self.import_defs_from_module_with_filter(
+        self.import_defs_with_filter(
             importing_module,
             path,
             NameResolutionFilter::AllNamespaces,
         )
     }
 
-    /// Resolves an import path from a concrete module origin and keeps only module results.
-    pub fn import_modules_from_module(
+    /// Resolves an import path and keeps only module results.
+    pub fn import_modules(
         &self,
         importing_module: ModuleRef,
         path: &ImportPath,
     ) -> Result<Vec<ModuleRef>, E::Error> {
-        let resolved_defs = self.import_defs_from_module_with_filter(
+        let resolved_defs = self.import_defs_with_filter(
             importing_module,
             path,
             NameResolutionFilter::TypesOnly,
@@ -516,13 +463,13 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
         Ok(modules.into_vec())
     }
 
-    /// Resolves an import path from a concrete module origin and keeps glob-capable sources.
-    pub fn import_glob_sources_from_module(
+    /// Resolves a glob import prefix to modules and enums that can export bindings.
+    pub fn import_glob_sources(
         &self,
         importing_module: ModuleRef,
         path: &ImportPath,
     ) -> Result<Vec<GlobImportSource>, E::Error> {
-        let resolved_defs = self.import_defs_from_module_with_filter(
+        let resolved_defs = self.import_defs_with_filter(
             importing_module,
             path,
             NameResolutionFilter::TypesOnly,
@@ -599,8 +546,7 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
     /// Resolves a path whose terminal segment must be a macro binding.
     pub fn macro_bindings(
         &self,
-        importing_target: TargetRef,
-        importing_module: ModuleId,
+        importing_module: ModuleRef,
         path: &ImportPath,
     ) -> Result<Vec<ScopeBinding>, E::Error> {
         let Some((terminal, prefix)) = path.segments.split_last() else {
@@ -610,19 +556,14 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
             return Ok(Vec::new());
         };
 
-        let importing_module_ref = ModuleRef {
-            origin: DefMapRef::Target(importing_target),
-            module: importing_module,
-        };
         let source_modules = if prefix.is_empty() {
             if path.absolute {
                 Vec::new()
             } else {
-                vec![importing_module_ref]
+                vec![importing_module]
             }
         } else {
             self.import_modules(
-                importing_target,
                 importing_module,
                 &ImportPath {
                     absolute: path.absolute,
@@ -637,7 +578,7 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
                 continue;
             };
             for binding in entry.macros() {
-                if self.binding_is_visible(importing_module_ref, binding)? {
+                if self.binding_is_visible(importing_module, binding)? {
                     bindings.push(binding.clone());
                 }
             }
@@ -646,7 +587,7 @@ impl<E: TargetResolutionEnv + ?Sized> PathResolver<'_, E> {
         Ok(bindings)
     }
 
-    fn import_defs_from_module_with_filter(
+    fn import_defs_with_filter(
         &self,
         importing_module: ModuleRef,
         path: &ImportPath,

--- a/crates/engine/ir-storage/src/def_map/query/resolution_env.rs
+++ b/crates/engine/ir-storage/src/def_map/query/resolution_env.rs
@@ -7,7 +7,10 @@
 use rg_ir_model::{DefId, LocalDefRef, ModuleRef, TargetRef};
 use rg_text::Name;
 
-use super::super::{LocalDefData, LocalDefKind, MacroDefinitionView, ModuleData, ScopeEntryRef};
+use super::super::{
+    LocalDefData, LocalDefKind, LocalEnumVariantEntry, MacroDefinitionView, ModuleData,
+    ScopeEntryRef,
+};
 
 /// Minimal scope graph required by path and visibility lookup.
 pub trait ScopeResolutionEnv {
@@ -30,6 +33,11 @@ pub trait ScopeResolutionEnv {
         &self,
         local_def_ref: LocalDefRef,
     ) -> Result<Option<&LocalDefData>, Self::Error>;
+
+    fn local_enum_variant_entries_for_enum<'a>(
+        &'a self,
+        enum_def: LocalDefRef,
+    ) -> Result<Vec<LocalEnumVariantEntry<'a>>, Self::Error>;
 
     fn local_def_kind(
         &self,

--- a/crates/engine/ir-storage/src/def_map/store.rs
+++ b/crates/engine/ir-storage/src/def_map/store.rs
@@ -4,14 +4,17 @@ use wincode::{SchemaRead, SchemaWrite};
 
 use rg_arena::Arena;
 use rg_ir_model::{
-    BodyRef, DefMapRef, ImportId, LocalDefId, LocalDefRef, LocalImplId, LocalImplRef, ModuleId,
-    ModuleRef, TargetRef,
+    BodyRef, DefMapRef, ImportId, LocalDefId, LocalDefRef, LocalEnumVariantId, LocalEnumVariantRef,
+    LocalImplId, LocalImplRef, ModuleId, ModuleRef, TargetRef,
     hir::source::{GeneratedSourceData, GeneratedSourceId},
 };
 
 use super::{
     import::ImportData,
-    local::{LocalDefData, LocalImplData, MacroDefinitionData},
+    local::{
+        LocalDefData, LocalEnumVariantData, LocalEnumVariantEntry, LocalImplData,
+        MacroDefinitionData,
+    },
     module::ModuleData,
 };
 
@@ -19,6 +22,7 @@ use super::{
 struct DefMapData {
     modules: Arena<ModuleId, ModuleData>,
     local_defs: Arena<LocalDefId, LocalDefData>,
+    local_enum_variants: Arena<LocalEnumVariantId, LocalEnumVariantData>,
     macro_definitions: HashMap<LocalDefId, MacroDefinitionData>,
     local_impls: Arena<LocalImplId, LocalImplData>,
     imports: Arena<ImportId, ImportData>,
@@ -59,6 +63,16 @@ impl DefMapBuilder {
 
     pub fn alloc_local_def(&mut self, local_def: LocalDefData) -> LocalDefId {
         self.def_map.data.local_defs.alloc(local_def)
+    }
+
+    pub fn alloc_local_enum_variant(
+        &mut self,
+        local_enum_variant: LocalEnumVariantData,
+    ) -> LocalEnumVariantId {
+        self.def_map
+            .data
+            .local_enum_variants
+            .alloc(local_enum_variant)
     }
 
     pub fn insert_macro_definition(
@@ -114,6 +128,21 @@ impl<'a> PartialDefMap<'a> {
     /// Returns local definition data allocated so far during collection/finalization.
     pub fn local_def(&self, local_def: LocalDefId) -> Option<&'a LocalDefData> {
         self.def_map.local_def(local_def)
+    }
+
+    /// Returns enum variant data allocated so far during collection/finalization.
+    pub fn local_enum_variant(
+        &self,
+        local_enum_variant: LocalEnumVariantId,
+    ) -> Option<&'a LocalEnumVariantData> {
+        self.def_map.local_enum_variant(local_enum_variant)
+    }
+
+    pub fn local_enum_variant_entries_for_enum(
+        &self,
+        enum_def: LocalDefId,
+    ) -> impl Iterator<Item = LocalEnumVariantEntry<'a>> + 'a {
+        self.def_map.local_enum_variant_entries_for_enum(enum_def)
     }
 
     /// Returns a declarative macro payload allocated so far during collection/finalization.
@@ -210,6 +239,41 @@ impl DefMap {
             origin: self.own_ref,
             local_def: LocalDefId(id),
         })
+    }
+
+    /// Returns enum variant data by id.
+    pub fn local_enum_variant(
+        &self,
+        local_enum_variant: LocalEnumVariantId,
+    ) -> Option<&LocalEnumVariantData> {
+        self.data.local_enum_variants.get(local_enum_variant)
+    }
+
+    /// Returns all enum variants in stable variant-id order.
+    pub fn local_enum_variants(&self) -> &[LocalEnumVariantData] {
+        self.data.local_enum_variants.as_slice()
+    }
+
+    pub fn local_enum_variant_refs(&self) -> impl Iterator<Item = LocalEnumVariantRef> {
+        self.data
+            .local_enum_variants
+            .iter_with_ids()
+            .map(|(id, _)| LocalEnumVariantRef {
+                origin: self.own_ref,
+                local_enum_variant: id,
+            })
+    }
+
+    pub fn local_enum_variant_entries_for_enum(
+        &self,
+        enum_def: LocalDefId,
+    ) -> impl Iterator<Item = LocalEnumVariantEntry<'_>> {
+        let origin = self.own_ref;
+        self.data
+            .local_enum_variants
+            .iter_with_ids()
+            .filter(move |(_, variant)| variant.enum_def == enum_def)
+            .map(move |(id, data)| LocalEnumVariantEntry::new(origin, id, data))
     }
 
     /// Returns a declarative macro payload by its local definition id.

--- a/crates/engine/ir-storage/src/item/query/item_store.rs
+++ b/crates/engine/ir-storage/src/item/query/item_store.rs
@@ -6,7 +6,8 @@
 use rg_ir_model::items::{FieldKey, FieldList, GenericParams};
 use rg_ir_model::{
     ConstRef, DefMapRef, EnumVariantRef, FieldRef, FunctionRef, ImplRef, ItemOwner, LocalDefRef,
-    SemanticItemRef, StaticRef, TargetRef, TraitRef, TypeAliasRef, TypeDefId, TypeDefRef,
+    LocalEnumVariantRef, SemanticItemRef, StaticRef, TargetRef, TraitRef, TypeAliasRef, TypeDefId,
+    TypeDefRef,
     hir::items::{
         ConstData, EnumData, EnumVariantData, FieldData, FunctionData, ImplData, StaticData,
         TraitData, TypeAliasData,
@@ -14,7 +15,7 @@ use rg_ir_model::{
 };
 
 use super::ItemStoreSource;
-use crate::{ItemStore, SemanticItemView, TypePathContext};
+use crate::{ItemStore, LocalEnumVariantData, SemanticItemView, TypePathContext};
 
 /// Shared item queries over any storage that can route `DefMapRef` origins to item stores.
 ///
@@ -240,6 +241,22 @@ where
         } else {
             Ok(None)
         }
+    }
+
+    /// Projects a DefMap-local enum variant into the semantic variant ref lowered for it.
+    pub fn enum_variant_ref_for_local_enum_variant(
+        &self,
+        variant_ref: LocalEnumVariantRef,
+        variant_data: &LocalEnumVariantData,
+    ) -> Result<Option<EnumVariantRef>, S::Error> {
+        self.enum_variant_ref_for_local_def_index(
+            LocalDefRef {
+                origin: variant_ref.origin,
+                local_def: variant_data.enum_def,
+            },
+            variant_data.index,
+            Some(variant_data.name.as_str()),
+        )
     }
 
     /// Expands a variant ref with its enum owner and source facts.

--- a/crates/engine/ir-storage/src/item/query/item_store.rs
+++ b/crates/engine/ir-storage/src/item/query/item_store.rs
@@ -216,30 +216,53 @@ where
             }))
     }
 
+    /// Projects an enum local-def plus variant slot into the semantic variant ref lowered for it.
+    pub fn enum_variant_ref_for_local_def_index(
+        &self,
+        enum_def: LocalDefRef,
+        index: usize,
+        expected_name: Option<&str>,
+    ) -> Result<Option<EnumVariantRef>, S::Error> {
+        if let Some(SemanticItemRef::TypeDef(TypeDefRef {
+            origin,
+            id: TypeDefId::Enum(enum_id),
+        })) = self.semantic_item_for_local_def(enum_def)?
+            && let Some(items) = self.item_store_for_origin(origin)?
+            && let Some(data) = items.enum_data(enum_id)
+            && let Some(variant) = data.variants.get(index)
+            && expected_name.is_none_or(|expected_name| variant.name == expected_name)
+        {
+            Ok(Some(EnumVariantRef {
+                origin,
+                enum_id,
+                index,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Expands a variant ref with its enum owner and source facts.
     pub fn enum_variant_data(
         &self,
         variant_ref: EnumVariantRef,
     ) -> Result<Option<EnumVariantData<'a>>, S::Error> {
-        let Some(items) = self.item_store_for_origin(variant_ref.origin)? else {
-            return Ok(None);
-        };
-        let Some(data) = items.enum_data(variant_ref.enum_id) else {
-            return Ok(None);
-        };
-        let Some(variant) = data.variants.get(variant_ref.index) else {
-            return Ok(None);
-        };
-
-        Ok(Some(EnumVariantData {
-            owner: TypeDefRef {
-                origin: variant_ref.origin,
-                id: TypeDefId::Enum(variant_ref.enum_id),
-            },
-            owner_module: data.owner,
-            file_id: data.source.file_id,
-            variant,
-        }))
+        if let Some(items) = self.item_store_for_origin(variant_ref.origin)?
+            && let Some(data) = items.enum_data(variant_ref.enum_id)
+            && let Some(variant) = data.variants.get(variant_ref.index)
+        {
+            Ok(Some(EnumVariantData {
+                owner: TypeDefRef {
+                    origin: variant_ref.origin,
+                    id: TypeDefId::Enum(variant_ref.enum_id),
+                },
+                owner_module: data.owner,
+                file_id: data.source.file_id,
+                variant,
+            }))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Enumerates stable field refs without exposing whether the owner stores struct or union

--- a/crates/engine/ir-storage/src/lib.rs
+++ b/crates/engine/ir-storage/src/lib.rs
@@ -12,8 +12,8 @@ pub use self::{
         LocalEnumVariantData, LocalEnumVariantEntry, LocalImplData, MacroDefinitionData,
         MacroDefinitionEnv, MacroDefinitionPayload, MacroDefinitionView, ModuleData, ModuleOrigin,
         ModuleScope, ModuleScopeBuilder, NameResolutionFilter, Namespace, PackageDefMaps,
-        PartialDefMap, ScopeResolver, ResolvePathResult, ScopeBinding, ScopeBindingOrigin,
-        ScopeEntry, ScopeEntryRef, ScopeNamespace, ScopeResolutionEnv, TargetData,
+        PartialDefMap, ResolvePathResult, ScopeBinding, ScopeBindingOrigin, ScopeEntry,
+        ScopeEntryRef, ScopeNamespace, ScopeResolutionEnv, ScopeResolver, TargetData,
         TargetResolutionEnv, VisibleScopeDef, VisibleScopeDefs, VisibleScopeOrigin,
     },
     item::{

--- a/crates/engine/ir-storage/src/lib.rs
+++ b/crates/engine/ir-storage/src/lib.rs
@@ -12,7 +12,7 @@ pub use self::{
         LocalEnumVariantData, LocalEnumVariantEntry, LocalImplData, MacroDefinitionData,
         MacroDefinitionEnv, MacroDefinitionPayload, MacroDefinitionView, ModuleData, ModuleOrigin,
         ModuleScope, ModuleScopeBuilder, NameResolutionFilter, Namespace, PackageDefMaps,
-        PartialDefMap, PathResolver, ResolvePathResult, ScopeBinding, ScopeBindingOrigin,
+        PartialDefMap, ScopeResolver, ResolvePathResult, ScopeBinding, ScopeBindingOrigin,
         ScopeEntry, ScopeEntryRef, ScopeNamespace, ScopeResolutionEnv, TargetData,
         TargetResolutionEnv, VisibleScopeDef, VisibleScopeDefs, VisibleScopeOrigin,
     },

--- a/crates/engine/ir-storage/src/lib.rs
+++ b/crates/engine/ir-storage/src/lib.rs
@@ -7,13 +7,14 @@ pub use rg_std::UniqueVec;
 pub use self::{
     body::BodyLocalItems,
     def_map::{
-        DefMap, DefMapBuilder, DefMapQuery, DefMapSource, ImportBinding, ImportData, ImportKind,
-        ImportPath, ImportSourcePath, LocalDefData, LocalDefKind, LocalImplData,
-        MacroDefinitionData, MacroDefinitionEnv, MacroDefinitionPayload, MacroDefinitionView,
-        ModuleData, ModuleOrigin, ModuleScope, ModuleScopeBuilder, NameResolutionFilter, Namespace,
-        PackageDefMaps, PartialDefMap, PathResolver, ResolvePathResult, ScopeBinding,
-        ScopeBindingOrigin, ScopeEntry, ScopeEntryRef, ScopeNamespace, ScopeResolutionEnv,
-        TargetData, TargetResolutionEnv, VisibleScopeDef, VisibleScopeDefs, VisibleScopeOrigin,
+        DefMap, DefMapBuilder, DefMapQuery, DefMapSource, GlobImportSource, ImportBinding,
+        ImportData, ImportKind, ImportPath, ImportSourcePath, LocalDefData, LocalDefKind,
+        LocalEnumVariantData, LocalEnumVariantEntry, LocalImplData, MacroDefinitionData,
+        MacroDefinitionEnv, MacroDefinitionPayload, MacroDefinitionView, ModuleData, ModuleOrigin,
+        ModuleScope, ModuleScopeBuilder, NameResolutionFilter, Namespace, PackageDefMaps,
+        PartialDefMap, PathResolver, ResolvePathResult, ScopeBinding, ScopeBindingOrigin,
+        ScopeEntry, ScopeEntryRef, ScopeNamespace, ScopeResolutionEnv, TargetData,
+        TargetResolutionEnv, VisibleScopeDef, VisibleScopeDefs, VisibleScopeOrigin,
     },
     item::{
         ItemLookupIndex, ItemStore, ItemStoreBuilder, ItemStoreQuery, ItemStoreSource,

--- a/crates/engine/ir-view/src/item/declaration.rs
+++ b/crates/engine/ir-view/src/item/declaration.rs
@@ -89,11 +89,7 @@ impl<'a, 'db> DeclarationView<'a, 'db> {
 
     /// Return the file backing a root module.
     pub fn root_module_file(&self, module_ref: ModuleRef) -> anyhow::Result<Option<FileId>> {
-        let Some(module) = self
-            .db
-            .def_map_for_origin(module_ref.origin)?
-            .and_then(|def_map| def_map.module(module_ref.module))
-        else {
+        let Some(module) = self.db.module_data(module_ref)? else {
             return Ok(None);
         };
         let ModuleOrigin::Root { file_id } = module.origin else {
@@ -104,11 +100,7 @@ impl<'a, 'db> DeclarationView<'a, 'db> {
 
     /// Return declaration facts for an inline or out-of-line module declaration.
     fn module(&self, module_ref: ModuleRef) -> anyhow::Result<Option<Declaration>> {
-        let Some(module) = self
-            .db
-            .def_map_for_origin(module_ref.origin)?
-            .and_then(|def_map| def_map.module(module_ref.module))
-        else {
+        let Some(module) = self.db.module_data(module_ref)? else {
             return Ok(None);
         };
         let Some(name) = module.name.as_ref().map(ToString::to_string) else {
@@ -139,11 +131,7 @@ impl<'a, 'db> DeclarationView<'a, 'db> {
 
     /// Return declaration facts for a DefMap local item.
     fn local_def(&self, local_def: LocalDefRef) -> anyhow::Result<Option<Declaration>> {
-        let Some(data) = self
-            .db
-            .def_map_for_origin(local_def.origin)?
-            .and_then(|def_map| def_map.local_def(local_def.local_def))
-        else {
+        let Some(data) = self.db.local_def_data(local_def)? else {
             return Ok(None);
         };
 
@@ -177,11 +165,7 @@ impl<'a, 'db> DeclarationView<'a, 'db> {
                 let Some(local_impl_ref) = view.local_impl() else {
                     return Ok(None);
                 };
-                let Some(local_impl) = self
-                    .db
-                    .def_map_for_origin(local_impl_ref.origin)?
-                    .and_then(|def_map| def_map.local_impl(local_impl_ref.local_impl))
-                else {
+                let Some(local_impl) = self.db.local_impl_data(local_impl_ref)? else {
                     return Ok(None);
                 };
                 let Some((self_ty, trait_ref)) = view.impl_header() else {

--- a/crates/engine/ir-view/src/item/declaration.rs
+++ b/crates/engine/ir-view/src/item/declaration.rs
@@ -5,7 +5,7 @@ use rg_ir_model::{
     BodyBindingRef, EnumVariantRef, FieldRef, FunctionRef, ItemOwner, LocalDefRef, ModuleRef,
     SemanticItemKind, SemanticItemRef, TargetRef, identity::DeclarationRef,
 };
-use rg_ir_storage::{DefMapQuery, ItemStoreQuery, ModuleOrigin};
+use rg_ir_storage::{DefMapSource, ItemStoreQuery, ModuleOrigin};
 use rg_parse::{FileId, Span};
 
 use crate::{IndexedViewDb, SymbolKind};
@@ -89,8 +89,11 @@ impl<'a, 'db> DeclarationView<'a, 'db> {
 
     /// Return the file backing a root module.
     pub fn root_module_file(&self, module_ref: ModuleRef) -> anyhow::Result<Option<FileId>> {
-        let def_maps = DefMapQuery::new(self.db);
-        let Some(module) = def_maps.module_data(module_ref)? else {
+        let Some(module) = self
+            .db
+            .def_map_for_origin(module_ref.origin)?
+            .and_then(|def_map| def_map.module(module_ref.module))
+        else {
             return Ok(None);
         };
         let ModuleOrigin::Root { file_id } = module.origin else {
@@ -101,8 +104,11 @@ impl<'a, 'db> DeclarationView<'a, 'db> {
 
     /// Return declaration facts for an inline or out-of-line module declaration.
     fn module(&self, module_ref: ModuleRef) -> anyhow::Result<Option<Declaration>> {
-        let def_maps = DefMapQuery::new(self.db);
-        let Some(module) = def_maps.module_data(module_ref)? else {
+        let Some(module) = self
+            .db
+            .def_map_for_origin(module_ref.origin)?
+            .and_then(|def_map| def_map.module(module_ref.module))
+        else {
             return Ok(None);
         };
         let Some(name) = module.name.as_ref().map(ToString::to_string) else {
@@ -133,8 +139,11 @@ impl<'a, 'db> DeclarationView<'a, 'db> {
 
     /// Return declaration facts for a DefMap local item.
     fn local_def(&self, local_def: LocalDefRef) -> anyhow::Result<Option<Declaration>> {
-        let def_maps = DefMapQuery::new(self.db);
-        let Some(data) = def_maps.local_def_data(local_def)? else {
+        let Some(data) = self
+            .db
+            .def_map_for_origin(local_def.origin)?
+            .and_then(|def_map| def_map.local_def(local_def.local_def))
+        else {
             return Ok(None);
         };
 
@@ -168,8 +177,11 @@ impl<'a, 'db> DeclarationView<'a, 'db> {
                 let Some(local_impl_ref) = view.local_impl() else {
                     return Ok(None);
                 };
-                let def_maps = DefMapQuery::new(self.db);
-                let Some(local_impl) = def_maps.local_impl_data(local_impl_ref)? else {
+                let Some(local_impl) = self
+                    .db
+                    .def_map_for_origin(local_impl_ref.origin)?
+                    .and_then(|def_map| def_map.local_impl(local_impl_ref.local_impl))
+                else {
                     return Ok(None);
                 };
                 let Some((self_ty, trait_ref)) = view.impl_header() else {

--- a/crates/engine/ir-view/src/item/details.rs
+++ b/crates/engine/ir-view/src/item/details.rs
@@ -10,7 +10,7 @@ use rg_ir_model::{
     SemanticItemRef, StaticRef, TraitRef, TypeAliasRef, TypeDefId, TypeDefRef,
     identity::DeclarationRef,
 };
-use rg_ir_storage::{DefMapQuery, ItemStoreQuery};
+use rg_ir_storage::{DefMapQuery, DefMapSource, ItemStoreQuery};
 
 use crate::{
     IndexedViewDb, SymbolKind, display::signature::SignatureRenderer, item::path::PathView,
@@ -276,8 +276,11 @@ impl<'a, 'db> DeclarationDetailsView<'a, 'db> {
         module_ref: ModuleRef,
         context: &DeclarationDetailsContext,
     ) -> anyhow::Result<Option<DeclarationDetails>> {
-        let def_maps = DefMapQuery::new(self.db);
-        let Some(module) = def_maps.module_data(module_ref)? else {
+        let Some(module) = self
+            .db
+            .def_map_for_origin(module_ref.origin)?
+            .and_then(|def_map| def_map.module(module_ref.module))
+        else {
             return Ok(None);
         };
         let name = context
@@ -298,8 +301,11 @@ impl<'a, 'db> DeclarationDetailsView<'a, 'db> {
         &self,
         local_def_ref: LocalDefRef,
     ) -> anyhow::Result<Option<DeclarationDetails>> {
-        let def_maps = DefMapQuery::new(self.db);
-        let Some(data) = def_maps.local_def_data(local_def_ref)? else {
+        let Some(data) = self
+            .db
+            .def_map_for_origin(local_def_ref.origin)?
+            .and_then(|def_map| def_map.local_def(local_def_ref.local_def))
+        else {
             return Ok(None);
         };
         let path = PathView::new(self.db)
@@ -308,7 +314,7 @@ impl<'a, 'db> DeclarationDetailsView<'a, 'db> {
                 module: data.module,
             })?
             .map(|module| format!("{module}::{}", data.name));
-        let docs = def_maps
+        let docs = DefMapQuery::new(self.db)
             .macro_definition_view(DefId::Local(local_def_ref))?
             .and_then(|macro_| macro_.data.docs.as_ref().map(Documentation::text));
         Ok(Some(DeclarationDetails {

--- a/crates/engine/ir-view/src/item/details.rs
+++ b/crates/engine/ir-view/src/item/details.rs
@@ -276,11 +276,7 @@ impl<'a, 'db> DeclarationDetailsView<'a, 'db> {
         module_ref: ModuleRef,
         context: &DeclarationDetailsContext,
     ) -> anyhow::Result<Option<DeclarationDetails>> {
-        let Some(module) = self
-            .db
-            .def_map_for_origin(module_ref.origin)?
-            .and_then(|def_map| def_map.module(module_ref.module))
-        else {
+        let Some(module) = self.db.module_data(module_ref)? else {
             return Ok(None);
         };
         let name = context
@@ -301,11 +297,7 @@ impl<'a, 'db> DeclarationDetailsView<'a, 'db> {
         &self,
         local_def_ref: LocalDefRef,
     ) -> anyhow::Result<Option<DeclarationDetails>> {
-        let Some(data) = self
-            .db
-            .def_map_for_origin(local_def_ref.origin)?
-            .and_then(|def_map| def_map.local_def(local_def_ref.local_def))
-        else {
+        let Some(data) = self.db.local_def_data(local_def_ref)? else {
             return Ok(None);
         };
         let path = PathView::new(self.db)

--- a/crates/engine/ir-view/src/item/path.rs
+++ b/crates/engine/ir-view/src/item/path.rs
@@ -32,10 +32,10 @@ impl<'a, 'db> PathView<'a, 'db> {
         // Module ids form a parent chain rooted at the target module. Walking it upward and then
         // reversing gives us the same crate::item::module::child shape users see in Rust paths.
         loop {
-            let Some(module) = self
-                .0
-                .def_map_for_origin(module_ref.origin)?
-                .and_then(|def_map| def_map.module(current))
+            let Some(module) = self.0.module_data(ModuleRef {
+                origin: module_ref.origin,
+                module: current,
+            })?
             else {
                 return Ok(None);
             };

--- a/crates/engine/ir-view/src/item/path.rs
+++ b/crates/engine/ir-view/src/item/path.rs
@@ -8,7 +8,7 @@ use rg_ir_model::{
     ConstRef, DefMapRef, FunctionRef, ImplId, ImplRef, ItemOwner, ModuleRef, StaticRef, TraitRef,
     TypeAliasRef, TypeDefId, TypeDefRef, hir::items::EnumVariantData,
 };
-use rg_ir_storage::{DefMapQuery, ItemStoreQuery};
+use rg_ir_storage::{DefMapSource, ItemStoreQuery};
 
 use crate::IndexedViewDb;
 
@@ -26,17 +26,16 @@ impl<'a, 'db> PathView<'a, 'db> {
             return Ok(None);
         };
         let package = self.0.def_map.package(target.package)?;
-        let def_maps = DefMapQuery::new(self.0);
         let mut names = Vec::new();
         let mut current = module_ref.module;
 
         // Module ids form a parent chain rooted at the target module. Walking it upward and then
         // reversing gives us the same crate::item::module::child shape users see in Rust paths.
         loop {
-            let Some(module) = def_maps.module_data(ModuleRef {
-                origin: module_ref.origin,
-                module: current,
-            })?
+            let Some(module) = self
+                .0
+                .def_map_for_origin(module_ref.origin)?
+                .and_then(|def_map| def_map.module(current))
             else {
                 return Ok(None);
             };

--- a/crates/engine/ir-view/src/lookup/name.rs
+++ b/crates/engine/ir-view/src/lookup/name.rs
@@ -8,7 +8,8 @@ use rg_ir_model::{
     DefId, FunctionRef, LocalDefRef, ModuleRef, Path, SemanticItemRef, identity::DeclarationRef,
 };
 use rg_ir_storage::{
-    DefMapQuery, ItemStoreQuery, ScopeNamespace, VisibleScopeDef, VisibleScopeOrigin,
+    DefMapQuery, DefMapSource, ItemStoreQuery, NameResolutionFilter, ScopeNamespace,
+    VisibleScopeDef, VisibleScopeOrigin,
 };
 
 use crate::{IndexedViewDb, SymbolKind};
@@ -107,8 +108,12 @@ impl<'a, 'db> NameLookupView<'a, 'db> {
         importing_module: ModuleRef,
         qualifier: &Path,
     ) -> anyhow::Result<Vec<ModuleScopeName>> {
-        let resolved = DefMapQuery::new(self.db)
-            .resolve_path_in_type_namespace(importing_module, qualifier)?;
+        let def_maps = DefMapQuery::new(self.db);
+        let resolved = def_maps.scope_resolver().resolve_path(
+            importing_module,
+            qualifier,
+            NameResolutionFilter::TypesOnly,
+        )?;
         let mut names = Vec::new();
 
         // Qualified module lookup only lists names from modules. Associated items hang off type
@@ -117,9 +122,7 @@ impl<'a, 'db> NameLookupView<'a, 'db> {
             let DefId::Module(source_module) = def else {
                 continue;
             };
-            for visible_def in
-                DefMapQuery::new(self.db).visible_scope_defs(importing_module, source_module)?
-            {
+            for visible_def in def_maps.visible_scope_defs(importing_module, source_module)? {
                 if let Some(name) = self.module_scope_name(visible_def)? {
                     names.push(name);
                 }
@@ -148,11 +151,14 @@ impl<'a, 'db> NameLookupView<'a, 'db> {
         &self,
         visible_def: VisibleScopeDef,
     ) -> anyhow::Result<Option<ModuleScopeName>> {
-        let def_maps = DefMapQuery::new(self.db);
         let mut function = None;
         let (declaration, kind, documentation) = match visible_def.def {
             DefId::Module(module) => {
-                let Some(data) = def_maps.module_data(module)? else {
+                let Some(data) = self
+                    .db
+                    .def_map_for_origin(module.origin)?
+                    .and_then(|def_map| def_map.module(module.module))
+                else {
                     return Ok(None);
                 };
                 (
@@ -162,7 +168,11 @@ impl<'a, 'db> NameLookupView<'a, 'db> {
                 )
             }
             DefId::Local(local_def_ref) => {
-                let Some(data) = def_maps.local_def_data(local_def_ref)? else {
+                let Some(data) = self
+                    .db
+                    .def_map_for_origin(local_def_ref.origin)?
+                    .and_then(|def_map| def_map.local_def(local_def_ref.local_def))
+                else {
                     return Ok(None);
                 };
                 if let Some(SemanticItemRef::Function(function_ref)) =
@@ -178,7 +188,10 @@ impl<'a, 'db> NameLookupView<'a, 'db> {
             }
             DefId::EnumVariant(variant_def) => {
                 let item_query = ItemStoreQuery::new(self.db);
-                if let Some(variant_def_data) = def_maps.local_enum_variant_data(variant_def)?
+                if let Some(variant_def_data) = self
+                    .db
+                    .def_map_for_origin(variant_def.origin)?
+                    .and_then(|def_map| def_map.local_enum_variant(variant_def.local_enum_variant))
                     && let Some(variant_ref) = item_query.enum_variant_ref_for_local_def_index(
                         LocalDefRef {
                             origin: variant_def.origin,

--- a/crates/engine/ir-view/src/lookup/name.rs
+++ b/crates/engine/ir-view/src/lookup/name.rs
@@ -4,7 +4,9 @@
 //! concepts: they are names visible from an indexed module or lexical body scope.
 
 use rg_ir_model::items::Documentation;
-use rg_ir_model::{DefId, FunctionRef, ModuleRef, Path, SemanticItemRef, identity::DeclarationRef};
+use rg_ir_model::{
+    DefId, FunctionRef, LocalDefRef, ModuleRef, Path, SemanticItemRef, identity::DeclarationRef,
+};
 use rg_ir_storage::{
     DefMapQuery, ItemStoreQuery, ScopeNamespace, VisibleScopeDef, VisibleScopeOrigin,
 };
@@ -147,14 +149,14 @@ impl<'a, 'db> NameLookupView<'a, 'db> {
         visible_def: VisibleScopeDef,
     ) -> anyhow::Result<Option<ModuleScopeName>> {
         let def_maps = DefMapQuery::new(self.db);
-        let declaration = DeclarationRef::from_def(visible_def.def);
         let mut function = None;
-        let (kind, documentation) = match visible_def.def {
+        let (declaration, kind, documentation) = match visible_def.def {
             DefId::Module(module) => {
                 let Some(data) = def_maps.module_data(module)? else {
                     return Ok(None);
                 };
                 (
+                    DeclarationRef::Module(module),
                     SymbolKind::Module,
                     data.docs.as_ref().map(Documentation::text),
                 )
@@ -168,7 +170,35 @@ impl<'a, 'db> NameLookupView<'a, 'db> {
                 {
                     function = Some(function_ref);
                 }
-                (SymbolKind::from_local_def_kind(data.kind), None)
+                (
+                    DeclarationRef::LocalDef(local_def_ref),
+                    SymbolKind::from_local_def_kind(data.kind),
+                    None,
+                )
+            }
+            DefId::EnumVariant(variant_def) => {
+                let item_query = ItemStoreQuery::new(self.db);
+                if let Some(variant_def_data) = def_maps.local_enum_variant_data(variant_def)?
+                    && let Some(variant_ref) = item_query.enum_variant_ref_for_local_def_index(
+                        LocalDefRef {
+                            origin: variant_def.origin,
+                            local_def: variant_def_data.enum_def,
+                        },
+                        variant_def_data.index,
+                        Some(variant_def_data.name.as_str()),
+                    )?
+                {
+                    let docs = item_query
+                        .enum_variant_data(variant_ref)?
+                        .and_then(|data| data.variant.docs.as_ref().map(Documentation::text));
+                    (
+                        DeclarationRef::EnumVariant(variant_ref),
+                        SymbolKind::EnumVariant,
+                        docs,
+                    )
+                } else {
+                    return Ok(None);
+                }
             }
         };
 

--- a/crates/engine/ir-view/src/lookup/name.rs
+++ b/crates/engine/ir-view/src/lookup/name.rs
@@ -4,9 +4,7 @@
 //! concepts: they are names visible from an indexed module or lexical body scope.
 
 use rg_ir_model::items::Documentation;
-use rg_ir_model::{
-    DefId, FunctionRef, LocalDefRef, ModuleRef, Path, SemanticItemRef, identity::DeclarationRef,
-};
+use rg_ir_model::{DefId, FunctionRef, ModuleRef, Path, SemanticItemRef, identity::DeclarationRef};
 use rg_ir_storage::{
     DefMapQuery, DefMapSource, ItemStoreQuery, NameResolutionFilter, ScopeNamespace,
     VisibleScopeDef, VisibleScopeOrigin,
@@ -154,11 +152,7 @@ impl<'a, 'db> NameLookupView<'a, 'db> {
         let mut function = None;
         let (declaration, kind, documentation) = match visible_def.def {
             DefId::Module(module) => {
-                let Some(data) = self
-                    .db
-                    .def_map_for_origin(module.origin)?
-                    .and_then(|def_map| def_map.module(module.module))
-                else {
+                let Some(data) = self.db.module_data(module)? else {
                     return Ok(None);
                 };
                 (
@@ -168,11 +162,7 @@ impl<'a, 'db> NameLookupView<'a, 'db> {
                 )
             }
             DefId::Local(local_def_ref) => {
-                let Some(data) = self
-                    .db
-                    .def_map_for_origin(local_def_ref.origin)?
-                    .and_then(|def_map| def_map.local_def(local_def_ref.local_def))
-                else {
+                let Some(data) = self.db.local_def_data(local_def_ref)? else {
                     return Ok(None);
                 };
                 if let Some(SemanticItemRef::Function(function_ref)) =
@@ -188,18 +178,9 @@ impl<'a, 'db> NameLookupView<'a, 'db> {
             }
             DefId::EnumVariant(variant_def) => {
                 let item_query = ItemStoreQuery::new(self.db);
-                if let Some(variant_def_data) = self
-                    .db
-                    .def_map_for_origin(variant_def.origin)?
-                    .and_then(|def_map| def_map.local_enum_variant(variant_def.local_enum_variant))
-                    && let Some(variant_ref) = item_query.enum_variant_ref_for_local_def_index(
-                        LocalDefRef {
-                            origin: variant_def.origin,
-                            local_def: variant_def_data.enum_def,
-                        },
-                        variant_def_data.index,
-                        Some(variant_def_data.name.as_str()),
-                    )?
+                if let Some(variant_def_data) = self.db.local_enum_variant_data(variant_def)?
+                    && let Some(variant_ref) = item_query
+                        .enum_variant_ref_for_local_enum_variant(variant_def, variant_def_data)?
                 {
                     let docs = item_query
                         .enum_variant_data(variant_ref)?

--- a/crates/engine/ir-view/src/lookup/resolution.rs
+++ b/crates/engine/ir-view/src/lookup/resolution.rs
@@ -10,7 +10,9 @@ use rg_ir_model::{
     BodyRef, DefId, LocalDefRef, ModuleRef, ScopeId, TypePathResolution,
     identity::{DeclarationRef, ExprRef},
 };
-use rg_ir_storage::{DefMapQuery, ItemStoreQuery, TypePathContext};
+use rg_ir_storage::{
+    DefMapQuery, DefMapSource, ItemStoreQuery, NameResolutionFilter, TypePathContext,
+};
 use rg_ty::ItemPathQuery;
 
 use crate::{IndexedViewDb, body::BodyResolutionView, source::IndexedTypePathScope};
@@ -102,9 +104,11 @@ impl<'a, 'db> ResolutionView<'a, 'db> {
                 Ok(vec![declaration])
             }
             DefId::EnumVariant(variant_def) => {
-                let def_maps = DefMapQuery::new(self.0);
                 let item_query = ItemStoreQuery::new(self.0);
-                if let Some(variant_def_data) = def_maps.local_enum_variant_data(variant_def)?
+                if let Some(variant_def_data) = self
+                    .0
+                    .def_map_for_origin(variant_def.origin)?
+                    .and_then(|def_map| def_map.local_enum_variant(variant_def.local_enum_variant))
                     && let Some(variant_ref) = item_query.enum_variant_ref_for_local_def_index(
                         LocalDefRef {
                             origin: variant_def.origin,
@@ -141,8 +145,10 @@ impl<'a, 'db> ResolutionView<'a, 'db> {
         path: &Path,
     ) -> anyhow::Result<Vec<DeclarationRef>> {
         let mut declarations = Vec::new();
-        for def in DefMapQuery::new(self.0)
-            .resolve_path(module, path)?
+        let def_maps = DefMapQuery::new(self.0);
+        for def in def_maps
+            .scope_resolver()
+            .resolve_path(module, path, NameResolutionFilter::AllNamespaces)?
             .resolved
         {
             declarations.extend(self.declarations_for_def(def)?);

--- a/crates/engine/ir-view/src/lookup/resolution.rs
+++ b/crates/engine/ir-view/src/lookup/resolution.rs
@@ -101,6 +101,24 @@ impl<'a, 'db> ResolutionView<'a, 'db> {
                     .unwrap_or_else(|| self.fallback_name_def(local_def));
                 Ok(vec![declaration])
             }
+            DefId::EnumVariant(variant_def) => {
+                let def_maps = DefMapQuery::new(self.0);
+                let item_query = ItemStoreQuery::new(self.0);
+                if let Some(variant_def_data) = def_maps.local_enum_variant_data(variant_def)?
+                    && let Some(variant_ref) = item_query.enum_variant_ref_for_local_def_index(
+                        LocalDefRef {
+                            origin: variant_def.origin,
+                            local_def: variant_def_data.enum_def,
+                        },
+                        variant_def_data.index,
+                        Some(variant_def_data.name.as_str()),
+                    )?
+                {
+                    Ok(vec![DeclarationRef::EnumVariant(variant_ref)])
+                } else {
+                    Ok(Vec::new())
+                }
+            }
         }
     }
 

--- a/crates/engine/ir-view/src/lookup/resolution.rs
+++ b/crates/engine/ir-view/src/lookup/resolution.rs
@@ -105,18 +105,9 @@ impl<'a, 'db> ResolutionView<'a, 'db> {
             }
             DefId::EnumVariant(variant_def) => {
                 let item_query = ItemStoreQuery::new(self.0);
-                if let Some(variant_def_data) = self
-                    .0
-                    .def_map_for_origin(variant_def.origin)?
-                    .and_then(|def_map| def_map.local_enum_variant(variant_def.local_enum_variant))
-                    && let Some(variant_ref) = item_query.enum_variant_ref_for_local_def_index(
-                        LocalDefRef {
-                            origin: variant_def.origin,
-                            local_def: variant_def_data.enum_def,
-                        },
-                        variant_def_data.index,
-                        Some(variant_def_data.name.as_str()),
-                    )?
+                if let Some(variant_def_data) = self.0.local_enum_variant_data(variant_def)?
+                    && let Some(variant_ref) = item_query
+                        .enum_variant_ref_for_local_enum_variant(variant_def, variant_def_data)?
                 {
                     Ok(vec![DeclarationRef::EnumVariant(variant_ref)])
                 } else {

--- a/crates/engine/ir-view/src/source/occurrence.rs
+++ b/crates/engine/ir-view/src/source/occurrence.rs
@@ -248,7 +248,9 @@ impl<'a, 'db> SourceOccurrenceView<'a, 'db> {
             }
         }
         for candidate in self.db.def_map.cursor_candidates(target, file_id, offset)? {
-            occurrences.push(Self::def_map_occurrence(target, candidate));
+            if let Some(occurrence) = Self::def_map_occurrence(target, candidate) {
+                occurrences.push(occurrence);
+            }
         }
         for candidate in self
             .db
@@ -272,7 +274,9 @@ impl<'a, 'db> SourceOccurrenceView<'a, 'db> {
         let mut occurrences = Vec::new();
 
         for candidate in self.db.def_map.source_candidates(target, file_id)? {
-            occurrences.push(Self::def_map_occurrence(target, candidate));
+            if let Some(occurrence) = Self::def_map_occurrence(target, candidate) {
+                occurrences.push(occurrence);
+            }
         }
         for candidate in self.db.body_ir.source_candidates(target, file_id)? {
             if let Some(occurrence) = self.body_occurrence(target, candidate, file_id)? {
@@ -296,38 +300,42 @@ impl<'a, 'db> SourceOccurrenceView<'a, 'db> {
     fn def_map_occurrence(
         target: TargetRef,
         candidate: DefMapCursorCandidate,
-    ) -> IndexedSourceOccurrence {
+    ) -> Option<IndexedSourceOccurrence> {
         match candidate {
             DefMapCursorCandidate::Def { def, file_id, span } => {
-                IndexedSourceOccurrence::declaration(
-                    IndexedSourceFact::Declaration(DeclarationRef::from_def(def)),
+                // TODO: Technically we are being defensive here, because enum variants
+                // are not candidates. Probably we need a slightly better representation
+                // and should get rid of option.
+                let declaration = DeclarationRef::try_from_def(def)?;
+                Some(IndexedSourceOccurrence::declaration(
+                    IndexedSourceFact::Declaration(declaration),
                     target,
                     file_id,
                     span,
-                )
+                ))
             }
             DefMapCursorCandidate::UsePath {
                 module,
                 path,
                 file_id,
                 span,
-            } => IndexedSourceOccurrence::reference(
+            } => Some(IndexedSourceOccurrence::reference(
                 IndexedSourceFact::UsePath { module, path },
                 target,
                 file_id,
                 span,
-            ),
+            )),
             DefMapCursorCandidate::ImportAlias {
                 module,
                 path,
                 file_id,
                 span,
-            } => IndexedSourceOccurrence::structural(
+            } => Some(IndexedSourceOccurrence::structural(
                 IndexedSourceFact::UsePath { module, path },
                 target,
                 file_id,
                 span,
-            ),
+            )),
         }
     }
 

--- a/crates/engine/ir-view/src/symbol/view.rs
+++ b/crates/engine/ir-view/src/symbol/view.rs
@@ -120,18 +120,15 @@ impl<'a, 'db> SymbolItemIndex<'a, 'db> {
     fn module_declarations(&self, target: TargetRef) -> Result<Vec<DeclarationRef>> {
         Ok(self
             .db
-            .def_map_for_origin(DefMapRef::Target(target))?
-            .map(|def_map| def_map.module_refs().map(DeclarationRef::module).collect())
-            .unwrap_or_default())
+            .module_refs(target)?
+            .into_iter()
+            .map(DeclarationRef::module)
+            .collect())
     }
 
     /// Return a workspace-symbol container name for a module.
     fn module_container_name(&self, module_ref: ModuleRef) -> Result<Option<String>> {
-        let Some(module) = self
-            .db
-            .def_map_for_origin(module_ref.origin)?
-            .and_then(|def_map| def_map.module(module_ref.module))
-        else {
+        let Some(module) = self.db.module_data(module_ref)? else {
             return Ok(None);
         };
         let Some(parent) = module.parent else {
@@ -340,11 +337,7 @@ impl<'a, 'db> SymbolItemIndex<'a, 'db> {
 
     /// Return a local module path for workspace-symbol containers.
     fn module_path(&self, origin: DefMapRef, module: ModuleId) -> Result<String> {
-        let Some(data) = self
-            .db
-            .def_map_for_origin(origin)?
-            .and_then(|def_map| def_map.module(module))
-        else {
+        let Some(data) = self.db.module_data(ModuleRef { origin, module })? else {
             return Ok(String::new());
         };
         let Some(name) = &data.name else {

--- a/crates/engine/ir-view/src/symbol/view.rs
+++ b/crates/engine/ir-view/src/symbol/view.rs
@@ -6,7 +6,7 @@ use rg_ir_model::{
     FunctionRef as SemanticFunctionRef, ModuleId, ModuleRef, SemanticItemKind, TargetRef,
     TypeAliasRef, TypeDefId, TypeDefRef, identity::DeclarationRef,
 };
-use rg_ir_storage::{DefMapQuery, ItemStoreQuery, SemanticItemView};
+use rg_ir_storage::{DefMapSource, ItemStoreQuery, SemanticItemView};
 use rg_parse::{FileId, Span};
 
 use crate::{
@@ -118,17 +118,20 @@ impl<'a, 'db> SymbolItemIndex<'a, 'db> {
 
     /// Return module declarations for one target.
     fn module_declarations(&self, target: TargetRef) -> Result<Vec<DeclarationRef>> {
-        Ok(DefMapQuery::new(self.db)
-            .module_refs(target)?
-            .into_iter()
-            .map(DeclarationRef::module)
-            .collect())
+        Ok(self
+            .db
+            .def_map_for_origin(DefMapRef::Target(target))?
+            .map(|def_map| def_map.module_refs().map(DeclarationRef::module).collect())
+            .unwrap_or_default())
     }
 
     /// Return a workspace-symbol container name for a module.
     fn module_container_name(&self, module_ref: ModuleRef) -> Result<Option<String>> {
-        let def_maps = DefMapQuery::new(self.db);
-        let Some(module) = def_maps.module_data(module_ref)? else {
+        let Some(module) = self
+            .db
+            .def_map_for_origin(module_ref.origin)?
+            .and_then(|def_map| def_map.module(module_ref.module))
+        else {
             return Ok(None);
         };
         let Some(parent) = module.parent else {
@@ -337,8 +340,11 @@ impl<'a, 'db> SymbolItemIndex<'a, 'db> {
 
     /// Return a local module path for workspace-symbol containers.
     fn module_path(&self, origin: DefMapRef, module: ModuleId) -> Result<String> {
-        let def_maps = DefMapQuery::new(self.db);
-        let Some(data) = def_maps.module_data(ModuleRef { origin, module })? else {
+        let Some(data) = self
+            .db
+            .def_map_for_origin(origin)?
+            .and_then(|def_map| def_map.module(module))
+        else {
             return Ok(String::new());
         };
         let Some(name) = &data.name else {

--- a/crates/engine/ty/src/item_path.rs
+++ b/crates/engine/ty/src/item_path.rs
@@ -8,7 +8,10 @@ use rg_ir_model::items::{GenericArg as ItemGenericArg, TypeBound, TypePath, Type
 use rg_ir_model::{
     DefId, ModuleRef, Path, SemanticItemRef, TraitRef, TypeDefRef, TypePathResolution,
 };
-use rg_ir_storage::{DefMapQuery, DefMapSource, ItemStoreQuery, ItemStoreSource, TypePathContext};
+use rg_ir_storage::{
+    DefMapQuery, DefMapSource, ItemStoreQuery, ItemStoreSource, NameResolutionFilter,
+    TypePathContext,
+};
 use rg_std::{ExpectedUnique, UniqueVec};
 
 use crate::{GenericArg, OpaqueTraitBound, PrimitiveTy, Ty, TypeSubst};
@@ -197,7 +200,11 @@ where
         from: ModuleRef,
         path: &Path,
     ) -> Result<UniqueVec<SemanticItemRef>, D::Error> {
-        let result = self.def_maps.resolve_path_in_type_namespace(from, path)?;
+        let result = self.def_maps.scope_resolver().resolve_path(
+            from,
+            path,
+            NameResolutionFilter::TypesOnly,
+        )?;
         let mut resolved_items = UniqueVec::new();
         for def in result.resolved {
             if let DefId::Local(local_def) = def

--- a/crates/rust-glancer/src/compare_lsp/query/mod.rs
+++ b/crates/rust-glancer/src/compare_lsp/query/mod.rs
@@ -62,6 +62,9 @@ crates/ide/src/child_modules.rs:30:48 # definition/associated-function: from_mod
 crates/ide/src/child_modules.rs:54:68 # definition/method-call: focus_or_full_range
 crates/ide/src/goto_implementation.rs:83:28 # definition/helper-call: impls_for_trait_item
 crates/ide/src/goto_definition.rs:125:16 # definition/helper-call: try_lookup_include_path
+crates/ide/src/call_hierarchy.rs:107:8 # definition/enum-variant-import: SyntaxKind::IDENT
+crates/hir-def/src/item_scope.rs:784:12 # definition/body-macro: format_to
+crates/hir-def/src/item_tree/pretty.rs:58:8 # definition/body-macro: wln
 crates/ide/src/lib.rs:89:21 # definition/reexport: GotoDefinitionConfig
 crates/ide/src/lib.rs:93:21 # definition/reexport: HoverConfig
 crates/ide/src/lib.rs:109:24 # definition/reexport: NavigationTarget
@@ -70,6 +73,7 @@ crates/ide/src/references.rs:132:16 # definition/helper-call: retain_adt_literal
 crates/ide/src/references.rs:162:41 # definition/method-call: focus_or_full_range-extra-ref
 crates/ide/src/references.rs:174:23 # definition/helper-call: handle_control_flow_keywords
 crates/ide/src/references.rs:204:17 # definition/helper-call: find_defs
+crates/ide/src/references.rs:224:12 # definition/glob-enum-variant: SyntaxKind::IDENT
 
 [textDocument/typeDefinition]
 crates/ide/src/call_hierarchy.rs:52:12 # type_definition/local: calls
@@ -176,9 +180,14 @@ crates/ide/src/hover.rs:79:9 # hover/enum: HoverAction
 crates/ide/src/hover.rs:81:19 # hover/enum-variant: Implementation
 crates/ide/src/hover.rs:119:11 # hover/type: HoverResult
 crates/ide/src/hover.rs:130:14 # hover/function: hover
+crates/ide/src/hover.rs:389:38 # hover/body-macro: format
 crates/ide/src/hover.rs:159:3 # hover/helper: hover_offset
+crates/ide/src/inlay_hints.rs:803:27 # hover/enum-variant: Err
 crates/ide/src/lib.rs:109:24 # hover/reexport: NavigationTarget
 crates/ide/src/navigation_target.rs:31:11 # hover/type: NavigationTarget
 crates/ide/src/navigation_target.rs:120:10 # hover/trait: TryToNav
+crates/ide/src/navigation_target.rs:86:8 # hover/enum-variant: Ok
+crates/ide/src/references.rs:155:20 # hover/enum-variant: Some
+crates/ide/src/references.rs:156:20 # hover/enum-variant: None
 crates/ide/src/references.rs:91:8 # hover/field: search_scope
 "#;


### PR DESCRIPTION
With this feature, `Some` / `None` / `Err` / `Ok` finally work!

Plus plenty of long warranted refactoring on top.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved name resolution now treats enum variants as first-class value candidates, including during imports and lookups.
  * Imported enum variants (including constructor-like behavior) now resolve and render like other value expressions.

* **Bug Fixes**
  * Updated type, value, macro, and pattern path resolution to use scope-aware resolution, reducing ambiguous or missed matches.
  * IR display/snapshots now label resolved functions as `fn` instead of `item fn`.

* **Tests**
  * Added coverage for resolving imported enum-variant constructors and updated existing expectations accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->