### PR TITLE
fix: Improve file watching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +577,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +613,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -726,6 +754,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "gungraun"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +855,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "ignore"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +880,26 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -862,6 +939,26 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -938,6 +1035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -973,6 +1071,46 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02b49179cfebc9932238d04d6079912d26de0379328872846118a0fa0dbb302"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1584,6 +1722,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures",
+ "ignore",
+ "notify-debouncer-full",
  "rg_lsp_proto",
  "rg_std",
  "serde_json",
@@ -1893,6 +2033,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2453,6 +2602,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2563,6 +2722,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,9 +72,11 @@ either = "1.15.0"
 expect-test = "1.5.1"
 futures = "0.3.32"
 gungraun = "0.18.2"
+ignore = "0.4.26"
 itertools = "0.14.0"
 ls_types = { package = "ls-types", version = "0.0.6" }
 memchr = "2.8.0"
+notify-debouncer-full = "0.7.0"
 parser = { package = "rg_parser", path = "crates/vendor/parser" }
 proc-macro2 = "1.0.106"
 quote = "1.0.45"

--- a/crates/lsp/engine/src/debounce.rs
+++ b/crates/lsp/engine/src/debounce.rs
@@ -56,6 +56,14 @@ impl Debouncer {
         callback();
     }
 
+    pub(crate) fn cancel(&self) {
+        let mut pending = self.pending();
+        self.next_generation();
+        if let Some(previous) = pending.take() {
+            previous.abort();
+        }
+    }
+
     fn next_generation(&self) -> u64 {
         self.state
             .generation

--- a/crates/lsp/engine/src/diagnostics/mod.rs
+++ b/crates/lsp/engine/src/diagnostics/mod.rs
@@ -11,13 +11,14 @@ use std::{
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
     sync::Arc,
+    time::Duration,
 };
 
 use ls_types::ProgressToken;
 use rg_lsp_proto::{AnalysisConfig, DiagnosticsConfig};
 use tokio::{sync::Mutex, task::JoinHandle};
 
-use crate::{documents::DocumentStore, service::ServiceNotificationsSink};
+use crate::{debounce::Debouncer, documents::DocumentStore, service::ServiceNotificationsSink};
 
 mod cargo;
 mod command;
@@ -30,6 +31,8 @@ use self::{
     task::DiagnosticsTaskContext,
 };
 
+const EXTERNAL_CHANGE_DIAGNOSTICS_DEBOUNCE: Duration = Duration::from_secs(1);
+
 /// Launches Cargo diagnostics independently from the synchronous analysis engine.
 #[derive(Clone, Debug)]
 pub(crate) struct DiagnosticsHandle {
@@ -37,6 +40,7 @@ pub(crate) struct DiagnosticsHandle {
     documents: Arc<Mutex<DocumentStore>>,
     inner: Arc<Mutex<DiagnosticsHandleInner>>,
     current: Arc<Mutex<Option<CurrentDiagnostics>>>,
+    external_change_debouncer: Debouncer,
 }
 
 impl DiagnosticsHandle {
@@ -49,6 +53,7 @@ impl DiagnosticsHandle {
             documents,
             inner: Arc::default(),
             current: Arc::default(),
+            external_change_debouncer: Debouncer::new(EXTERNAL_CHANGE_DIAGNOSTICS_DEBOUNCE),
         }
     }
 
@@ -68,9 +73,29 @@ impl DiagnosticsHandle {
         self.launch(DiagnosticsTrigger::Startup).await;
     }
 
-    pub(crate) async fn launch_on_save(&self, saved_path: PathBuf) {
-        self.launch(DiagnosticsTrigger::Save { path: saved_path })
+    pub(crate) async fn launch_on_editor_save(&self, saved_path: PathBuf) {
+        self.external_change_debouncer.cancel();
+        self.launch(DiagnosticsTrigger::EditorSave { path: saved_path })
             .await;
+    }
+
+    pub(crate) async fn launch_on_external_change(&self, changed_path: PathBuf) {
+        if !self.on_save_diagnostics_enabled().await {
+            return;
+        }
+
+        // The previous cargo run belongs to an older saved snapshot. Stop it immediately, then
+        // wait for nearby external changes to settle before spending work on a replacement run.
+        self.cancel_current().await;
+
+        let handle = self.clone();
+        self.external_change_debouncer.call(move || {
+            tokio::spawn(async move {
+                handle
+                    .launch(DiagnosticsTrigger::ExternalChange { path: changed_path })
+                    .await;
+            });
+        });
     }
 
     async fn launch(&self, trigger: DiagnosticsTrigger) {
@@ -96,10 +121,24 @@ impl DiagnosticsHandle {
     }
 
     pub(crate) async fn shutdown(&self) {
+        self.external_change_debouncer.cancel();
         if let Some(current) = self.current.lock().await.take() {
             current.task.abort();
             current.progress.finish(ProgressFinish::Cancelled).await;
         }
+    }
+
+    async fn on_save_diagnostics_enabled(&self) -> bool {
+        let inner = self.inner.lock().await;
+        if !inner.config.on_save {
+            return false;
+        }
+        if inner.workspace_root.is_none() {
+            tracing::debug!("cargo diagnostics requested before workspace configuration");
+            return false;
+        }
+
+        true
     }
 
     async fn prepare_launch(&self, trigger: DiagnosticsTrigger) -> Option<DiagnosticsSnapshot> {
@@ -173,14 +212,15 @@ struct DiagnosticsSnapshot {
 #[derive(Debug)]
 enum DiagnosticsTrigger {
     Startup,
-    Save { path: PathBuf },
+    EditorSave { path: PathBuf },
+    ExternalChange { path: PathBuf },
 }
 
 impl DiagnosticsTrigger {
     fn enabled(&self, config: &DiagnosticsConfig) -> bool {
         match self {
             Self::Startup => config.on_startup,
-            Self::Save { .. } => config.on_save,
+            Self::EditorSave { .. } | Self::ExternalChange { .. } => config.on_save,
         }
     }
 }
@@ -189,7 +229,8 @@ impl std::fmt::Display for DiagnosticsTrigger {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Startup => f.write_str("startup"),
-            Self::Save { path } => write!(f, "save:{}", path.display()),
+            Self::EditorSave { path } => write!(f, "editor-save:{}", path.display()),
+            Self::ExternalChange { path } => write!(f, "external-change:{}", path.display()),
         }
     }
 }

--- a/crates/lsp/engine/src/engine/mod.rs
+++ b/crates/lsp/engine/src/engine/mod.rs
@@ -1,5 +1,4 @@
 mod command;
-mod debounce;
 mod project_proxy;
 mod worker;
 
@@ -18,9 +17,9 @@ use rg_lsp_proto::{ServiceLogLevel, ServiceNotification};
 use tokio::sync::{Mutex, oneshot};
 
 pub(crate) use self::command::EngineCommand;
-use self::debounce::Debouncer;
 use self::{command::EngineResponse, worker::EngineWorker};
 use crate::{
+    debounce::Debouncer,
     dirty_state::DirtyState,
     documents::{DirtyDocumentSnapshotState, DocumentStore},
     memory::MemoryControl,

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -1298,7 +1298,7 @@ impl EngineWorker {
         Some(verified)
     }
 
-    /// Runs a read-only request, responds immediately, then heals disposable cache failures.
+    /// Runs a read-only request and hides disposable cache churn from the LSP client.
     fn respond_to_query<T>(
         &mut self,
         context: QueryContext,
@@ -1368,10 +1368,14 @@ impl EngineWorker {
             }
         }
 
-        let _ = respond_to.send(result);
-
         if should_recover {
+            // Lazy package loads can fail when an offloaded artifact becomes stale between
+            // indexing and a query. The next command sees a repaired project, while this request
+            // degrades to an empty answer instead of a visible JSON-RPC popup in the editor.
+            let _ = respond_to.send(Ok(T::default()));
             self.recover_after_query_cache_failure(label);
+        } else {
+            let _ = respond_to.send(result);
         }
     }
 

--- a/crates/lsp/engine/src/lib.rs
+++ b/crates/lsp/engine/src/lib.rs
@@ -4,6 +4,7 @@
 //! memory reporting for an engine instance. Public APIs expose engine construction and event
 //! delivery primitives; shared request and notification contracts live in `rg_lsp_proto`.
 
+mod debounce;
 mod diagnostics;
 mod dirty_state;
 mod documents;

--- a/crates/lsp/engine/src/service/notifications.rs
+++ b/crates/lsp/engine/src/service/notifications.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use rg_lsp_proto::{NotificationsServiceClient, ServiceNotification};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 pub(crate) trait ServiceNotificationPublisher: std::fmt::Debug + Send + Sync {
     fn send(&self, notification: ServiceNotification);
@@ -8,9 +9,9 @@ pub(crate) trait ServiceNotificationPublisher: std::fmt::Debug + Send + Sync {
 
 /// Fire-and-forget notifications from the service to the LSP orchestrator.
 ///
-/// Engine and diagnostics work must not block on editor-side publication. Each notification is
-/// published on a detached task, keeping progress and diagnostics best-effort across the process
-/// boundary.
+/// Engine and diagnostics work must not block on editor-side publication. The real RPC publisher
+/// preserves notification order on one background task, so progress begin/end pairs cannot race
+/// each other while callers still only enqueue best-effort work.
 #[derive(Clone, Debug)]
 pub struct ServiceNotificationsSink {
     publisher: Arc<dyn ServiceNotificationPublisher>,
@@ -18,12 +19,12 @@ pub struct ServiceNotificationsSink {
 
 #[derive(Clone, Debug)]
 struct TarpcServiceNotificationPublisher {
-    notifications: NotificationsServiceClient,
+    sender: UnboundedSender<ServiceNotification>,
 }
 
 impl ServiceNotificationsSink {
     pub fn new(notifications: NotificationsServiceClient) -> Self {
-        Self::from_publisher(TarpcServiceNotificationPublisher { notifications })
+        Self::from_publisher(TarpcServiceNotificationPublisher::spawn(notifications))
     }
 
     pub(crate) fn from_publisher(publisher: impl ServiceNotificationPublisher + 'static) -> Self {
@@ -37,10 +38,19 @@ impl ServiceNotificationsSink {
     }
 }
 
-impl ServiceNotificationPublisher for TarpcServiceNotificationPublisher {
-    fn send(&self, notification: ServiceNotification) {
-        let notifications = self.notifications.clone();
-        tokio::spawn(async move {
+impl TarpcServiceNotificationPublisher {
+    fn spawn(notifications: NotificationsServiceClient) -> Self {
+        let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn(Self::publish_in_order(notifications, receiver));
+
+        Self { sender }
+    }
+
+    async fn publish_in_order(
+        notifications: NotificationsServiceClient,
+        mut receiver: UnboundedReceiver<ServiceNotification>,
+    ) {
+        while let Some(notification) = receiver.recv().await {
             match notifications
                 .publish(tarpc::context::current(), notification)
                 .await
@@ -56,6 +66,14 @@ impl ServiceNotificationPublisher for TarpcServiceNotificationPublisher {
                     tracing::debug!(error = %error, "failed to publish service notification");
                 }
             }
-        });
+        }
+    }
+}
+
+impl ServiceNotificationPublisher for TarpcServiceNotificationPublisher {
+    fn send(&self, notification: ServiceNotification) {
+        if self.sender.send(notification).is_err() {
+            tracing::debug!("failed to enqueue service notification");
+        }
     }
 }

--- a/crates/lsp/engine/src/service/service_impl.rs
+++ b/crates/lsp/engine/src/service/service_impl.rs
@@ -111,7 +111,7 @@ impl EngineService for Service {
         path: PathBuf,
         text: Option<String>,
     ) -> EngineResult<()> {
-        self.diagnostics.launch_on_save(path.clone()).await;
+        self.diagnostics.launch_on_editor_save(path.clone()).await;
         let saved_text_len = text.as_ref().map(String::len);
         let mut documents = self.engine.documents.lock().await;
         documents.did_save(path.clone(), text.as_deref());
@@ -218,7 +218,7 @@ impl EngineService for Service {
 
         // Diagnostics run as a workspace command, so one changed path is enough to start them.
         if let Some(path) = forwarded_paths.first().cloned() {
-            self.diagnostics.launch_on_save(path).await;
+            self.diagnostics.launch_on_external_change(path).await;
         }
 
         // The project decides whether a path is a source edit or a Cargo graph change.

--- a/crates/lsp/server/Cargo.toml
+++ b/crates/lsp/server/Cargo.toml
@@ -12,6 +12,8 @@ description.workspace = true
 [dependencies]
 anyhow.workspace = true
 futures.workspace = true
+ignore.workspace = true
+notify-debouncer-full.workspace = true
 rg_lsp_proto.workspace = true
 rg_std.workspace = true
 tarpc = { workspace = true, features = ["serde-transport", "serde-transport-json", "tcp", "tokio1"] }

--- a/crates/lsp/server/src/backend.rs
+++ b/crates/lsp/server/src/backend.rs
@@ -17,6 +17,7 @@ use crate::{
     engine_client::EngineClient,
     engine_registry::EngineRegistry,
     methods::{self, MethodContext},
+    project_watcher::ProjectWatcher,
     recent_editor_saves::RecentEditorSaves,
 };
 
@@ -24,6 +25,7 @@ use crate::{
 pub(crate) struct Backend {
     lsp_client: LspClient,
     engines: OnceCell<EngineRegistry>,
+    project_watcher: OnceCell<ProjectWatcher>,
     client_capabilities: OnceCell<EngineClientCapabilities>,
     recent_editor_saves: RecentEditorSaves,
 }
@@ -33,6 +35,7 @@ impl Backend {
         Self {
             lsp_client,
             engines: OnceCell::new(),
+            project_watcher: OnceCell::new(),
             client_capabilities: OnceCell::new(),
             recent_editor_saves: RecentEditorSaves::default(),
         }
@@ -114,13 +117,33 @@ impl LanguageServer for Backend {
                 message: Cow::Borrowed("rust-glancer client capabilities are already initialized"),
                 data: None,
             })?;
-        let engines = EngineRegistry::new(self.lsp_client.clone(), workspace_folders, config);
+        let engines =
+            EngineRegistry::new(self.lsp_client.clone(), workspace_folders.clone(), config);
+        let project_watcher = ProjectWatcher::spawn(
+            workspace_folders,
+            engines.clone(),
+            self.recent_editor_saves.clone(),
+        )
+        .map_err(|error| Error {
+            code: ErrorCode::ServerError(-32003),
+            message: Cow::Owned(format!(
+                "failed to start rust-glancer project watcher: {error}"
+            )),
+            data: None,
+        })?;
 
         self.engines.set(engines).map_err(|_| Error {
             code: ErrorCode::InvalidRequest,
             message: Cow::Borrowed("rust-glancer engine registry is already initialized"),
             data: None,
         })?;
+        self.project_watcher
+            .set(project_watcher)
+            .map_err(|_| Error {
+                code: ErrorCode::InvalidRequest,
+                message: Cow::Borrowed("rust-glancer project watcher is already initialized"),
+                data: None,
+            })?;
 
         Ok(methods::initialize())
     }

--- a/crates/lsp/server/src/engine_registry/mod.rs
+++ b/crates/lsp/server/src/engine_registry/mod.rs
@@ -32,7 +32,7 @@ use self::{
 ///
 /// The server process is the only place that knows about multiple engines. Routing owns path/root
 /// decisions, while the registry owns engine lifecycle slots and RPC clients.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct EngineRegistry {
     lsp_client: LspClient,
     inner: Arc<Mutex<EngineRegistryInner>>,

--- a/crates/lsp/server/src/file_identity.rs
+++ b/crates/lsp/server/src/file_identity.rs
@@ -1,0 +1,35 @@
+//! Lightweight disk identity for saved-file watcher filtering.
+//!
+//! This is deliberately metadata-based. It may occasionally report a false positive after a
+//! metadata-only touch, but it keeps watcher filtering cheap and leaves exact source reads to the
+//! engine when a path is actually forwarded.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+/// File metadata precise enough to suppress repeated saved-file notifications.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct FileIdentity {
+    len: u64,
+    modified: SystemTime,
+}
+
+impl FileIdentity {
+    pub(crate) fn read(path: &Path) -> Option<(PathBuf, Self)> {
+        let metadata = fs::metadata(path).ok()?;
+        if !metadata.is_file() {
+            return None;
+        }
+
+        Some((
+            path.canonicalize().unwrap_or_else(|_| path.to_path_buf()),
+            Self {
+                len: metadata.len(),
+                modified: metadata.modified().ok()?,
+            },
+        ))
+    }
+}

--- a/crates/lsp/server/src/lib.rs
+++ b/crates/lsp/server/src/lib.rs
@@ -14,6 +14,7 @@ mod engine_process;
 mod engine_registry;
 mod methods;
 mod notifications;
+mod project_watcher;
 mod recent_editor_saves;
 mod stdio;
 

--- a/crates/lsp/server/src/lib.rs
+++ b/crates/lsp/server/src/lib.rs
@@ -12,6 +12,7 @@ mod config;
 mod engine_client;
 mod engine_process;
 mod engine_registry;
+mod file_identity;
 mod methods;
 mod notifications;
 mod project_watcher;

--- a/crates/lsp/server/src/project_watcher.rs
+++ b/crates/lsp/server/src/project_watcher.rs
@@ -5,7 +5,7 @@
 //! behavior cannot leave the saved project behind disk.
 
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     ffi::OsStr,
     path::{Component, Path, PathBuf},
     time::{Duration, Instant},
@@ -19,7 +19,10 @@ use notify_debouncer_full::{
 };
 use tokio::{sync::mpsc, task::JoinHandle};
 
-use crate::{engine_registry::EngineRegistry, recent_editor_saves::RecentEditorSaves};
+use crate::{
+    engine_registry::EngineRegistry, file_identity::FileIdentity,
+    recent_editor_saves::RecentEditorSaves,
+};
 
 const WATCH_DEBOUNCE: Duration = Duration::from_millis(300);
 
@@ -48,7 +51,7 @@ impl ProjectWatcher {
 
         for root in workspace_roots
             .into_iter()
-            .map(WorkspaceWatcher::normalize_path)
+            .map(WorkspaceWatcher::normalize_root)
         {
             match WorkspaceWatcher::spawn(
                 root.clone(),
@@ -117,9 +120,11 @@ impl WorkspaceWatcher {
         );
 
         let forwarder_root = root.clone();
+        let mut snapshot = ProjectPathSnapshot::scan(forwarder_root.as_path());
         let forwarder = tokio::spawn(async move {
             while let Some(result) = receiver.recv().await {
                 Self::forward_watcher_result(
+                    &mut snapshot,
                     forwarder_root.as_path(),
                     &registry,
                     &recent_editor_saves,
@@ -138,6 +143,7 @@ impl WorkspaceWatcher {
 
     #[tracing::instrument(level = "trace", skip_all, fields(root = %root.display()))]
     async fn forward_watcher_result(
+        snapshot: &mut ProjectPathSnapshot,
         root: &Path,
         registry: &EngineRegistry,
         recent_editor_saves: &RecentEditorSaves,
@@ -156,7 +162,7 @@ impl WorkspaceWatcher {
                         raw_paths = raw_path_count,
                         "project watcher requested rescan after missed events"
                     );
-                    let paths = Self::scan_project_paths(root);
+                    let paths = snapshot.changed_paths_after_rescan(root);
                     tracing::debug!(
                         events = event_count,
                         raw_paths = raw_path_count,
@@ -167,15 +173,22 @@ impl WorkspaceWatcher {
                     paths
                 } else {
                     let mut ignored_paths = 0usize;
+                    let mut unchanged_paths = 0usize;
                     let paths = events
                         .iter()
                         .flat_map(|event| event.event.paths.iter())
                         .filter_map(|path| {
-                            let project_path = Self::project_path_from_event(path);
-                            if project_path.is_none() {
+                            let project_path = WatchedProjectPath::from_event(path);
+                            let Some(project_path) = project_path else {
                                 ignored_paths += 1;
+                                return None;
+                            };
+                            if snapshot.refresh_path(&project_path) {
+                                Some(project_path)
+                            } else {
+                                unchanged_paths += 1;
+                                None
                             }
-                            project_path
                         })
                         .collect::<BTreeSet<_>>()
                         .into_iter()
@@ -184,6 +197,7 @@ impl WorkspaceWatcher {
                         events = event_count,
                         raw_paths = raw_path_count,
                         ignored_paths,
+                        unchanged_paths,
                         relevant_paths = paths.len(),
                         need_rescan = false,
                         "processed project watcher batch"
@@ -199,7 +213,7 @@ impl WorkspaceWatcher {
                         "project watcher reported an error; rescanning workspace root"
                     );
                 }
-                let paths = Self::scan_project_paths(root);
+                let paths = snapshot.changed_paths_after_rescan(root);
                 tracing::debug!(
                     errors = error_count,
                     relevant_paths = paths.len(),
@@ -228,18 +242,81 @@ impl WorkspaceWatcher {
         registry.external_project_paths_changed(paths).await;
     }
 
-    #[tracing::instrument(level = "trace", skip_all, fields(root = %root.display()))]
-    fn scan_project_paths(root: &Path) -> Vec<PathBuf> {
+    fn normalize_root(path: impl AsRef<Path>) -> PathBuf {
+        let path = path.as_ref();
+        path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    }
+}
+
+struct WatchedProjectPath;
+
+impl WatchedProjectPath {
+    fn from_event(path: &Path) -> Option<PathBuf> {
+        if Self::is_ignored(path) || !Self::is_project_input(path) {
+            return None;
+        }
+
+        Some(Self::normalize(path))
+    }
+
+    fn identity(path: &Path) -> Option<(PathBuf, FileIdentity)> {
+        if Self::is_ignored(path) || !Self::is_project_input(path) {
+            return None;
+        }
+
+        FileIdentity::read(&Self::normalize(path))
+    }
+
+    fn should_visit(path: &Path) -> bool {
+        !Self::is_ignored(path)
+    }
+
+    fn normalize(path: impl AsRef<Path>) -> PathBuf {
+        let path = path.as_ref();
+        path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    }
+
+    fn is_project_input(path: &Path) -> bool {
+        let file_name = path.file_name().and_then(OsStr::to_str);
+        path.extension().and_then(OsStr::to_str) == Some("rs")
+            || matches!(file_name, Some("Cargo.toml" | "Cargo.lock"))
+    }
+
+    fn is_ignored(path: &Path) -> bool {
+        path.components().any(|component| {
+            let Component::Normal(name) = component else {
+                return false;
+            };
+            matches!(
+                name.to_str(),
+                Some(".git" | "target" | "node_modules" | ".direnv")
+            )
+        })
+    }
+}
+
+#[derive(Debug)]
+struct ProjectPathSnapshot {
+    identities: BTreeMap<PathBuf, FileIdentity>,
+}
+
+impl ProjectPathSnapshot {
+    /// Tracks just enough disk state to suppress watcher startup noise and full-rescan false
+    /// positives. The engine remains the source of analysis truth; this snapshot only decides
+    /// whether a watcher batch describes a real saved-input change. Metadata is intentionally
+    /// enough here: a false positive only costs a small reindex, while hashing every file would
+    /// make watcher rescans scale with source size.
+    fn scan(root: &Path) -> Self {
         let started = Instant::now();
         let mut files_seen = 0usize;
-        let mut paths = BTreeSet::new();
+        let mut identities = BTreeMap::new();
         let mut builder = WalkBuilder::new(root);
         builder
             .hidden(false)
             .git_ignore(true)
             .git_global(true)
             .git_exclude(true)
-            .filter_entry(|entry| !Self::has_ignored_component(entry.path()));
+            .filter_entry(|entry| WatchedProjectPath::should_visit(entry.path()));
 
         for entry in builder.build() {
             let entry = match entry {
@@ -261,49 +338,50 @@ impl WorkspaceWatcher {
                 continue;
             }
             files_seen += 1;
-            if Self::is_project_path(path) {
-                paths.insert(Self::normalize_path(path));
+
+            let Some((path, identity)) = WatchedProjectPath::identity(path) else {
+                continue;
+            };
+            identities.insert(path, identity);
+        }
+
+        tracing::debug!(
+            files_seen,
+            project_files_seen = identities.len(),
+            elapsed_ms = started.elapsed().as_millis(),
+            "snapshotted watched workspace project paths"
+        );
+        Self { identities }
+    }
+
+    fn changed_paths_after_rescan(&mut self, root: &Path) -> Vec<PathBuf> {
+        let next = Self::scan(root);
+        let mut changed = BTreeSet::new();
+
+        for (path, identity) in &next.identities {
+            if self.identities.get(path) != Some(identity) {
+                changed.insert(path.clone());
+            }
+        }
+        for path in self.identities.keys() {
+            if !next.identities.contains_key(path) {
+                changed.insert(path.clone());
             }
         }
 
-        let paths = paths.into_iter().collect::<Vec<_>>();
-        tracing::debug!(
-            files_seen,
-            project_files_seen = paths.len(),
-            elapsed_ms = started.elapsed().as_millis(),
-            "scanned watched workspace root for project paths"
-        );
-        paths
+        self.identities = next.identities;
+        changed.into_iter().collect()
     }
 
-    fn project_path_from_event(path: &Path) -> Option<PathBuf> {
-        if Self::has_ignored_component(path) || !Self::is_project_path(path) {
-            return None;
+    fn refresh_path(&mut self, path: &Path) -> bool {
+        let normalized = WatchedProjectPath::normalize(path);
+        match WatchedProjectPath::identity(&normalized) {
+            Some((path, identity)) => {
+                let changed = self.identities.get(&path) != Some(&identity);
+                self.identities.insert(path, identity);
+                changed
+            }
+            None => self.identities.remove(&normalized).is_some(),
         }
-
-        Some(Self::normalize_path(path))
-    }
-
-    fn is_project_path(path: &Path) -> bool {
-        let file_name = path.file_name().and_then(OsStr::to_str);
-        path.extension().and_then(OsStr::to_str) == Some("rs")
-            || matches!(file_name, Some("Cargo.toml" | "Cargo.lock"))
-    }
-
-    fn has_ignored_component(path: &Path) -> bool {
-        path.components().any(|component| {
-            let Component::Normal(name) = component else {
-                return false;
-            };
-            matches!(
-                name.to_str(),
-                Some(".git" | "target" | "node_modules" | ".direnv")
-            )
-        })
-    }
-
-    fn normalize_path(path: impl AsRef<Path>) -> PathBuf {
-        let path = path.as_ref();
-        path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
     }
 }

--- a/crates/lsp/server/src/project_watcher.rs
+++ b/crates/lsp/server/src/project_watcher.rs
@@ -1,0 +1,309 @@
+//! Server-side filesystem watcher for saved project inputs.
+//!
+//! The analysis engine intentionally treats saved-file notifications as its filesystem coherence
+//! boundary. This watcher owns that boundary for external edits, so editor-specific watcher
+//! behavior cannot leave the saved project behind disk.
+
+use std::{
+    collections::BTreeSet,
+    ffi::OsStr,
+    path::{Component, Path, PathBuf},
+    time::{Duration, Instant},
+};
+
+use anyhow::Context as _;
+use ignore::WalkBuilder;
+use notify_debouncer_full::{
+    DebounceEventResult, Debouncer, NoCache,
+    notify::{Config as NotifyConfig, RecommendedWatcher, RecursiveMode},
+};
+use tokio::{sync::mpsc, task::JoinHandle};
+
+use crate::{engine_registry::EngineRegistry, recent_editor_saves::RecentEditorSaves};
+
+const WATCH_DEBOUNCE: Duration = Duration::from_millis(300);
+
+type ProjectDebouncer = Debouncer<RecommendedWatcher, NoCache>;
+
+/// Keeps native filesystem watching alive for the lifetime of the LSP server.
+#[derive(Debug)]
+pub(crate) struct ProjectWatcher {
+    _workspaces: Vec<WorkspaceWatcher>,
+}
+
+#[derive(Debug)]
+struct WorkspaceWatcher {
+    _root: PathBuf,
+    _debouncer: ProjectDebouncer,
+    _forwarder: JoinHandle<()>,
+}
+
+impl ProjectWatcher {
+    pub(crate) fn spawn(
+        workspace_roots: Vec<PathBuf>,
+        registry: EngineRegistry,
+        recent_editor_saves: RecentEditorSaves,
+    ) -> anyhow::Result<Self> {
+        let mut workspaces = Vec::new();
+
+        for root in workspace_roots
+            .into_iter()
+            .map(WorkspaceWatcher::normalize_path)
+        {
+            match WorkspaceWatcher::spawn(
+                root.clone(),
+                registry.clone(),
+                recent_editor_saves.clone(),
+            ) {
+                Ok(workspace) => workspaces.push(workspace),
+                Err(error) => {
+                    tracing::warn!(
+                        root = %root.display(),
+                        error = %error,
+                        "failed to watch workspace root for saved project changes"
+                    );
+                }
+            }
+        }
+
+        anyhow::ensure!(
+            !workspaces.is_empty(),
+            "no workspace roots could be watched for saved project changes"
+        );
+
+        Ok(Self {
+            _workspaces: workspaces,
+        })
+    }
+}
+
+impl WorkspaceWatcher {
+    fn spawn(
+        root: PathBuf,
+        registry: EngineRegistry,
+        recent_editor_saves: RecentEditorSaves,
+    ) -> anyhow::Result<Self> {
+        let (sender, mut receiver) = mpsc::unbounded_channel::<DebounceEventResult>();
+        let callback_root = root.clone();
+
+        let mut debouncer = notify_debouncer_full::new_debouncer_opt(
+            WATCH_DEBOUNCE,
+            Some(WATCH_DEBOUNCE),
+            move |result| {
+                if sender.send(result).is_err() {
+                    tracing::trace!(
+                        root = %callback_root.display(),
+                        "project watcher event dropped because receiver is gone"
+                    );
+                }
+            },
+            NoCache::new(),
+            NotifyConfig::default(),
+        )
+        .context("while attempting to create project filesystem watcher")?;
+
+        debouncer
+            .watch(&root, RecursiveMode::Recursive)
+            .with_context(|| {
+                format!(
+                    "while attempting to watch workspace root {}",
+                    root.display()
+                )
+            })?;
+        tracing::debug!(
+            root = %root.display(),
+            debounce_ms = WATCH_DEBOUNCE.as_millis(),
+            "watching workspace root for saved project changes"
+        );
+
+        let forwarder_root = root.clone();
+        let forwarder = tokio::spawn(async move {
+            while let Some(result) = receiver.recv().await {
+                Self::forward_watcher_result(
+                    forwarder_root.as_path(),
+                    &registry,
+                    &recent_editor_saves,
+                    result,
+                )
+                .await;
+            }
+        });
+
+        Ok(Self {
+            _root: root,
+            _debouncer: debouncer,
+            _forwarder: forwarder,
+        })
+    }
+
+    #[tracing::instrument(level = "trace", skip_all, fields(root = %root.display()))]
+    async fn forward_watcher_result(
+        root: &Path,
+        registry: &EngineRegistry,
+        recent_editor_saves: &RecentEditorSaves,
+        result: DebounceEventResult,
+    ) {
+        let paths = match result {
+            Ok(events) => {
+                let event_count = events.len();
+                let raw_path_count = events
+                    .iter()
+                    .map(|event| event.event.paths.len())
+                    .sum::<usize>();
+                if events.iter().any(|event| event.need_rescan()) {
+                    tracing::warn!(
+                        events = event_count,
+                        raw_paths = raw_path_count,
+                        "project watcher requested rescan after missed events"
+                    );
+                    let paths = Self::scan_project_paths(root);
+                    tracing::debug!(
+                        events = event_count,
+                        raw_paths = raw_path_count,
+                        relevant_paths = paths.len(),
+                        need_rescan = true,
+                        "processed project watcher batch"
+                    );
+                    paths
+                } else {
+                    let mut ignored_paths = 0usize;
+                    let paths = events
+                        .iter()
+                        .flat_map(|event| event.event.paths.iter())
+                        .filter_map(|path| {
+                            let project_path = Self::project_path_from_event(path);
+                            if project_path.is_none() {
+                                ignored_paths += 1;
+                            }
+                            project_path
+                        })
+                        .collect::<BTreeSet<_>>()
+                        .into_iter()
+                        .collect::<Vec<_>>();
+                    tracing::debug!(
+                        events = event_count,
+                        raw_paths = raw_path_count,
+                        ignored_paths,
+                        relevant_paths = paths.len(),
+                        need_rescan = false,
+                        "processed project watcher batch"
+                    );
+                    paths
+                }
+            }
+            Err(errors) => {
+                let error_count = errors.len();
+                for error in errors {
+                    tracing::warn!(
+                        error = %error,
+                        "project watcher reported an error; rescanning workspace root"
+                    );
+                }
+                let paths = Self::scan_project_paths(root);
+                tracing::debug!(
+                    errors = error_count,
+                    relevant_paths = paths.len(),
+                    "processed project watcher error batch"
+                );
+                paths
+            }
+        };
+        let path_count_before_save_filter = paths.len();
+        let paths = recent_editor_saves.saves_to_process(paths).await;
+
+        if paths.is_empty() {
+            tracing::debug!(
+                paths_before_save_filter = path_count_before_save_filter,
+                forwarded_paths = 0usize,
+                "server-side watched project changes filtered out"
+            );
+            return;
+        }
+
+        tracing::debug!(
+            paths_before_save_filter = path_count_before_save_filter,
+            forwarded_paths = paths.len(),
+            "forwarding server-side watched project changes"
+        );
+        registry.external_project_paths_changed(paths).await;
+    }
+
+    #[tracing::instrument(level = "trace", skip_all, fields(root = %root.display()))]
+    fn scan_project_paths(root: &Path) -> Vec<PathBuf> {
+        let started = Instant::now();
+        let mut files_seen = 0usize;
+        let mut paths = BTreeSet::new();
+        let mut builder = WalkBuilder::new(root);
+        builder
+            .hidden(false)
+            .git_ignore(true)
+            .git_global(true)
+            .git_exclude(true)
+            .filter_entry(|entry| !Self::has_ignored_component(entry.path()));
+
+        for entry in builder.build() {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) => {
+                    tracing::debug!(
+                        error = %error,
+                        "failed to scan watched workspace root entry"
+                    );
+                    continue;
+                }
+            };
+
+            let path = entry.path();
+            if !entry
+                .file_type()
+                .is_some_and(|file_type| file_type.is_file())
+            {
+                continue;
+            }
+            files_seen += 1;
+            if Self::is_project_path(path) {
+                paths.insert(Self::normalize_path(path));
+            }
+        }
+
+        let paths = paths.into_iter().collect::<Vec<_>>();
+        tracing::debug!(
+            files_seen,
+            project_files_seen = paths.len(),
+            elapsed_ms = started.elapsed().as_millis(),
+            "scanned watched workspace root for project paths"
+        );
+        paths
+    }
+
+    fn project_path_from_event(path: &Path) -> Option<PathBuf> {
+        if Self::has_ignored_component(path) || !Self::is_project_path(path) {
+            return None;
+        }
+
+        Some(Self::normalize_path(path))
+    }
+
+    fn is_project_path(path: &Path) -> bool {
+        let file_name = path.file_name().and_then(OsStr::to_str);
+        path.extension().and_then(OsStr::to_str) == Some("rs")
+            || matches!(file_name, Some("Cargo.toml" | "Cargo.lock"))
+    }
+
+    fn has_ignored_component(path: &Path) -> bool {
+        path.components().any(|component| {
+            let Component::Normal(name) = component else {
+                return false;
+            };
+            matches!(
+                name.to_str(),
+                Some(".git" | "target" | "node_modules" | ".direnv")
+            )
+        })
+    }
+
+    fn normalize_path(path: impl AsRef<Path>) -> PathBuf {
+        let path = path.as_ref();
+        path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    }
+}

--- a/crates/lsp/server/src/recent_editor_saves.rs
+++ b/crates/lsp/server/src/recent_editor_saves.rs
@@ -6,6 +6,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    sync::Arc,
     time::{Duration, Instant, SystemTime},
 };
 
@@ -18,9 +19,9 @@ const MAX_RECENT_EDITOR_SAVES: usize = 128;
 ///
 /// If file metadata changes after the save, for example because `rustfmt` rewrote the file, the
 /// watched change goes through.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct RecentEditorSaves {
-    inner: Mutex<RecentEditorSavesInner>,
+    inner: Arc<Mutex<RecentEditorSavesInner>>,
 }
 
 impl RecentEditorSaves {

--- a/crates/lsp/server/src/recent_editor_saves.rs
+++ b/crates/lsp/server/src/recent_editor_saves.rs
@@ -4,13 +4,14 @@
 //! files and ignore watched changes that still match the same file metadata.
 
 use std::{
-    fs,
     path::{Path, PathBuf},
     sync::Arc,
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, Instant},
 };
 
 use tokio::sync::Mutex;
+
+use crate::file_identity::FileIdentity;
 
 const RECENT_EDITOR_SAVE_TTL: Duration = Duration::from_secs(2);
 const MAX_RECENT_EDITOR_SAVES: usize = 128;
@@ -71,13 +72,13 @@ impl RecentEditorSavesInner {
 
     fn is_save_echo_at(&mut self, path: &Path, now: Instant) -> bool {
         self.prune_expired(now);
-        let Some((path, metadata)) = file_identity(path) else {
+        let Some((path, identity)) = FileIdentity::read(path) else {
             return false;
         };
 
         self.entries
             .iter()
-            .any(|entry| entry.path == path && entry.metadata == metadata)
+            .any(|entry| entry.path == path && entry.identity == identity)
     }
 
     fn prune_expired(&mut self, now: Instant) {
@@ -92,41 +93,19 @@ impl RecentEditorSavesInner {
 #[derive(Clone, Debug)]
 struct RecentEditorSave {
     path: PathBuf,
-    metadata: FileIdentity,
+    identity: FileIdentity,
     recorded_at: Instant,
 }
 
 impl RecentEditorSave {
     fn from_path(path: &Path, recorded_at: Instant) -> Option<Self> {
-        let (path, metadata) = file_identity(path)?;
+        let (path, identity) = FileIdentity::read(path)?;
         Some(Self {
             path,
-            metadata,
+            identity,
             recorded_at,
         })
     }
-}
-
-/// Disk identity used to decide whether a watched event is the same save.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct FileIdentity {
-    len: u64,
-    modified: SystemTime,
-}
-
-fn file_identity(path: &Path) -> Option<(PathBuf, FileIdentity)> {
-    let metadata = fs::metadata(path).ok()?;
-    if !metadata.is_file() {
-        return None;
-    }
-
-    Some((
-        path.canonicalize().unwrap_or_else(|_| path.to_path_buf()),
-        FileIdentity {
-            len: metadata.len(),
-            modified: metadata.modified().ok()?,
-        },
-    ))
 }
 
 #[cfg(test)]

--- a/crates/lsp/server/src/recent_editor_saves.rs
+++ b/crates/lsp/server/src/recent_editor_saves.rs
@@ -165,7 +165,7 @@ mod tests {
         let saves = RecentEditorSaves::default();
 
         saves.record_editor_save(&path).await;
-        std::fs::write(&path, "pub fn external_agent_edit() {}\n")
+        std::fs::write(&path, "pub fn external_edit() {}\n")
             .expect("fixture file should be writable");
 
         assert_eq!(saves.saves_to_process(vec![path.clone()]).await, vec![path]);
@@ -178,12 +178,12 @@ mod tests {
             //- /src/lib.rs
             pub fn saved() {}
 
-            //- /src/agent.rs
+            //- /src/ext.rs
             pub fn external() {}
             "#,
         );
         let saved_path = fixture.path("src/lib.rs");
-        let external_path = fixture.path("src/agent.rs");
+        let external_path = fixture.path("src/ext.rs");
         let saves = RecentEditorSaves::default();
 
         saves.record_editor_save(&saved_path).await;

--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,8 @@ allow = [
   "MIT",
   "MIT-0",
   "Unicode-3.0",
+  "ISC",
+  "CC0-1.0"
 ]
 
 [bans]

--- a/editors/code/src/language-client/language-client-session.ts
+++ b/editors/code/src/language-client/language-client-session.ts
@@ -75,16 +75,10 @@ export class LanguageClientSession implements vscode.Disposable {
     this.extensionLog.info(`server source: ${statusDetails.serverSource}`);
     this.clientStatus.starting(statusDetails);
 
-    const fileEvents = vscode.workspace.createFileSystemWatcher(
-      new vscode.RelativePattern(this.workspaceFolder, "**/{*.rs,Cargo.toml,Cargo.lock}"),
-    );
     const clientOptions: LanguageClientOptions = {
       documentSelector: [{ scheme: "file", language: "rust" }],
       diagnosticCollectionName: "rust-glancer",
       outputChannel: this.serverOutput,
-      synchronize: {
-        fileEvents,
-      },
       initializationOptions: {
         cfg: config.cfg,
         diagnostics: config.diagnostics,
@@ -104,7 +98,6 @@ export class LanguageClientSession implements vscode.Disposable {
 
     this.client = client;
     this.clientState = vscode.Disposable.from(
-      fileEvents,
       client.onDidChangeState((event) => {
         switch (event.newState) {
           case State.Starting:


### PR DESCRIPTION
Default vs code watcher turned out to be very unreliable so we have built our own. This one works much better. Not a perfect solution still but a major improvement over what we had.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added background project file watching, so changes to Rust project files are detected more reliably.
  * Diagnostics now react separately to editor saves and external file changes for better responsiveness.

* **Bug Fixes**
  * Improved diagnostics behavior to avoid outdated or duplicated runs after recent changes.
  * Fixed notification delivery so progress and status updates are sent in order.
  * Reduced noisy re-analysis by filtering out unchanged file events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->