### PR TITLE
feat: Type inference v3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,23 +78,47 @@ It is not yet in production, so we must optimize for the code quality right now 
 
 ## Comments
 
-Add short (1-3 lines) comments in logically complex blocks to hint reader what's going on.
-Typically, a comment on a non-trivial function is sufficient.
-Not every function needs a comment, only ones that are not obvious right away.
-Same goes for types.
+Add simple-to-read comments in logically complex blocks to help the reader see what's going on.
+Where reasonable, use small examples driven by Rust syntax.
+Typically, functions with real business logic deserve at least a short comment.
+Simple getters, constructors, and obvious wrappers usually do not. Same goes for types.
 Inside of functions, comments might be helpful to explain an intention or non-trivial
-block of logic.
+block of logic. When the function represents multiple logical steps, walkthrough-style
+comments are usually a good idea.
+
+Comment priorities: clarity first, size second. The comment might be slightly obvious
+if it helps to understand what's going on, but we don't need to explain the entire codebase
+all the time.
 
 The goal of comments is to reduce cognitive complexity and help read the code as a book.
 Prefer commenting what exists, not cross-reference.
-Avoid documenting things that can go stale quick and do NOT help reading the code, e.g.
-the scope of the task you're working on, other files/modules that use this function.
+Avoid documenting things that can go stale quickly and do NOT help reading the code, e.g.
+the scope of the task you're working on, other files/modules that use this function,
+temporary design decisions.
 
 Rules of thumb:
-- user should not need to go to other places to understand the comment, it should keep reading with more knowledge
-- user should not have special knowledge to understand the comment (e.g. project roadmap/tasks/private discussions)
-- user should get a knowledge from comment that otherwise would require them to spend time reasoning about codebase.
+- reader should not have special knowledge to understand the comment (e.g. project roadmap/tasks/private discussions)
+- reader should learn something from the comment that otherwise would require them to spend time reasoning about codebase.
 - if your comment uses the word "currently" or another implication of current state that is likely to change, then it's probably a temporary implementation detail that should not be mentioned.
+
+### Documentation Voice
+
+In this project, we favor plain pre-reading notes over polished reference-doc summaries.
+The docs may be step-by-step, slightly repetitive, or intentionally simple if that helps the next
+reader understand the code before reading it.
+
+When proofreading existing comments, preserve the author's structure and voice. Do not compress,
+formalize, or "upgrade" comments into academic Rustdoc style unless explicitly asked. Fix only the
+parts that are unclear, grammatically broken, or misleading.
+
+A lot of existing documentation may still read too polished or bland, this is a bug, not a feature.
+Do not treat overly concise/compressed docs as a model to match, since we try to improve situation
+by making new documentation better than what we had, not create a uniform mix between "old" and
+"new" styles. Think of documentation in this project as being in the stage of slow and gradual
+rewrite spanning multiple months.
+
+A good comment should pass this test: can a tired reader understand why the next code exists before
+they read the code? If not, make the comment more concrete, not more elegant.
 
 ## `reference/` folder
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ readme = "README.md"
 description = "A Rust workspace for rust-glancer."
 
 [workspace.dependencies]
-anyhow = "1.0.102"
+anyhow = "1.0.103"
 atomic-write-file = "0.3.0"
 blake3 = "1.8.5"
 bumpalo = "3.17.0"

--- a/crates/engine/analysis/src/tests/inference.rs
+++ b/crates/engine/analysis/src/tests/inference.rs
@@ -683,15 +683,30 @@ impl AttrVec {
     pub fn push(&mut self, attr: Attr) {}
 }
 
+pub struct Id;
+
+pub struct Factory;
+
+impl Factory {
+    type Id = Id;
+
+    pub fn with_id(f: impl FnOnce(Self::Id)) {}
+}
+
 pub fn with_attrs(f: impl FnOnce(&mut AttrVec)) {}
 
 pub fn use_it(attr: Attr) {
     with_attrs(|attrs| attrs$type_attrs$.push(attr)$type_push$);
+    Factory::with_id(|id| id$type_inherent_assoc$);
 }
 "#,
         &[
             AnalysisQuery::ty("direct closure expected param", "type_attrs"),
             AnalysisQuery::ty("direct closure expected method call", "type_push"),
+            AnalysisQuery::ty(
+                "direct closure inherent associated param",
+                "type_inherent_assoc",
+            ),
         ],
         expect![[r#"
             direct closure expected param
@@ -699,6 +714,9 @@ pub fn use_it(attr: Attr) {
 
             direct closure expected method call
             - ()
+
+            direct closure inherent associated param
+            - syntax Self::Id
         "#]],
     );
 }
@@ -761,6 +779,143 @@ pub fn use_it(user: User, users: &[User]) {
             - nominal struct analysis_generic_closure_expectation_inference[lib]::crate::Name
 
             conflicting generic closure param
+            - <unknown>
+        "#]],
+    );
+}
+
+#[test]
+fn infers_iterator_closure_params_from_selected_trait_method_bounds() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["core", "app"]
+resolver = "3"
+
+//- /core/Cargo.toml
+[package]
+name = "fake_core"
+version = "0.1.0"
+edition = "2024"
+
+//- /core/src/lib.rs
+pub mod iter {
+    pub trait Iterator {
+        type Item;
+
+        fn map<B, F>(self, f: F) -> Map<Self, F>
+        where
+            F: FnMut(Self::Item) -> B;
+
+        fn filter<P>(self, predicate: P) -> Filter<Self, P>
+        where
+            P: FnMut(&Self::Item) -> bool;
+
+        fn find<P>(self, predicate: P)
+        where
+            P: FnMut(&Self::Item) -> bool;
+
+        fn produce<F>(self, f: F)
+        where
+            F: FnOnce() -> Self::Item;
+    }
+
+    pub struct Map<I, F> {
+        iter: I,
+        f: F,
+    }
+
+    pub struct Filter<I, P> {
+        iter: I,
+        predicate: P,
+    }
+}
+
+pub mod slice {
+    pub struct Iter<'a, T>(&'a T);
+}
+
+impl<T> [T] {
+    pub fn iter(&self) -> slice::Iter<'_, T> {
+        missing()
+    }
+}
+
+impl<'a, T> iter::Iterator for slice::Iter<'a, T> {
+    type Item = &'a T;
+}
+
+//- /app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+core = { package = "fake_core", path = "../core" }
+
+//- /app/src/lib.rs
+pub struct User;
+pub struct Name;
+pub struct Searcher;
+
+impl User {
+    pub fn name(&self) -> Name {}
+
+    pub fn is_active(&self) -> bool {}
+}
+
+impl Searcher {
+    pub fn find<F>(&self, f: F) {}
+}
+
+pub fn id<T>(value: T) -> T {}
+pub fn missing<T>() -> T {}
+
+pub fn use_it(users: &[User], searcher: Searcher) {
+    let mapped = users.iter().map(|user| user$type_map_param$.name()$type_map_call$);
+    let filtered = users.iter().filter(|user| user$type_filter_param$.is_active()$type_filter_call$);
+    users.iter().find(|user| user$type_find_param$.is_active()$type_find_call$);
+    users.iter().produce(|| id(missing())$type_produce_body$);
+    searcher.find(|value| value$type_same_name_find_param$);
+}
+"#,
+        &[
+            AnalysisQuery::ty("iterator map closure param", "type_map_param").in_lib("app"),
+            AnalysisQuery::ty("iterator map closure method call", "type_map_call").in_lib("app"),
+            AnalysisQuery::ty("iterator filter closure param", "type_filter_param").in_lib("app"),
+            AnalysisQuery::ty("iterator filter closure method call", "type_filter_call")
+                .in_lib("app"),
+            AnalysisQuery::ty("iterator find closure param", "type_find_param").in_lib("app"),
+            AnalysisQuery::ty("iterator find closure method call", "type_find_call").in_lib("app"),
+            AnalysisQuery::ty("iterator callable return body", "type_produce_body").in_lib("app"),
+            AnalysisQuery::ty("same-name find closure param", "type_same_name_find_param")
+                .in_lib("app"),
+        ],
+        expect![[r#"
+            iterator map closure param
+            - &nominal struct app[lib]::crate::User
+
+            iterator map closure method call
+            - nominal struct app[lib]::crate::Name
+
+            iterator filter closure param
+            - &&nominal struct app[lib]::crate::User
+
+            iterator filter closure method call
+            - bool
+
+            iterator find closure param
+            - &&nominal struct app[lib]::crate::User
+
+            iterator find closure method call
+            - bool
+
+            iterator callable return body
+            - &nominal struct app[lib]::crate::User
+
+            same-name find closure param
             - <unknown>
         "#]],
     );

--- a/crates/engine/analysis/src/tests/inference.rs
+++ b/crates/engine/analysis/src/tests/inference.rs
@@ -665,6 +665,156 @@ pub fn expected_destination(def_map: &DefMap) {
 }
 
 #[test]
+fn projects_iterator_adapter_items_into_collect_destination() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["core", "app"]
+resolver = "3"
+
+//- /core/Cargo.toml
+[package]
+name = "fake_core"
+version = "0.1.0"
+edition = "2024"
+
+//- /core/src/lib.rs
+pub mod iter {
+    pub trait FromIterator<A> {}
+
+    pub trait Iterator {
+        type Item;
+
+        fn map<B, F>(self, f: F) -> Map<Self, F>
+        where
+            F: FnMut(Self::Item) -> B;
+
+        fn filter_map<B, F>(self, f: F) -> FilterMap<Self, F>
+        where
+            F: FnMut(Self::Item) -> Option<B>;
+
+        fn collect<B>(self) -> B
+        where
+            B: FromIterator<Self::Item>;
+    }
+
+    pub struct Map<I, F> {
+        iter: I,
+        f: F,
+    }
+
+    pub struct FilterMap<I, F> {
+        iter: I,
+        f: F,
+    }
+}
+
+pub mod slice {
+    pub struct Iter<'a, T>(&'a T);
+}
+
+pub enum Option<T> {
+    Some(T),
+    None,
+}
+
+pub struct Vec<T> {
+    value: T,
+}
+
+impl<T> iter::FromIterator<T> for Vec<T> {}
+
+impl<T> [T] {
+    pub fn iter(&self) -> slice::Iter<'_, T> {
+        missing()
+    }
+}
+
+impl<'a, T> iter::Iterator for slice::Iter<'a, T> {
+    type Item = &'a T;
+}
+
+impl<I, F, B> iter::Iterator for iter::Map<I, F>
+where
+    I: iter::Iterator,
+    F: FnMut(I::Item) -> B,
+{
+    type Item = B;
+}
+
+impl<I, F, B> iter::Iterator for iter::FilterMap<I, F>
+where
+    I: iter::Iterator,
+    F: FnMut(I::Item) -> Option<B>,
+{
+    type Item = B;
+}
+
+pub fn missing<T>() -> T {}
+
+//- /app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+core = { package = "fake_core", path = "../core" }
+
+//- /app/src/lib.rs
+use core::{Option, Vec};
+
+pub struct User;
+pub struct Name;
+pub struct Email;
+
+impl User {
+    pub fn name(&self) -> Name {}
+    pub fn email(&self) -> Option<Email> {}
+}
+
+pub struct SameNameMap;
+
+impl SameNameMap {
+    pub fn map<F>(&self, f: F) {}
+}
+
+pub fn use_it(users: &[User], same_name: SameNameMap) {
+    let names = users.iter().map(|user| user$type_map_param$.name()).collect::<Vec<_>>()$type_names$;
+    let emails = users.iter().filter_map(|user| user$type_filter_map_param$.email()).collect::<Vec<_>>()$type_emails$;
+    same_name.map(|value| value$type_same_name_map_param$);
+}
+"#,
+        &[
+            AnalysisQuery::ty("iterator map closure param", "type_map_param").in_lib("app"),
+            AnalysisQuery::ty("iterator map collect result", "type_names").in_lib("app"),
+            AnalysisQuery::ty("iterator filter_map closure param", "type_filter_map_param")
+                .in_lib("app"),
+            AnalysisQuery::ty("iterator filter_map collect result", "type_emails").in_lib("app"),
+            AnalysisQuery::ty("same-name map closure param", "type_same_name_map_param")
+                .in_lib("app"),
+        ],
+        expect![[r#"
+            iterator map closure param
+            - &nominal struct app[lib]::crate::User
+
+            iterator map collect result
+            - nominal struct fake_core[lib]::crate::Vec<nominal struct app[lib]::crate::Name>
+
+            iterator filter_map closure param
+            - &nominal struct app[lib]::crate::User
+
+            iterator filter_map collect result
+            - nominal struct fake_core[lib]::crate::Vec<nominal struct app[lib]::crate::Email>
+
+            same-name map closure param
+            - <unknown>
+        "#]],
+    );
+}
+
+#[test]
 fn infers_closure_params_and_returns_from_callable_bounds() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/inference.rs
+++ b/crates/engine/analysis/src/tests/inference.rs
@@ -770,7 +770,13 @@ pub struct Vec<T> {
     value: T,
 }
 
+pub struct HashMap<K, V> {
+    key: K,
+    value: V,
+}
+
 impl<T> iter::FromIterator<T> for Vec<T> {}
+impl<K, V> iter::FromIterator<(K, V)> for HashMap<K, V> {}
 
 impl<T> [T] {
     pub fn iter(&self) -> slice::Iter<'_, T> {
@@ -817,15 +823,19 @@ edition = "2024"
 core = { package = "fake_core", path = "../core" }
 
 //- /app/src/lib.rs
-use core::{Option, Vec};
+use core::{HashMap, Option, Vec};
 
 pub struct User;
 pub struct Name;
 pub struct Email;
+pub struct Key;
+pub struct Value;
 
 impl User {
     pub fn name(&self) -> Name {}
     pub fn email(&self) -> Option<Email> {}
+    pub fn key(&self) -> Key {}
+    pub fn value(&self) -> Value {}
 }
 
 pub struct SameNameMap;
@@ -834,11 +844,32 @@ impl SameNameMap {
     pub fn map<F>(&self, f: F) {}
 }
 
+pub struct PairIter;
+
+impl core::iter::Iterator for PairIter {
+    type Item = (Key, Value);
+}
+
+pub struct AmbiguousMap<K, V> {
+    key: K,
+    value: V,
+}
+
+impl<K, V> core::iter::FromIterator<(K, V)> for AmbiguousMap<K, V> {}
+impl core::iter::FromIterator<(Key, Value)> for AmbiguousMap<Key, Value> {}
+
+pub fn pairs() -> PairIter {
+    core::missing()
+}
+
 pub fn use_it(users: &[User], same_name: SameNameMap) {
     let names = users.iter().map(|user| user$type_map_param$.name()).collect::<Vec<_>>()$type_names$;
     let emails = users.iter().filter_map(|user| user$type_filter_map_param$.email()).collect::<Vec<_>>()$type_emails$;
     let enumerated = users.iter().enumerate().collect::<Vec<_>>()$type_enumerated$;
     let name_pairs = users.iter().enumerate().map(|(index, user)| (index$type_enumerate_index$, user$type_enumerate_user$)).collect::<Vec<_>>();
+    let direct_lookup = pairs().collect::<HashMap<_, _>>()$type_direct_lookup$;
+    let lookup = users.iter().map(|user| (user.key(), user.value())).collect::<HashMap<_, _>>()$type_lookup$;
+    let ambiguous = pairs().collect::<AmbiguousMap<_, _>>()$type_ambiguous$;
     same_name.map(|value| value$type_same_name_map_param$);
 }
 "#,
@@ -853,6 +884,9 @@ pub fn use_it(users: &[User], same_name: SameNameMap) {
                 .in_lib("app"),
             AnalysisQuery::ty("iterator enumerate map user param", "type_enumerate_user")
                 .in_lib("app"),
+            AnalysisQuery::ty("direct HashMap collect result", "type_direct_lookup").in_lib("app"),
+            AnalysisQuery::ty("mapped HashMap collect result", "type_lookup").in_lib("app"),
+            AnalysisQuery::ty("ambiguous HashMap collect result", "type_ambiguous").in_lib("app"),
             AnalysisQuery::ty("same-name map closure param", "type_same_name_map_param")
                 .in_lib("app"),
         ],
@@ -877,6 +911,15 @@ pub fn use_it(users: &[User], same_name: SameNameMap) {
 
             iterator enumerate map user param
             - &nominal struct app[lib]::crate::User
+
+            direct HashMap collect result
+            - nominal struct fake_core[lib]::crate::HashMap<nominal struct app[lib]::crate::Key, nominal struct app[lib]::crate::Value>
+
+            mapped HashMap collect result
+            - nominal struct fake_core[lib]::crate::HashMap<nominal struct app[lib]::crate::Key, nominal struct app[lib]::crate::Value>
+
+            ambiguous HashMap collect result
+            - nominal struct app[lib]::crate::AmbiguousMap<<unknown>, <unknown>>
 
             same-name map closure param
             - <unknown>

--- a/crates/engine/analysis/src/tests/inference.rs
+++ b/crates/engine/analysis/src/tests/inference.rs
@@ -1075,6 +1075,122 @@ pub fn use_it(not_callable: NotCallable) {
 }
 
 #[test]
+fn projects_associated_type_from_callable_impl_where_clause_with_generic_assoc_input() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_callable_impl_where_assoc_input_projection"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub trait Stream {
+    type Item;
+
+    fn map<B, F>(self, f: F) -> Map<Self, F>
+    where
+        F: FnMut(Self::Item) -> B;
+
+    fn map_ref<B, F>(self, f: F) -> RefMap<Self, F>
+    where
+        F: FnMut(&Self::Item) -> B;
+
+    fn map_marked<B, F>(self, f: F) -> MarkedMap<Self, F>
+    where
+        F: FnMut(Self::Item) -> B;
+
+    fn get(self) -> Self::Item;
+}
+
+pub trait Marker {}
+
+pub struct Source<T> {
+    value: T,
+}
+
+pub struct Map<S, F> {
+    stream: S,
+    f: F,
+}
+
+pub struct RefMap<S, F> {
+    stream: S,
+    f: F,
+}
+
+pub struct MarkedMap<S, F> {
+    stream: S,
+    f: F,
+}
+
+pub struct User;
+pub struct Name;
+
+impl User {
+    pub fn name(&self) -> Name {}
+}
+
+impl<T> Stream for Source<T> {
+    type Item = T;
+}
+
+impl<S, F, B> Stream for Map<S, F>
+where
+    S: Stream,
+    F: FnMut(S::Item) -> B,
+{
+    type Item = B;
+}
+
+impl<S, F, B> Stream for RefMap<S, F>
+where
+    S: Stream,
+    F: FnMut(&S::Item) -> B,
+{
+    type Item = B;
+}
+
+impl<S, F, B> Stream for MarkedMap<S, F>
+where
+    S: Stream,
+    F: FnMut(S::Item) -> B,
+    B: Marker,
+{
+    type Item = B;
+}
+
+pub fn use_it(source: Source<User>) {
+    let mapped = source.map(|user| user.name()).get()$type_mapped$;
+    let ref_mapped = source.map_ref(|user| user.name()).get()$type_ref_mapped$;
+    let marked = source.map_marked(|user| user.name()).get()$type_marked$;
+}
+"#,
+        &[
+            AnalysisQuery::ty(
+                "callable impl where associated input projection",
+                "type_mapped",
+            ),
+            AnalysisQuery::ty(
+                "callable impl where referenced associated input projection",
+                "type_ref_mapped",
+            ),
+            AnalysisQuery::ty("unsupported impl where projection", "type_marked"),
+        ],
+        expect![[r#"
+            callable impl where associated input projection
+            - nominal struct analysis_callable_impl_where_assoc_input_projection[lib]::crate::Name
+
+            callable impl where referenced associated input projection
+            - nominal struct analysis_callable_impl_where_assoc_input_projection[lib]::crate::Name
+
+            unsupported impl where projection
+            - <unknown>
+        "#]],
+    );
+}
+
+#[test]
 fn propagates_expected_types_through_result_expressions() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/inference.rs
+++ b/crates/engine/analysis/src/tests/inference.rs
@@ -746,16 +746,9 @@ where
     F: FnMut(&T),
 {}
 
-pub fn visit_conflict<T, F>(value: T, f: F)
-where
-    F: FnOnce(T),
-    F: FnOnce(bool),
-{}
-
 pub fn use_it(user: User, users: &[User]) {
     visit(user, |user| user$type_inline_param$.name()$type_inline_call$);
     visit_all(users, |user| user$type_where_param$.name()$type_where_call$);
-    visit_conflict(user, |value| value$type_conflict_param$);
 }
 "#,
         &[
@@ -763,7 +756,6 @@ pub fn use_it(user: User, users: &[User]) {
             AnalysisQuery::ty("inline generic closure method call", "type_inline_call"),
             AnalysisQuery::ty("where generic closure param", "type_where_param"),
             AnalysisQuery::ty("where generic closure method call", "type_where_call"),
-            AnalysisQuery::ty("conflicting generic closure param", "type_conflict_param"),
         ],
         expect![[r#"
             inline generic closure param
@@ -777,9 +769,6 @@ pub fn use_it(user: User, users: &[User]) {
 
             where generic closure method call
             - nominal struct analysis_generic_closure_expectation_inference[lib]::crate::Name
-
-            conflicting generic closure param
-            - <unknown>
         "#]],
     );
 }
@@ -1000,6 +989,8 @@ pub fn try_apply<T, R, F: FnOnce(T) -> Option<R>>(value: T, f: F) -> Option<R> {
 
 pub fn use_it(flag: bool, id: Id) {
     let user = apply(id, |id| make_user(id))$type_apply$;
+    let stored_f = |id| make_user(id);
+    let stored = apply(id, stored_f)$type_stored_apply$;
     let maybe = try_apply(id, |id| Option::Some(make_user(id)))$type_try_apply$;
     let conflict = apply(id, |id| if flag {
         make_user(id)
@@ -1010,11 +1001,15 @@ pub fn use_it(flag: bool, id: Id) {
 "#,
         &[
             AnalysisQuery::ty("generic closure return result", "type_apply"),
+            AnalysisQuery::ty("stored generic closure return result", "type_stored_apply"),
             AnalysisQuery::ty("nested generic closure return result", "type_try_apply"),
             AnalysisQuery::ty("conflicting generic closure return result", "type_conflict"),
         ],
         expect![[r#"
             generic closure return result
+            - nominal struct analysis_generic_closure_return_inference[lib]::crate::User
+
+            stored generic closure return result
             - nominal struct analysis_generic_closure_return_inference[lib]::crate::User
 
             nested generic closure return result

--- a/crates/engine/analysis/src/tests/inference.rs
+++ b/crates/engine/analysis/src/tests/inference.rs
@@ -665,6 +665,45 @@ pub fn expected_destination(def_map: &DefMap) {
 }
 
 #[test]
+fn infers_closure_params_from_direct_fn_trait_expectations() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_direct_closure_expectation_inference"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct Attr;
+
+pub struct AttrVec;
+
+impl AttrVec {
+    pub fn push(&mut self, attr: Attr) {}
+}
+
+pub fn with_attrs(f: impl FnOnce(&mut AttrVec)) {}
+
+pub fn use_it(attr: Attr) {
+    with_attrs(|attrs| attrs$type_attrs$.push(attr)$type_push$);
+}
+"#,
+        &[
+            AnalysisQuery::ty("direct closure expected param", "type_attrs"),
+            AnalysisQuery::ty("direct closure expected method call", "type_push"),
+        ],
+        expect![[r#"
+            direct closure expected param
+            - &mut nominal struct analysis_direct_closure_expectation_inference[lib]::crate::AttrVec
+
+            direct closure expected method call
+            - ()
+        "#]],
+    );
+}
+
+#[test]
 fn propagates_expected_types_through_result_expressions() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/inference.rs
+++ b/crates/engine/analysis/src/tests/inference.rs
@@ -704,6 +704,56 @@ pub fn use_it(attr: Attr) {
 }
 
 #[test]
+fn infers_closure_body_from_direct_fn_trait_return_expectations() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_direct_closure_return_expectation_inference"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct User;
+
+pub fn id<T>(value: T) -> T {}
+pub fn missing<T>() -> T {}
+
+pub fn with_user(f: impl FnOnce() -> User) {}
+pub fn with_branch(f: impl FnOnce() -> User) {}
+
+pub fn use_it(flag: bool, user: User) {
+    with_user(|| id(missing())$type_direct$);
+    with_branch(|| if flag {
+        id(missing())$type_then$
+    } else {
+        user$type_else$
+    }$type_if$);
+}
+"#,
+        &[
+            AnalysisQuery::ty("direct closure return body", "type_direct"),
+            AnalysisQuery::ty("branch closure return then", "type_then"),
+            AnalysisQuery::ty("branch closure return else", "type_else"),
+            AnalysisQuery::ty("branch closure return body", "type_if"),
+        ],
+        expect![[r#"
+            direct closure return body
+            - nominal struct analysis_direct_closure_return_expectation_inference[lib]::crate::User
+
+            branch closure return then
+            - nominal struct analysis_direct_closure_return_expectation_inference[lib]::crate::User
+
+            branch closure return else
+            - nominal struct analysis_direct_closure_return_expectation_inference[lib]::crate::User
+
+            branch closure return body
+            - nominal struct analysis_direct_closure_return_expectation_inference[lib]::crate::User
+        "#]],
+    );
+}
+
+#[test]
 fn propagates_expected_types_through_result_expressions() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/inference.rs
+++ b/crates/engine/analysis/src/tests/inference.rs
@@ -704,6 +704,69 @@ pub fn use_it(attr: Attr) {
 }
 
 #[test]
+fn infers_closure_params_from_generic_fn_trait_bounds() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_generic_closure_expectation_inference"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct User;
+pub struct Name;
+
+impl User {
+    pub fn name(&self) -> Name {}
+}
+
+pub fn visit<T, F: FnOnce(T)>(value: T, f: F) {}
+
+pub fn visit_all<T, F>(values: &[T], f: F)
+where
+    F: FnMut(&T),
+{}
+
+pub fn visit_conflict<T, F>(value: T, f: F)
+where
+    F: FnOnce(T),
+    F: FnOnce(bool),
+{}
+
+pub fn use_it(user: User, users: &[User]) {
+    visit(user, |user| user$type_inline_param$.name()$type_inline_call$);
+    visit_all(users, |user| user$type_where_param$.name()$type_where_call$);
+    visit_conflict(user, |value| value$type_conflict_param$);
+}
+"#,
+        &[
+            AnalysisQuery::ty("inline generic closure param", "type_inline_param"),
+            AnalysisQuery::ty("inline generic closure method call", "type_inline_call"),
+            AnalysisQuery::ty("where generic closure param", "type_where_param"),
+            AnalysisQuery::ty("where generic closure method call", "type_where_call"),
+            AnalysisQuery::ty("conflicting generic closure param", "type_conflict_param"),
+        ],
+        expect![[r#"
+            inline generic closure param
+            - nominal struct analysis_generic_closure_expectation_inference[lib]::crate::User
+
+            inline generic closure method call
+            - nominal struct analysis_generic_closure_expectation_inference[lib]::crate::Name
+
+            where generic closure param
+            - &nominal struct analysis_generic_closure_expectation_inference[lib]::crate::User
+
+            where generic closure method call
+            - nominal struct analysis_generic_closure_expectation_inference[lib]::crate::Name
+
+            conflicting generic closure param
+            - <unknown>
+        "#]],
+    );
+}
+
+#[test]
 fn infers_closure_body_from_direct_fn_trait_return_expectations() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/inference.rs
+++ b/crates/engine/analysis/src/tests/inference.rs
@@ -562,6 +562,47 @@ pub fn use_it(builder: Builder) {
 }
 
 #[test]
+fn preserves_live_receiver_self_when_instantiating_method_return() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_method_self_return_inference"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct User;
+pub struct Name;
+
+pub struct Iter<T> {
+    value: T,
+}
+
+pub struct Pair<A, B> {
+    left: A,
+    right: B,
+}
+
+impl<T> Iter<T> {
+    pub fn pair<U>(self, value: U) -> Pair<Self, U> {}
+}
+
+pub fn make_iter<T>(value: T) -> Iter<T> {}
+
+pub fn use_it(user: User, name: Name) {
+    let pair = make_iter(user).pair(name)$type_pair$;
+}
+"#,
+        &[AnalysisQuery::ty("method Self return", "type_pair")],
+        expect![[r#"
+            method Self return
+            - nominal struct analysis_method_self_return_inference[lib]::crate::Pair<nominal struct analysis_method_self_return_inference[lib]::crate::Iter<nominal struct analysis_method_self_return_inference[lib]::crate::User>, nominal struct analysis_method_self_return_inference[lib]::crate::Name>
+        "#]],
+    );
+}
+
+#[test]
 fn infers_collect_destination_through_trait_obligations() {
     check_analysis_queries(
         r#"
@@ -694,6 +735,8 @@ pub mod iter {
         where
             F: FnMut(Self::Item) -> Option<B>;
 
+        fn enumerate(self) -> Enumerate<Self>;
+
         fn collect<B>(self) -> B
         where
             B: FromIterator<Self::Item>;
@@ -707,6 +750,10 @@ pub mod iter {
     pub struct FilterMap<I, F> {
         iter: I,
         f: F,
+    }
+
+    pub struct Enumerate<I> {
+        iter: I,
     }
 }
 
@@ -751,6 +798,13 @@ where
     type Item = B;
 }
 
+impl<I> iter::Iterator for iter::Enumerate<I>
+where
+    I: iter::Iterator,
+{
+    type Item = (usize, I::Item);
+}
+
 pub fn missing<T>() -> T {}
 
 //- /app/Cargo.toml
@@ -783,6 +837,8 @@ impl SameNameMap {
 pub fn use_it(users: &[User], same_name: SameNameMap) {
     let names = users.iter().map(|user| user$type_map_param$.name()).collect::<Vec<_>>()$type_names$;
     let emails = users.iter().filter_map(|user| user$type_filter_map_param$.email()).collect::<Vec<_>>()$type_emails$;
+    let enumerated = users.iter().enumerate().collect::<Vec<_>>()$type_enumerated$;
+    let name_pairs = users.iter().enumerate().map(|(index, user)| (index$type_enumerate_index$, user$type_enumerate_user$)).collect::<Vec<_>>();
     same_name.map(|value| value$type_same_name_map_param$);
 }
 "#,
@@ -792,6 +848,11 @@ pub fn use_it(users: &[User], same_name: SameNameMap) {
             AnalysisQuery::ty("iterator filter_map closure param", "type_filter_map_param")
                 .in_lib("app"),
             AnalysisQuery::ty("iterator filter_map collect result", "type_emails").in_lib("app"),
+            AnalysisQuery::ty("iterator enumerate collect result", "type_enumerated").in_lib("app"),
+            AnalysisQuery::ty("iterator enumerate map index param", "type_enumerate_index")
+                .in_lib("app"),
+            AnalysisQuery::ty("iterator enumerate map user param", "type_enumerate_user")
+                .in_lib("app"),
             AnalysisQuery::ty("same-name map closure param", "type_same_name_map_param")
                 .in_lib("app"),
         ],
@@ -807,6 +868,15 @@ pub fn use_it(users: &[User], same_name: SameNameMap) {
 
             iterator filter_map collect result
             - nominal struct fake_core[lib]::crate::Vec<nominal struct app[lib]::crate::Email>
+
+            iterator enumerate collect result
+            - nominal struct fake_core[lib]::crate::Vec<(usize, &nominal struct app[lib]::crate::User)>
+
+            iterator enumerate map index param
+            - usize
+
+            iterator enumerate map user param
+            - &nominal struct app[lib]::crate::User
 
             same-name map closure param
             - <unknown>

--- a/crates/engine/analysis/src/tests/inference.rs
+++ b/crates/engine/analysis/src/tests/inference.rs
@@ -665,12 +665,12 @@ pub fn expected_destination(def_map: &DefMap) {
 }
 
 #[test]
-fn infers_closure_params_from_direct_fn_trait_expectations() {
+fn infers_closure_params_and_returns_from_callable_bounds() {
     check_analysis_queries(
         r#"
 //- /Cargo.toml
 [package]
-name = "analysis_direct_closure_expectation_inference"
+name = "analysis_callable_closure_bound_inference"
 version = "0.1.0"
 edition = "2024"
 
@@ -687,57 +687,26 @@ pub struct Id;
 
 pub struct Factory;
 
+pub struct User;
+pub struct Name;
+
+pub enum Option<T> {
+    Some(T),
+    None,
+}
+
 impl Factory {
     type Id = Id;
 
     pub fn with_id(f: impl FnOnce(Self::Id)) {}
 }
 
-pub fn with_attrs(f: impl FnOnce(&mut AttrVec)) {}
-
-pub fn use_it(attr: Attr) {
-    with_attrs(|attrs| attrs$type_attrs$.push(attr)$type_push$);
-    Factory::with_id(|id| id$type_inherent_assoc$);
-}
-"#,
-        &[
-            AnalysisQuery::ty("direct closure expected param", "type_attrs"),
-            AnalysisQuery::ty("direct closure expected method call", "type_push"),
-            AnalysisQuery::ty(
-                "direct closure inherent associated param",
-                "type_inherent_assoc",
-            ),
-        ],
-        expect![[r#"
-            direct closure expected param
-            - &mut nominal struct analysis_direct_closure_expectation_inference[lib]::crate::AttrVec
-
-            direct closure expected method call
-            - ()
-
-            direct closure inherent associated param
-            - syntax Self::Id
-        "#]],
-    );
-}
-
-#[test]
-fn infers_closure_params_from_generic_fn_trait_bounds() {
-    check_analysis_queries(
-        r#"
-//- /Cargo.toml
-[package]
-name = "analysis_generic_closure_expectation_inference"
-version = "0.1.0"
-edition = "2024"
-
-//- /src/lib.rs
-pub struct User;
-pub struct Name;
-
 impl User {
     pub fn name(&self) -> Name {}
 }
+
+pub fn with_attrs(f: impl FnOnce(&mut AttrVec)) {}
+pub fn with_user(f: impl FnOnce() -> User) {}
 
 pub fn visit<T, F: FnOnce(T)>(value: T, f: F) {}
 
@@ -746,29 +715,99 @@ where
     F: FnMut(&T),
 {}
 
-pub fn use_it(user: User, users: &[User]) {
-    visit(user, |user| user$type_inline_param$.name()$type_inline_call$);
-    visit_all(users, |user| user$type_where_param$.name()$type_where_call$);
+pub fn apply<T, R, F: FnOnce(T) -> R>(value: T, f: F) -> R {}
+
+pub fn try_apply<T, R, F: FnOnce(T) -> Option<R>>(value: T, f: F) -> Option<R> {}
+
+pub fn id<T>(value: T) -> T {}
+pub fn missing<T>() -> T {}
+pub fn make_user(id: Id) -> User {}
+pub fn make_name(id: Id) -> Name {}
+
+pub fn use_it(flag: bool, attr: Attr, user: User, users: &[User], seed: Id) {
+    with_attrs(|attrs| attrs$type_direct_param$.push(attr)$type_direct_param_call$);
+    Factory::with_id(|id| id$type_inherent_assoc$);
+    with_user(|| id(missing())$type_direct_return_body$);
+
+    visit(user, |user| user$type_generic_inline_param$.name()$type_generic_inline_call$);
+    visit_all(users, |user| user$type_generic_where_param$.name()$type_generic_where_call$);
+
+    let applied = apply(seed, |id| make_user(id))$type_generic_result$;
+    let stored_f = |id| make_user(id);
+    let stored = apply(seed, stored_f)$type_stored_result$;
+    let maybe = try_apply(seed, |id| Option::Some(make_user(id)))$type_nested_result$;
+    let conflict = apply(seed, |id| if flag {
+        make_user(id)
+    } else {
+        make_name(id)
+    })$type_conflict$;
 }
 "#,
         &[
-            AnalysisQuery::ty("inline generic closure param", "type_inline_param"),
-            AnalysisQuery::ty("inline generic closure method call", "type_inline_call"),
-            AnalysisQuery::ty("where generic closure param", "type_where_param"),
-            AnalysisQuery::ty("where generic closure method call", "type_where_call"),
+            AnalysisQuery::ty("direct callable closure param", "type_direct_param"),
+            AnalysisQuery::ty(
+                "direct callable closure method call",
+                "type_direct_param_call",
+            ),
+            AnalysisQuery::ty(
+                "direct closure inherent associated param",
+                "type_inherent_assoc",
+            ),
+            AnalysisQuery::ty(
+                "direct callable closure return body",
+                "type_direct_return_body",
+            ),
+            AnalysisQuery::ty("inline generic closure param", "type_generic_inline_param"),
+            AnalysisQuery::ty(
+                "inline generic closure method call",
+                "type_generic_inline_call",
+            ),
+            AnalysisQuery::ty("where generic closure param", "type_generic_where_param"),
+            AnalysisQuery::ty(
+                "where generic closure method call",
+                "type_generic_where_call",
+            ),
+            AnalysisQuery::ty("generic closure return result", "type_generic_result"),
+            AnalysisQuery::ty("stored generic closure return result", "type_stored_result"),
+            AnalysisQuery::ty("nested generic closure return result", "type_nested_result"),
+            AnalysisQuery::ty("conflicting generic closure return result", "type_conflict"),
         ],
         expect![[r#"
+            direct callable closure param
+            - &mut nominal struct analysis_callable_closure_bound_inference[lib]::crate::AttrVec
+
+            direct callable closure method call
+            - ()
+
+            direct closure inherent associated param
+            - syntax Self::Id
+
+            direct callable closure return body
+            - nominal struct analysis_callable_closure_bound_inference[lib]::crate::User
+
             inline generic closure param
-            - nominal struct analysis_generic_closure_expectation_inference[lib]::crate::User
+            - nominal struct analysis_callable_closure_bound_inference[lib]::crate::User
 
             inline generic closure method call
-            - nominal struct analysis_generic_closure_expectation_inference[lib]::crate::Name
+            - nominal struct analysis_callable_closure_bound_inference[lib]::crate::Name
 
             where generic closure param
-            - &nominal struct analysis_generic_closure_expectation_inference[lib]::crate::User
+            - &nominal struct analysis_callable_closure_bound_inference[lib]::crate::User
 
             where generic closure method call
-            - nominal struct analysis_generic_closure_expectation_inference[lib]::crate::Name
+            - nominal struct analysis_callable_closure_bound_inference[lib]::crate::Name
+
+            generic closure return result
+            - nominal struct analysis_callable_closure_bound_inference[lib]::crate::User
+
+            stored generic closure return result
+            - nominal struct analysis_callable_closure_bound_inference[lib]::crate::User
+
+            nested generic closure return result
+            - nominal enum analysis_callable_closure_bound_inference[lib]::crate::Option<nominal struct analysis_callable_closure_bound_inference[lib]::crate::User>
+
+            conflicting generic closure return result
+            - <unknown>
         "#]],
     );
 }
@@ -905,117 +944,6 @@ pub fn use_it(users: &[User], searcher: Searcher) {
             - &nominal struct app[lib]::crate::User
 
             same-name find closure param
-            - <unknown>
-        "#]],
-    );
-}
-
-#[test]
-fn infers_closure_body_from_direct_fn_trait_return_expectations() {
-    check_analysis_queries(
-        r#"
-//- /Cargo.toml
-[package]
-name = "analysis_direct_closure_return_expectation_inference"
-version = "0.1.0"
-edition = "2024"
-
-//- /src/lib.rs
-pub struct User;
-
-pub fn id<T>(value: T) -> T {}
-pub fn missing<T>() -> T {}
-
-pub fn with_user(f: impl FnOnce() -> User) {}
-pub fn with_branch(f: impl FnOnce() -> User) {}
-
-pub fn use_it(flag: bool, user: User) {
-    with_user(|| id(missing())$type_direct$);
-    with_branch(|| if flag {
-        id(missing())$type_then$
-    } else {
-        user$type_else$
-    }$type_if$);
-}
-"#,
-        &[
-            AnalysisQuery::ty("direct closure return body", "type_direct"),
-            AnalysisQuery::ty("branch closure return then", "type_then"),
-            AnalysisQuery::ty("branch closure return else", "type_else"),
-            AnalysisQuery::ty("branch closure return body", "type_if"),
-        ],
-        expect![[r#"
-            direct closure return body
-            - nominal struct analysis_direct_closure_return_expectation_inference[lib]::crate::User
-
-            branch closure return then
-            - nominal struct analysis_direct_closure_return_expectation_inference[lib]::crate::User
-
-            branch closure return else
-            - nominal struct analysis_direct_closure_return_expectation_inference[lib]::crate::User
-
-            branch closure return body
-            - nominal struct analysis_direct_closure_return_expectation_inference[lib]::crate::User
-        "#]],
-    );
-}
-
-#[test]
-fn infers_generic_call_results_from_closure_return_expectations() {
-    check_analysis_queries(
-        r#"
-//- /Cargo.toml
-[package]
-name = "analysis_generic_closure_return_inference"
-version = "0.1.0"
-edition = "2024"
-
-//- /src/lib.rs
-pub struct Id;
-pub struct User;
-pub struct Name;
-
-pub enum Option<T> {
-    Some(T),
-    None,
-}
-
-pub fn make_user(id: Id) -> User {}
-pub fn make_name(id: Id) -> Name {}
-
-pub fn apply<T, R, F: FnOnce(T) -> R>(value: T, f: F) -> R {}
-
-pub fn try_apply<T, R, F: FnOnce(T) -> Option<R>>(value: T, f: F) -> Option<R> {}
-
-pub fn use_it(flag: bool, id: Id) {
-    let user = apply(id, |id| make_user(id))$type_apply$;
-    let stored_f = |id| make_user(id);
-    let stored = apply(id, stored_f)$type_stored_apply$;
-    let maybe = try_apply(id, |id| Option::Some(make_user(id)))$type_try_apply$;
-    let conflict = apply(id, |id| if flag {
-        make_user(id)
-    } else {
-        make_name(id)
-    })$type_conflict$;
-}
-"#,
-        &[
-            AnalysisQuery::ty("generic closure return result", "type_apply"),
-            AnalysisQuery::ty("stored generic closure return result", "type_stored_apply"),
-            AnalysisQuery::ty("nested generic closure return result", "type_try_apply"),
-            AnalysisQuery::ty("conflicting generic closure return result", "type_conflict"),
-        ],
-        expect![[r#"
-            generic closure return result
-            - nominal struct analysis_generic_closure_return_inference[lib]::crate::User
-
-            stored generic closure return result
-            - nominal struct analysis_generic_closure_return_inference[lib]::crate::User
-
-            nested generic closure return result
-            - nominal enum analysis_generic_closure_return_inference[lib]::crate::Option<nominal struct analysis_generic_closure_return_inference[lib]::crate::User>
-
-            conflicting generic closure return result
             - <unknown>
         "#]],
     );

--- a/crates/engine/analysis/src/tests/inference.rs
+++ b/crates/engine/analysis/src/tests/inference.rs
@@ -817,6 +817,61 @@ pub fn use_it(flag: bool, user: User) {
 }
 
 #[test]
+fn infers_generic_call_results_from_closure_return_expectations() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_generic_closure_return_inference"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct Id;
+pub struct User;
+pub struct Name;
+
+pub enum Option<T> {
+    Some(T),
+    None,
+}
+
+pub fn make_user(id: Id) -> User {}
+pub fn make_name(id: Id) -> Name {}
+
+pub fn apply<T, R, F: FnOnce(T) -> R>(value: T, f: F) -> R {}
+
+pub fn try_apply<T, R, F: FnOnce(T) -> Option<R>>(value: T, f: F) -> Option<R> {}
+
+pub fn use_it(flag: bool, id: Id) {
+    let user = apply(id, |id| make_user(id))$type_apply$;
+    let maybe = try_apply(id, |id| Option::Some(make_user(id)))$type_try_apply$;
+    let conflict = apply(id, |id| if flag {
+        make_user(id)
+    } else {
+        make_name(id)
+    })$type_conflict$;
+}
+"#,
+        &[
+            AnalysisQuery::ty("generic closure return result", "type_apply"),
+            AnalysisQuery::ty("nested generic closure return result", "type_try_apply"),
+            AnalysisQuery::ty("conflicting generic closure return result", "type_conflict"),
+        ],
+        expect![[r#"
+            generic closure return result
+            - nominal struct analysis_generic_closure_return_inference[lib]::crate::User
+
+            nested generic closure return result
+            - nominal enum analysis_generic_closure_return_inference[lib]::crate::Option<nominal struct analysis_generic_closure_return_inference[lib]::crate::User>
+
+            conflicting generic closure return result
+            - <unknown>
+        "#]],
+    );
+}
+
+#[test]
 fn propagates_expected_types_through_result_expressions() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/inference.rs
+++ b/crates/engine/analysis/src/tests/inference.rs
@@ -1022,6 +1022,59 @@ pub fn use_it(flag: bool, id: Id) {
 }
 
 #[test]
+fn projects_associated_type_from_callable_impl_where_clause() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_callable_impl_where_projection"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub trait Produces {
+    type Output;
+
+    fn produce(self) -> Self::Output;
+}
+
+pub struct Adapter<F> {
+    f: F,
+}
+
+pub struct Name;
+pub struct NotCallable;
+
+impl<F, R> Produces for Adapter<F>
+where
+    F: FnOnce() -> R,
+{
+    type Output = R;
+}
+
+pub fn adapter<F>(f: F) -> Adapter<F> {}
+pub fn make_name() -> Name {}
+
+pub fn use_it(not_callable: NotCallable) {
+    let produced = adapter(|| make_name()).produce()$type_produced$;
+    let unknown = adapter(not_callable).produce()$type_unknown$;
+}
+"#,
+        &[
+            AnalysisQuery::ty("callable impl where projection", "type_produced"),
+            AnalysisQuery::ty("non-callable impl where projection", "type_unknown"),
+        ],
+        expect![[r#"
+            callable impl where projection
+            - nominal struct analysis_callable_impl_where_projection[lib]::crate::Name
+
+            non-callable impl where projection
+            - <unknown>
+        "#]],
+    );
+}
+
+#[test]
 fn propagates_expected_types_through_result_expressions() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/utils.rs
+++ b/crates/engine/analysis/src/tests/utils.rs
@@ -1121,6 +1121,7 @@ impl<'a> AnalysisQuerySnapshot<'a> {
                 bounds.sort();
                 format!("impl {}", bounds.join(" + "))
             }
+            Ty::Closure(id) => format!("closure #{}", id.index()),
             Ty::Nominal(ty) => format!("nominal {}", self.render_body_nominal_ty(ty)),
             Ty::SelfTy(ty) => format!("Self {}", self.render_body_nominal_ty(ty)),
             Ty::Unknown => "<unknown>".to_string(),

--- a/crates/engine/analysis/src/tests/utils.rs
+++ b/crates/engine/analysis/src/tests/utils.rs
@@ -1121,7 +1121,7 @@ impl<'a> AnalysisQuerySnapshot<'a> {
                 bounds.sort();
                 format!("impl {}", bounds.join(" + "))
             }
-            Ty::Closure(id) => format!("closure #{}", id.index()),
+            Ty::Closure(id) => format!("closure #{id}"),
             Ty::Nominal(ty) => format!("nominal {}", self.render_body_nominal_ty(ty)),
             Ty::SelfTy(ty) => format!("Self {}", self.render_body_nominal_ty(ty)),
             Ty::Unknown => "<unknown>".to_string(),

--- a/crates/engine/body-ir/src/resolution/infer/call.rs
+++ b/crates/engine/body-ir/src/resolution/infer/call.rs
@@ -681,14 +681,14 @@ where
         // Stage 2+: lower selected-call bounds into trait goals and commit only unique solutions.
         BodyTraitObligationSolver::new(self.context).solve_selected_call(
             inference,
-            SelectedCallObligationInput {
-                function: target.function(),
-                owner: function_data.owner,
+            SelectedCallObligationInput::new(
+                target.function(),
+                function_data.owner,
                 generics,
-                subst: &subst,
-                signature_subst: projection.subst(),
-                selected_self_ty: projection.selected_self_ty(),
-            },
+                &subst,
+                projection.subst(),
+                projection.selected_self_ty(),
+            ),
         )
     }
 

--- a/crates/engine/body-ir/src/resolution/infer/call.rs
+++ b/crates/engine/body-ir/src/resolution/infer/call.rs
@@ -678,6 +678,17 @@ where
             &function_data.signature,
         );
 
+        let finalized_receiver_ty;
+        let selected_self_ty = match receiver {
+            Some(receiver) => {
+                finalized_receiver_ty = inference
+                    .table
+                    .finalize(&inference.root_resolved_expr_ty(receiver));
+                Some(&finalized_receiver_ty)
+            }
+            None => projection.selected_self_ty(),
+        };
+
         // Stage 2+: lower selected-call bounds into trait goals and commit only unique solutions.
         BodyTraitObligationSolver::new(self.context).solve_selected_call(
             inference,
@@ -687,7 +698,7 @@ where
                 generics,
                 &subst,
                 projection.subst(),
-                projection.selected_self_ty(),
+                selected_self_ty,
             ),
         )
     }

--- a/crates/engine/body-ir/src/resolution/infer/call.rs
+++ b/crates/engine/body-ir/src/resolution/infer/call.rs
@@ -5,6 +5,7 @@
 
 use rg_ir_model::{
     DefMapRef, ExprId, ImplRef, ItemOwner, ScopeId,
+    hir::items::FunctionData,
     items::{GenericArg as ItemGenericArg, GenericParams, TypeRef},
 };
 use rg_ir_storage::{DefMapSource, ItemStoreSource, TypePathContext};
@@ -14,7 +15,13 @@ use rg_ty::{
     inference::{InferTy, InferTypeRefProjector, InferTypeSubst},
 };
 
-use crate::resolution::{BodyResolutionContext, TypeRefUseSite};
+use crate::{
+    ir::ExprKind,
+    resolution::{
+        BodyResolutionContext, TypeRefUseSite, query::ResolvedCallTarget,
+        support::CallableTypeRefExpectation,
+    },
+};
 
 use super::{
     BodyInferenceCtx,
@@ -181,6 +188,80 @@ where
             .collect())
     }
 
+    /// Constrain closure bodies from callable return expectations in one selected call.
+    ///
+    /// Concrete return expectations such as `FnOnce() -> User` become `User`. Generic returns
+    /// such as `F: FnOnce(T) -> R` become the same `?R` slot used by the selected call result, so
+    /// evidence from the closure body can solve the outer call.
+    pub(crate) fn constrain_closure_return_expected_types(
+        &self,
+        inference: &mut BodyInferenceCtx,
+        call: ExprId,
+        args: &[ExprId],
+    ) -> Result<(), PackageStoreError> {
+        if !args.iter().any(|arg| {
+            matches!(
+                &self.context.body().expr_unchecked(*arg).kind,
+                ExprKind::Closure { .. }
+            )
+        }) {
+            return Ok(());
+        }
+
+        let calls = self.context.calls();
+        let Some(target) = calls.target(call)? else {
+            return Ok(());
+        };
+        let Some(function_data) = self
+            .context
+            .item_query()
+            .function_data(target.function())?
+            .cloned()
+        else {
+            return Ok(());
+        };
+        let projection = calls.signature(&target).project(args)?;
+        if projection.written_param_refs().len() != args.len() {
+            return Ok(());
+        }
+
+        let subst =
+            self.selected_call_infer_subst(inference, call, args, &target, &function_data)?;
+        let resolver = self
+            .context
+            .type_refs(TypeRefUseSite::Function(target.function()))
+            .with_subst(projection.subst());
+
+        for (arg, param_ty) in args.iter().copied().zip(projection.written_param_refs()) {
+            let ExprKind::Closure {
+                body: Some(body), ..
+            } = self.context.body().expr_unchecked(arg).kind.clone()
+            else {
+                continue;
+            };
+            let Some(param_ty) = param_ty else {
+                continue;
+            };
+            let Some(expectation) = CallableTypeRefExpectation::from_written_param(
+                param_ty,
+                function_data.signature.generics(),
+            ) else {
+                continue;
+            };
+
+            let resolved_return_ty = resolver.resolve(expectation.return_ty())?;
+            let return_ty = InferTypeRefProjector::new(&subst)
+                .ty_from_type_ref(expectation.return_ty(), &resolved_return_ty);
+            if return_ty.has_unknown() {
+                continue;
+            }
+
+            inference.constrain_expr_infer_ty(body, &return_ty);
+        }
+
+        Ok(())
+    }
+
     /// Use call args to solve function generics shared with the call result.
     ///
     /// Example: `id(missing())` makes the arg and return share the same `?T`.
@@ -207,6 +288,43 @@ where
             return Ok(());
         }
 
+        let subst =
+            self.selected_call_infer_subst(inference, call, args, &target, &function_data)?;
+
+        let written_params = function_data
+            .signature
+            .params()
+            .iter()
+            .skip(target.first_written_param_idx());
+        let mut projector = InferTypeRefProjector::new(&subst);
+        for ((arg, param), resolved_ty) in args
+            .iter()
+            .zip(written_params)
+            .zip(projection.written_param_tys())
+        {
+            let Some(param_ty) = &param.ty else {
+                continue;
+            };
+            let expected_ty = projector.ty_from_type_ref(param_ty, resolved_ty);
+            inference.constrain_expr_infer_ty(*arg, &expected_ty);
+        }
+
+        Ok(())
+    }
+
+    /// Rebuild the substitution that connects selected signature generics to live inference slots.
+    ///
+    /// This is the final-inference version of call projection. It starts from receiver/type-prefix
+    /// evidence, gives each function generic a `?T` slot, applies explicit generic args, and then
+    /// binds the declared return type to the already-instantiated call result.
+    fn selected_call_infer_subst(
+        &self,
+        inference: &mut BodyInferenceCtx,
+        call: ExprId,
+        args: &[ExprId],
+        target: &ResolvedCallTarget,
+        function_data: &FunctionData,
+    ) -> Result<InferTypeSubst, PackageStoreError> {
         let scope = self.context.body().expr_unchecked(call).scope;
         let mut subst = self.type_prefix_impl_infer_subst(
             inference,
@@ -231,25 +349,22 @@ where
             subst.bind_type_ref(&mut inference.table, ret_ty, &return_ty, generics);
         }
 
-        let written_params = function_data
-            .signature
-            .params()
-            .iter()
-            .skip(target.first_written_param_idx());
-        let mut projector = InferTypeRefProjector::new(&subst);
-        for ((arg, param), resolved_ty) in args
-            .iter()
-            .zip(written_params)
-            .zip(projection.written_param_tys())
-        {
-            let Some(param_ty) = &param.ty else {
-                continue;
-            };
-            let expected_ty = projector.ty_from_type_ref(param_ty, resolved_ty);
-            inference.constrain_expr_infer_ty(*arg, &expected_ty);
+        if let Some(generics) = function_data.signature.generics() {
+            let written_params = function_data
+                .signature
+                .params()
+                .iter()
+                .skip(target.first_written_param_idx());
+            for (arg, param) in args.iter().zip(written_params) {
+                let Some(param_ty) = &param.ty else {
+                    continue;
+                };
+                let arg_ty = inference.root_resolved_expr_ty(*arg);
+                subst.bind_type_ref(&mut inference.table, param_ty, &arg_ty, generics);
+            }
         }
 
-        Ok(())
+        Ok(subst)
     }
 
     /// Bind impl generics for a static `Type::function` call from its result slot.

--- a/crates/engine/body-ir/src/resolution/infer/call.rs
+++ b/crates/engine/body-ir/src/resolution/infer/call.rs
@@ -18,7 +18,10 @@ use rg_ty::{
 use crate::resolution::{
     BodyResolutionContext, TypeRefUseSite,
     query::ResolvedCallTarget,
-    support::{CallableTypeRefExpectation, CallableTypeResolver},
+    support::{
+        CallableTypeRefExpectation, CallableTypeResolver, SelectedTraitMethodContext,
+        self_associated_type_name,
+    },
 };
 
 use super::{
@@ -267,6 +270,67 @@ where
             let _ = callable_goal_solver
                 .solve_fn_trait_goal(inference, &self_ty, &params, &return_ty)?;
         }
+
+        Ok(())
+    }
+
+    /// Project exact `Self::Assoc` returns from selected trait methods in the inference view.
+    ///
+    /// Initial call projection only has ordinary `Ty` facts. Final inference may know more, such
+    /// as `Adapter<Closure#n>` after an inner call has bound its generic argument. That extra
+    /// closure witness is what lets impl where-clauses like `F: FnOnce() -> R` solve `R` before
+    /// projecting `type Output = R`.
+    pub(crate) fn project_selected_trait_associated_return_type(
+        &self,
+        inference: &mut BodyInferenceCtx,
+        call: ExprId,
+        args: &[ExprId],
+        receiver: Option<ExprId>,
+    ) -> Result<(), PackageStoreError> {
+        let calls = self.context.calls();
+        let Some(target) = calls.target(call)? else {
+            return Ok(());
+        };
+        let Some(function_data) = self
+            .context
+            .item_query()
+            .function_data(target.function())?
+            .cloned()
+        else {
+            return Ok(());
+        };
+        let projection = calls.signature(&target).project(args)?;
+        let Some(ret_ty) = projection.declared_return_ty() else {
+            return Ok(());
+        };
+        let Some(assoc_name) = self_associated_type_name(ret_ty) else {
+            return Ok(());
+        };
+
+        let finalized_receiver_ty;
+        let selected_self_ty = match receiver {
+            Some(receiver) => {
+                finalized_receiver_ty = inference
+                    .table
+                    .finalize(&inference.root_resolved_expr_ty(receiver));
+                Some(&finalized_receiver_ty)
+            }
+            None => projection.selected_self_ty(),
+        };
+        let Some(selected_trait_method) = SelectedTraitMethodContext::from_function(
+            self.context,
+            target.function(),
+            function_data.owner,
+            selected_self_ty,
+        )?
+        else {
+            return Ok(());
+        };
+
+        let projected_ty = BodyTraitObligationSolver::new(self.context)
+            .project_selected_trait_associated_alias(inference, &selected_trait_method, assoc_name)?
+            .unwrap_or(InferTy::Unknown);
+        inference.set_expr_infer_ty(call, projected_ty);
 
         Ok(())
     }

--- a/crates/engine/body-ir/src/resolution/infer/call.rs
+++ b/crates/engine/body-ir/src/resolution/infer/call.rs
@@ -15,17 +15,14 @@ use rg_ty::{
     inference::{InferTy, InferTypeRefProjector, InferTypeSubst},
 };
 
-use crate::{
-    ir::ExprKind,
-    resolution::{
-        BodyResolutionContext, TypeRefUseSite,
-        query::ResolvedCallTarget,
-        support::{CallableTypeRefExpectation, CallableTypeResolver},
-    },
+use crate::resolution::{
+    BodyResolutionContext, TypeRefUseSite,
+    query::ResolvedCallTarget,
+    support::{CallableTypeRefExpectation, CallableTypeResolver},
 };
 
 use super::{
-    BodyInferenceCtx,
+    BodyCallableGoalSolver, BodyInferenceCtx,
     trait_obligation::{BodyTraitObligationSolver, SelectedCallObligationInput},
 };
 
@@ -189,23 +186,22 @@ where
             .collect())
     }
 
-    /// Constrain closure bodies from callable return expectations in one selected call.
+    /// Solve direct `impl Fn*` callable syntax against closure arguments.
     ///
-    /// Concrete return expectations such as `FnOnce() -> User` become `User`. Generic returns
-    /// such as `F: FnOnce(T) -> R` become the same `?R` slot used by the selected call result, so
-    /// evidence from the closure body can solve the outer call.
-    pub(crate) fn constrain_closure_return_expected_types(
+    /// Generic callable params such as `F: FnOnce(T) -> R` are ordinary selected-call
+    /// obligations now. Inline `impl FnOnce(T) -> R` params do not have a named `F`, so this
+    /// hook turns their written callable args into the same closure-local goal directly:
+    /// `Closure#n: FnOnce(T) -> R`.
+    pub(crate) fn solve_direct_callable_closure_arguments(
         &self,
         inference: &mut BodyInferenceCtx,
         call: ExprId,
         args: &[ExprId],
     ) -> Result<(), PackageStoreError> {
-        if !args.iter().any(|arg| {
-            matches!(
-                &self.context.body().expr_unchecked(*arg).kind,
-                ExprKind::Closure { .. }
-            )
-        }) {
+        if !args
+            .iter()
+            .any(|arg| matches!(inference.root_resolved_expr_ty(*arg), InferTy::Closure(_)))
+        {
             return Ok(());
         }
 
@@ -240,32 +236,36 @@ where
             projection.selected_self_ty(),
         )?;
 
+        let callable_goal_solver = BodyCallableGoalSolver::new(self.context);
         for (arg, param_ty) in args.iter().copied().zip(projection.written_param_refs()) {
-            let ExprKind::Closure {
-                body: Some(body), ..
-            } = self.context.body().expr_unchecked(arg).kind.clone()
-            else {
+            let self_ty = inference.root_resolved_expr_ty(arg);
+            if !matches!(self_ty, InferTy::Closure(_)) {
                 continue;
-            };
+            }
             let Some(param_ty) = param_ty else {
                 continue;
             };
-            let Some(expectation) = CallableTypeRefExpectation::from_written_param(
-                param_ty,
-                function_data.signature.generics(),
-            )
-            .into_option() else {
+            let Some(expectation) =
+                CallableTypeRefExpectation::from_direct_impl_trait(param_ty).into_option()
+            else {
                 continue;
             };
 
+            let mut projector = InferTypeRefProjector::new(&subst);
+            let mut params = Vec::new();
+            for param in expectation.params() {
+                let resolved_param_ty = callable_resolver.resolve(param)?;
+                params.push(projector.ty_from_type_ref(param, &resolved_param_ty));
+            }
             let resolved_return_ty = callable_resolver.resolve(expectation.return_ty())?;
-            let return_ty = InferTypeRefProjector::new(&subst)
-                .ty_from_type_ref(expectation.return_ty(), &resolved_return_ty);
+            let return_ty =
+                projector.ty_from_type_ref(expectation.return_ty(), &resolved_return_ty);
             if return_ty.has_unknown() {
                 continue;
             }
 
-            inference.constrain_expr_infer_ty(body, &return_ty);
+            let _ = callable_goal_solver
+                .solve_fn_trait_goal(inference, &self_ty, &params, &return_ty)?;
         }
 
         Ok(())

--- a/crates/engine/body-ir/src/resolution/infer/call.rs
+++ b/crates/engine/body-ir/src/resolution/infer/call.rs
@@ -18,8 +18,9 @@ use rg_ty::{
 use crate::{
     ir::ExprKind,
     resolution::{
-        BodyResolutionContext, TypeRefUseSite, query::ResolvedCallTarget,
-        support::CallableTypeRefExpectation,
+        BodyResolutionContext, TypeRefUseSite,
+        query::ResolvedCallTarget,
+        support::{CallableTypeRefExpectation, CallableTypeResolver},
     },
 };
 
@@ -231,6 +232,13 @@ where
             .context
             .type_refs(TypeRefUseSite::Function(target.function()))
             .with_subst(projection.subst());
+        let callable_resolver = CallableTypeResolver::new(
+            self.context,
+            &resolver,
+            target.function(),
+            function_data.owner,
+            projection.selected_self_ty(),
+        )?;
 
         for (arg, param_ty) in args.iter().copied().zip(projection.written_param_refs()) {
             let ExprKind::Closure {
@@ -249,7 +257,7 @@ where
                 continue;
             };
 
-            let resolved_return_ty = resolver.resolve(expectation.return_ty())?;
+            let resolved_return_ty = callable_resolver.resolve(expectation.return_ty())?;
             let return_ty = InferTypeRefProjector::new(&subst)
                 .ty_from_type_ref(expectation.return_ty(), &resolved_return_ty);
             if return_ty.has_unknown() {

--- a/crates/engine/body-ir/src/resolution/infer/call.rs
+++ b/crates/engine/body-ir/src/resolution/infer/call.rs
@@ -10,6 +10,7 @@ use rg_ir_model::{
 };
 use rg_ir_storage::{DefMapSource, ItemStoreSource, TypePathContext};
 use rg_package_store::PackageStoreError;
+use rg_text::Name;
 use rg_ty::{
     Ty, TypeSubst,
     inference::{InferTy, InferTypeRefProjector, InferTypeSubst},
@@ -52,8 +53,14 @@ where
         inference: &mut BodyInferenceCtx,
         call: ExprId,
         args: &[ExprId],
+        receiver: Option<ExprId>,
     ) -> Result<(), PackageStoreError> {
-        if !self.context.body().expr_ty_unchecked(call).has_unknown() {
+        if !self
+            .context
+            .body()
+            .expr_ty_unchecked(call)
+            .has_unknown_or_syntax()
+        {
             return Ok(());
         }
 
@@ -62,9 +69,43 @@ where
             return Ok(());
         };
         let projection = calls.signature(&target).project(args)?;
+        let Some(function_data) = self
+            .context
+            .item_query()
+            .function_data(target.function())?
+            .cloned()
+        else {
+            return Ok(());
+        };
 
+        // Try instantiation paths from strongest to weakest. Once a branch writes the call slot,
+        // later branches must not replace it with an older or less precise projection.
         let mut instantiated = false;
-        if !projection.explicit_args().is_empty()
+
+        // Method returns that mention `Self` need the live receiver inference type. The call target
+        // only stores the receiver snapshot from method lookup, which can still contain stale
+        // source syntax such as `Iter<syntax T>`. Re-projecting here lets
+        // `make_iter(user).pair(name) -> Pair<Self, Name>` preserve `Self = Iter<User>`.
+        if let Some(receiver) = receiver
+            && let Some(ret_ty) = projection.declared_return_ty()
+        {
+            instantiated = self.instantiate_method_self_return_fact(
+                inference,
+                call,
+                args,
+                receiver,
+                &target,
+                &function_data,
+                ret_ty,
+                projection.return_ty(),
+            )?;
+        }
+
+        // Explicit type args can introduce written `_` holes that should become real inference
+        // slots inside the return. For example, `collect::<Vec<_>>()` should become `Vec<?T>` so
+        // later trait obligations can solve `?T`.
+        if !instantiated
+            && !projection.explicit_args().is_empty()
             && let Some(ret_ty) = projection.declared_return_ty()
             && let Some(generics) = projection.function_generics()
         {
@@ -78,7 +119,11 @@ where
             )?;
         }
 
-        if projection.explicit_args().is_empty()
+        // Without explicit args, a generic return can still expose function type params directly.
+        // `make_vec<T>() -> Vec<T>` becomes `Vec<?T>`, while non-generic return shapes are left to
+        // the fallback below.
+        if !instantiated
+            && projection.explicit_args().is_empty()
             && let Some(ret_ty) = projection.declared_return_ty()
             && let Some(generics) = projection.function_generics()
         {
@@ -97,6 +142,9 @@ where
             }
         }
 
+        // Last fallback for selected returns that already have the right outer shape but contain
+        // unresolved children, such as a receiver-derived `Vec<unknown>`. This does not understand
+        // written generics; it only replaces nested unknowns with inference slots.
         if !instantiated
             && projection.selected_self_ty().is_some_and(Ty::has_unknown)
             && projection.return_ty().has_unknown()
@@ -105,6 +153,53 @@ where
         }
 
         Ok(())
+    }
+
+    /// Re-project method returns like `Enumerate<Self>` from the current receiver inference type.
+    ///
+    /// Call resolution stores a snapshot of the selected receiver before body inference has a
+    /// chance to solve all child facts. For adapter methods, that can leave `Self` as
+    /// `Iter<syntax T>`. During inference we can do better: bind `Self` to the receiver expression
+    /// slot and then walk the declared return type again.
+    #[allow(clippy::too_many_arguments)]
+    fn instantiate_method_self_return_fact(
+        &self,
+        inference: &mut BodyInferenceCtx,
+        call: ExprId,
+        args: &[ExprId],
+        receiver: ExprId,
+        target: &ResolvedCallTarget,
+        function_data: &FunctionData,
+        ret_ty: &TypeRef,
+        resolved_ret_ty: &Ty,
+    ) -> Result<bool, PackageStoreError> {
+        if !ret_ty.mentions_type_param(&["Self"]) {
+            return Ok(false);
+        }
+
+        let scope = self.context.body().expr_unchecked(call).scope;
+        let mut subst = InferTypeSubst::new();
+        let receiver_ty = inference.root_resolved_expr_ty(receiver);
+        subst.push(&mut inference.table, Name::new("Self"), receiver_ty);
+        self.apply_function_generic_shadows(
+            inference,
+            &mut subst,
+            function_data.signature.generics(),
+            target.explicit_args(),
+            scope,
+        )?;
+        self.bind_selected_call_args_to_subst(
+            inference,
+            &mut subst,
+            args,
+            target,
+            &function_data.signature,
+        );
+
+        let return_ty =
+            InferTypeRefProjector::new(&subst).ty_from_type_ref(ret_ty, resolved_ret_ty);
+        inference.set_expr_infer_ty(call, return_ty);
+        Ok(true)
     }
 
     /// Instantiate explicit `_` args before projecting the call return.
@@ -303,6 +398,23 @@ where
         let Some(ret_ty) = projection.declared_return_ty() else {
             return Ok(());
         };
+        if let Some(receiver) = receiver
+            && self_associated_type_name(ret_ty).is_none()
+            && ret_ty.mentions_type_param(&["Self"])
+        {
+            let _ = self.instantiate_method_self_return_fact(
+                inference,
+                call,
+                args,
+                receiver,
+                &target,
+                &function_data,
+                ret_ty,
+                projection.return_ty(),
+            )?;
+            return Ok(());
+        }
+
         let Some(assoc_name) = self_associated_type_name(ret_ty) else {
             return Ok(());
         };

--- a/crates/engine/body-ir/src/resolution/infer/call.rs
+++ b/crates/engine/body-ir/src/resolution/infer/call.rs
@@ -5,7 +5,7 @@
 
 use rg_ir_model::{
     DefMapRef, ExprId, ImplRef, ItemOwner, ScopeId,
-    hir::items::FunctionData,
+    hir::{items::FunctionData, signature::FunctionSignature},
     items::{GenericArg as ItemGenericArg, GenericParams, TypeRef},
 };
 use rg_ir_storage::{DefMapSource, ItemStoreSource, TypePathContext};
@@ -253,7 +253,8 @@ where
             let Some(expectation) = CallableTypeRefExpectation::from_written_param(
                 param_ty,
                 function_data.signature.generics(),
-            ) else {
+            )
+            .into_option() else {
                 continue;
             };
 
@@ -357,20 +358,13 @@ where
             subst.bind_type_ref(&mut inference.table, ret_ty, &return_ty, generics);
         }
 
-        if let Some(generics) = function_data.signature.generics() {
-            let written_params = function_data
-                .signature
-                .params()
-                .iter()
-                .skip(target.first_written_param_idx());
-            for (arg, param) in args.iter().zip(written_params) {
-                let Some(param_ty) = &param.ty else {
-                    continue;
-                };
-                let arg_ty = inference.root_resolved_expr_ty(*arg);
-                subst.bind_type_ref(&mut inference.table, param_ty, &arg_ty, generics);
-            }
-        }
+        self.bind_selected_call_args_to_subst(
+            inference,
+            &mut subst,
+            args,
+            target,
+            &function_data.signature,
+        );
 
         Ok(subst)
     }
@@ -612,6 +606,13 @@ where
             let return_ty = inference.expr_ty(call);
             subst.bind_type_ref(&mut inference.table, ret_ty, &return_ty, generics);
         }
+        self.bind_selected_call_args_to_subst(
+            inference,
+            &mut subst,
+            args,
+            &target,
+            &function_data.signature,
+        );
 
         // Stage 2+: lower selected-call bounds into trait goals and commit only unique solutions.
         BodyTraitObligationSolver::new(self.context).solve_selected_call(
@@ -625,6 +626,45 @@ where
                 selected_self_ty: projection.selected_self_ty(),
             },
         )
+    }
+
+    /// Bind written call arguments into function generics.
+    ///
+    /// Example: `fn id<T>(value: T) -> T` plus `id(user)` gives `T = User`.
+    ///
+    /// Callable obligations need the same binding step:
+    /// `fn apply<T, F, R>(value: T, f: F) -> R where F: FnOnce(T) -> R`
+    /// plus `apply(user, |user| user.name())` gives:
+    /// - `T = User` from the first arg;
+    /// - `F = Closure#n` from the second arg.
+    ///
+    /// Obviously contradictory callable bounds, such as
+    /// `F: FnOnce(T) -> bool, F: FnOnce(T) -> u8`, are not a stable inference surface.
+    /// Inference may leave facts unknown or may be order-dependent there. The normal
+    /// path is intentionally simple and optimized for realistic selected calls.
+    fn bind_selected_call_args_to_subst(
+        &self,
+        inference: &mut BodyInferenceCtx,
+        subst: &mut InferTypeSubst,
+        args: &[ExprId],
+        target: &ResolvedCallTarget,
+        signature: &FunctionSignature,
+    ) {
+        let Some(generics) = signature.generics() else {
+            return;
+        };
+
+        let written_params = signature
+            .params()
+            .iter()
+            .skip(target.first_written_param_idx());
+        for (arg, param) in args.iter().zip(written_params) {
+            let Some(param_ty) = &param.ty else {
+                continue;
+            };
+            let arg_ty = inference.root_resolved_expr_ty(*arg);
+            subst.bind_type_ref(&mut inference.table, param_ty, &arg_ty, generics);
+        }
     }
 
     /// Bind impl generics from the selected receiver slot: `impl<T> Vec<T>` + `Vec<?T>`.

--- a/crates/engine/body-ir/src/resolution/infer/callable_goal.rs
+++ b/crates/engine/body-ir/src/resolution/infer/callable_goal.rs
@@ -89,7 +89,11 @@ where
             let Some(pat) = closure_param.pat else {
                 continue;
             };
-            let _ = pattern_inference.link_pat(inference, pat, expected_ty);
+            let expected_ty = inference.root_resolved_ty(expected_ty);
+            if expected_ty.has_unknown_or_syntax() {
+                continue;
+            }
+            let _ = pattern_inference.link_pat(inference, pat, &expected_ty);
         }
 
         // Return evidence flows in the opposite direction too: if `ret` is `?R` and the closure

--- a/crates/engine/body-ir/src/resolution/infer/callable_goal.rs
+++ b/crates/engine/body-ir/src/resolution/infer/callable_goal.rs
@@ -1,0 +1,401 @@
+//! Callable trait goals that can be answered from body-local closure witnesses.
+//!
+//! This is the first bridge between the real closure type witness and trait obligations. It does
+//! not try to prove capture semantics. For now, a closure witness can provide evidence for any of
+//! `Fn`, `FnMut`, or `FnOnce` when the goal's argument shape fits the closure's written params.
+
+use rg_ir_model::ExprId;
+use rg_ir_storage::{DefMapSource, ItemStoreSource};
+use rg_package_store::PackageStoreError;
+use rg_ty::{
+    TraitGoal,
+    inference::{InferGenericArg, InferTy},
+};
+
+use crate::{ir::ExprKind, resolution::BodyResolutionContext};
+
+use super::{BodyInferenceCtx, BodyPatternInference};
+
+/// Applies callable trait goals directly to body-local closure witnesses.
+///
+/// This is a "plug" for the trait solver that adds knowledge about Fn* trait without having to properly
+/// model all the related machinery. For example, if we see that it's a closure and can link it to Fn* trait
+/// anywhere, we directly apply this knowledge during trait solving.
+///
+/// This way we can "pretend" that it's a part of trait solving (which it will eventually be) so it's not
+/// misplaced, but we avoid 80% of complexity at 20% of effort.
+pub(crate) struct BodyCallableGoalSolver<'query, D, I> {
+    context: BodyResolutionContext<'query, D, I>,
+}
+
+impl<'query, D, I> BodyCallableGoalSolver<'query, D, I>
+where
+    D: DefMapSource<Error = PackageStoreError> + Copy,
+    I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
+{
+    pub(super) fn new(context: BodyResolutionContext<'query, D, I>) -> Self {
+        Self { context }
+    }
+
+    /// Use a goal like `Closure#n: FnOnce(User) -> R` as closure-local inference evidence.
+    ///
+    /// The goal is consumed only when it is really a callable trait goal on a closure witness.
+    /// Unsupported or malformed goals return `false` so ordinary trait selection may still try to
+    /// handle them. A callable arity mismatch is consumed but produces no evidence: we know this is
+    /// the closure-callable approximation, but the written function shape does not fit this
+    /// closure expression.
+    pub(super) fn solve_goal(
+        &self,
+        inference: &mut BodyInferenceCtx,
+        goal: &TraitGoal,
+    ) -> Result<bool, PackageStoreError> {
+        let Some((params, ret)) = self.callable_goal_args(goal)? else {
+            return Ok(false);
+        };
+        let Some(closure) = Self::closure_expr(inference, &goal.self_ty) else {
+            return Ok(false);
+        };
+        let Some(closure_data) = self.context.body().expr(closure).cloned() else {
+            return Ok(false);
+        };
+        let ExprKind::Closure {
+            params: closure_params,
+            body,
+            ..
+        } = closure_data.kind
+        else {
+            return Ok(false);
+        };
+        if closure_params.len() != params.len() {
+            return Ok(true);
+        }
+
+        // Function-call syntax gives parameter evidence positionally, so `FnOnce(User)` links the
+        // first closure pattern to `User`, including destructuring such as
+        // `FnOnce((Left, Right))` -> `|(left, right)|`.
+        let pattern_inference = BodyPatternInference::new(self.context);
+        for (closure_param, expected_ty) in closure_params.iter().zip(params) {
+            let Some(pat) = closure_param.pat else {
+                continue;
+            };
+            let _ = pattern_inference.link_pat(inference, pat, expected_ty);
+        }
+
+        // Return evidence flows in the opposite direction too: if `ret` is `?R` and the closure
+        // body is known to be `Name`, this solves `?R = Name` for the caller that owns the goal.
+        if let Some(body) = body {
+            let _ = inference.constrain_expr_infer_ty(body, ret);
+        }
+
+        Ok(true)
+    }
+
+    fn callable_goal_args<'goal>(
+        &self,
+        goal: &'goal TraitGoal,
+    ) -> Result<Option<(&'goal [InferTy], &'goal InferTy)>, PackageStoreError> {
+        let Some(trait_data) = self.context.item_query().trait_data(goal.trait_ref)? else {
+            return Ok(None);
+        };
+        if !matches!(trait_data.name.as_str(), "Fn" | "FnMut" | "FnOnce") {
+            return Ok(None);
+        }
+
+        let [InferGenericArg::FnTraitArgs { params, ret }] = goal.args.as_slice() else {
+            return Ok(None);
+        };
+        Ok(Some((params, ret)))
+    }
+
+    fn closure_expr(inference: &BodyInferenceCtx, ty: &InferTy) -> Option<ExprId> {
+        let InferTy::Closure(id) = inference.root_resolved_ty(ty) else {
+            return None;
+        };
+        let index = usize::try_from(id.index()).expect("closure type id should fit in usize");
+        Some(ExprId(index))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rg_def_map::PackageSlot;
+    use rg_ir_model::{BindingId, BodyId, BodyRef, TargetRef, TraitRef, TypeDefRef};
+    use rg_package_store::PackageLoader;
+    use rg_parse::TargetId;
+    use rg_ty::{
+        NominalTy, TraitGoal, Ty,
+        inference::{InferGenericArg, InferTy},
+    };
+
+    use super::*;
+    use crate::{ResolvedBodyData, testonly::BodyIrFixture};
+
+    const FIXTURE: &str = r#"
+//- /Cargo.toml
+[package]
+name = "body_callable_goal_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub trait FnOnce {}
+pub trait NotCallable {}
+
+pub struct User;
+pub struct Name;
+
+pub fn use_it(seed: Name) {
+    let _closure = |user| seed;
+}
+"#;
+
+    #[test]
+    fn callable_goal_constrains_closure_param_and_body() {
+        let fixture = GoalFixture::new();
+        let mut inference = fixture.inference();
+        let goal = fixture.callable_goal(
+            &inference,
+            vec![InferTy::from_ty(&fixture.user_ty())],
+            InferTy::from_ty(&fixture.name_ty()),
+        );
+
+        assert!(
+            fixture
+                .solve_goal(&mut inference, &goal)
+                .expect("callable goal should solve")
+        );
+
+        assert_eq!(
+            inference.finalize_binding_ty(fixture.closure_param_binding()),
+            fixture.user_ty()
+        );
+        assert_eq!(
+            inference.finalize_expr_ty(fixture.closure_body()),
+            fixture.name_ty()
+        );
+    }
+
+    #[test]
+    fn callable_goal_solves_generic_return_from_closure_body() {
+        let fixture = GoalFixture::new();
+        let mut inference = fixture.inference();
+        let ret = inference.table.new_type_var();
+        let goal = fixture.callable_goal(
+            &inference,
+            vec![InferTy::from_ty(&fixture.user_ty())],
+            ret.clone(),
+        );
+
+        assert!(
+            fixture
+                .solve_goal(&mut inference, &goal)
+                .expect("callable goal should solve")
+        );
+
+        assert_eq!(inference.table.finalize(&ret), fixture.name_ty());
+    }
+
+    #[test]
+    fn non_callable_trait_goal_does_not_touch_closure() {
+        let fixture = GoalFixture::new();
+        let mut inference = fixture.inference();
+        let goal = TraitGoal {
+            self_ty: inference.expr_ty(fixture.closure_expr()),
+            trait_ref: fixture.trait_ref("NotCallable"),
+            args: Vec::new(),
+        };
+
+        assert!(
+            !fixture
+                .solve_goal(&mut inference, &goal)
+                .expect("non-callable goal should not fail")
+        );
+
+        assert_eq!(
+            inference.finalize_binding_ty(fixture.closure_param_binding()),
+            Ty::Unknown
+        );
+    }
+
+    #[test]
+    fn callable_arity_mismatch_is_no_evidence() {
+        let fixture = GoalFixture::new();
+        let mut inference = fixture.inference();
+        let ret = inference.table.new_type_var();
+        let goal = fixture.callable_goal(&inference, Vec::new(), ret.clone());
+
+        assert!(
+            fixture
+                .solve_goal(&mut inference, &goal)
+                .expect("callable goal should be recognized")
+        );
+
+        assert_eq!(
+            inference.finalize_binding_ty(fixture.closure_param_binding()),
+            Ty::Unknown
+        );
+        assert_eq!(inference.table.finalize(&ret), Ty::Unknown);
+    }
+
+    struct GoalFixture {
+        project: BodyIrFixture,
+        target: TargetRef,
+        body_ref: BodyRef,
+    }
+
+    impl GoalFixture {
+        fn new() -> Self {
+            let project = BodyIrFixture::build(FIXTURE);
+            let target = TargetRef {
+                package: PackageSlot(0),
+                target: TargetId(0),
+            };
+            let body_ref = BodyRef {
+                target,
+                body: BodyId(0),
+            };
+            Self {
+                project,
+                target,
+                body_ref,
+            }
+        }
+
+        fn solve_goal(
+            &self,
+            inference: &mut BodyInferenceCtx,
+            goal: &TraitGoal,
+        ) -> Result<bool, PackageStoreError> {
+            let def_maps = self
+                .project
+                .def_map_db()
+                .read_txn(PackageLoader::resident_only("callable goal def maps"));
+            let item_stores = self
+                .project
+                .semantic_ir_db()
+                .read_txn(PackageLoader::resident_only("callable goal item stores"));
+            let body_ir = self
+                .project
+                .body_ir_db()
+                .read_txn(PackageLoader::resident_only("callable goal body ir"));
+            let target_bodies = body_ir
+                .target_bodies(self.target)
+                .expect("target bodies should load")
+                .expect("target bodies should exist");
+            let body = target_bodies
+                .body(self.body_ref.body)
+                .expect("body should exist");
+            let context = BodyResolutionContext::new(
+                &def_maps,
+                &item_stores,
+                self.body_ref,
+                body,
+                target_bodies.semantic_index(),
+            );
+            BodyCallableGoalSolver::new(context).solve_goal(inference, goal)
+        }
+
+        fn body(&self) -> &ResolvedBodyData {
+            self.project
+                .resident_body(self.body_ref)
+                .expect("fixture body should exist")
+        }
+
+        fn inference(&self) -> BodyInferenceCtx {
+            let body = self.body();
+            let mut inference = BodyInferenceCtx::new(body.exprs().len(), body.bindings().len());
+            for expr_idx in 0..body.exprs().len() {
+                let expr = ExprId(expr_idx);
+                inference.set_expr_ty(expr, body.expr_ty_unchecked(expr));
+            }
+            for binding_idx in 0..body.bindings().len() {
+                let binding = BindingId(binding_idx);
+                inference.set_binding_ty(binding, body.binding_ty_unchecked(binding));
+            }
+            inference
+        }
+
+        fn callable_goal(
+            &self,
+            inference: &BodyInferenceCtx,
+            params: Vec<InferTy>,
+            ret: InferTy,
+        ) -> TraitGoal {
+            TraitGoal {
+                self_ty: inference.expr_ty(self.closure_expr()),
+                trait_ref: self.trait_ref("FnOnce"),
+                args: vec![InferGenericArg::FnTraitArgs {
+                    params,
+                    ret: Box::new(ret),
+                }],
+            }
+        }
+
+        fn closure_expr(&self) -> ExprId {
+            self.body()
+                .exprs()
+                .iter()
+                .enumerate()
+                .find_map(|(idx, expr)| {
+                    matches!(&expr.kind, ExprKind::Closure { .. }).then_some(ExprId(idx))
+                })
+                .expect("fixture should contain a closure")
+        }
+
+        fn closure_param_binding(&self) -> BindingId {
+            let ExprKind::Closure { params, .. } =
+                self.body().expr_unchecked(self.closure_expr()).kind.clone()
+            else {
+                panic!("fixture closure expr should still be a closure");
+            };
+            params
+                .first()
+                .and_then(|param| param.bindings.first())
+                .copied()
+                .expect("fixture closure should have one binding param")
+        }
+
+        fn closure_body(&self) -> ExprId {
+            let ExprKind::Closure { body, .. } =
+                self.body().expr_unchecked(self.closure_expr()).kind
+            else {
+                panic!("fixture closure expr should still be a closure");
+            };
+            body.expect("fixture closure should have a body")
+        }
+
+        fn user_ty(&self) -> Ty {
+            Ty::nominal(NominalTy::bare(self.type_def("User")))
+        }
+
+        fn name_ty(&self) -> Ty {
+            Ty::nominal(NominalTy::bare(self.type_def("Name")))
+        }
+
+        fn type_def(&self, name: &str) -> TypeDefRef {
+            let item_store = self
+                .project
+                .resident_target_ir(self.target)
+                .expect("target item store should exist");
+            item_store
+                .structs()
+                .iter_with_ids()
+                .find_map(|(id, data)| {
+                    (data.name.as_str() == name)
+                        .then_some(TypeDefRef::new_struct(item_store.origin(), id))
+                })
+                .expect("fixture type should exist")
+        }
+
+        fn trait_ref(&self, name: &str) -> TraitRef {
+            let item_store = self
+                .project
+                .resident_target_ir(self.target)
+                .expect("target item store should exist");
+            item_store
+                .traits_with_refs()
+                .find_map(|(trait_ref, data)| (data.name.as_str() == name).then_some(trait_ref))
+                .expect("fixture trait should exist")
+        }
+    }
+}

--- a/crates/engine/body-ir/src/resolution/infer/callable_goal.rs
+++ b/crates/engine/body-ir/src/resolution/infer/callable_goal.rs
@@ -122,8 +122,7 @@ where
         let InferTy::Closure(id) = inference.root_resolved_ty(ty) else {
             return None;
         };
-        let index = usize::try_from(id.index()).expect("closure type id should fit in usize");
-        Some(ExprId(index))
+        Some(id.into_expr_id())
     }
 }
 

--- a/crates/engine/body-ir/src/resolution/infer/callable_goal.rs
+++ b/crates/engine/body-ir/src/resolution/infer/callable_goal.rs
@@ -52,7 +52,18 @@ where
         let Some((params, ret)) = self.callable_goal_args(goal)? else {
             return Ok(false);
         };
-        let Some(closure) = Self::closure_expr(inference, &goal.self_ty) else {
+        self.solve_fn_trait_goal(inference, &goal.self_ty, params, ret)
+    }
+
+    /// Use already-projected callable fn-trait args as closure-local inference evidence.
+    pub(super) fn solve_fn_trait_goal(
+        &self,
+        inference: &mut BodyInferenceCtx,
+        self_ty: &InferTy,
+        params: &[InferTy],
+        ret: &InferTy,
+    ) -> Result<bool, PackageStoreError> {
+        let Some(closure) = Self::closure_expr(inference, self_ty) else {
             return Ok(false);
         };
         let Some(closure_data) = self.context.body().expr(closure).cloned() else {
@@ -74,7 +85,7 @@ where
         // first closure pattern to `User`, including destructuring such as
         // `FnOnce((Left, Right))` -> `|(left, right)|`.
         let pattern_inference = BodyPatternInference::new(self.context);
-        for (closure_param, expected_ty) in closure_params.iter().zip(params) {
+        for (closure_param, expected_ty) in closure_params.iter().zip(params.iter()) {
             let Some(pat) = closure_param.pat else {
                 continue;
             };

--- a/crates/engine/body-ir/src/resolution/infer/context.rs
+++ b/crates/engine/body-ir/src/resolution/infer/context.rs
@@ -37,9 +37,7 @@ impl BodyInferenceCtx {
     pub(crate) fn set_expr_closure_ty(&mut self, expr: ExprId) -> bool {
         // The id intentionally points back to the body expression index. Later callable-trait
         // phases can use that link to recover the closure params/body from the same body arena.
-        let index = u32::try_from(expr.0)
-            .expect("one body should not contain more than u32::MAX expressions");
-        self.set_expr_infer_ty(expr, InferTy::Closure(ClosureTyId::new(index)))
+        self.set_expr_infer_ty(expr, InferTy::Closure(ClosureTyId::new(expr)))
     }
 
     pub(crate) fn expr_ty(&self, expr: ExprId) -> InferTy {

--- a/crates/engine/body-ir/src/resolution/infer/context.rs
+++ b/crates/engine/body-ir/src/resolution/infer/context.rs
@@ -2,7 +2,7 @@ use rg_ir_model::items::{GenericParams, TypeRef};
 use rg_ir_model::{BindingId, ExprId, ExprWrapperKind};
 
 use rg_ty::{
-    Ty,
+    ClosureTyId, Ty,
     inference::{
         ExplicitTypeArgInstantiationBuilder, GenericReturnInstantiationBuilder, InferTy,
         InferTypeSubst, InferenceTable, UnknownTypeInstantiationBuilder,
@@ -32,6 +32,14 @@ impl BodyInferenceCtx {
 
     pub(crate) fn set_expr_infer_ty(&mut self, expr: ExprId, ty: InferTy) -> bool {
         self.set_expr_fact(expr, ty)
+    }
+
+    pub(crate) fn set_expr_closure_ty(&mut self, expr: ExprId) -> bool {
+        // The id intentionally points back to the body expression index. Later callable-trait
+        // phases can use that link to recover the closure params/body from the same body arena.
+        let index = u32::try_from(expr.0)
+            .expect("one body should not contain more than u32::MAX expressions");
+        self.set_expr_infer_ty(expr, InferTy::Closure(ClosureTyId::new(index)))
     }
 
     pub(crate) fn expr_ty(&self, expr: ExprId) -> InferTy {

--- a/crates/engine/body-ir/src/resolution/infer/mod.rs
+++ b/crates/engine/body-ir/src/resolution/infer/mod.rs
@@ -9,6 +9,7 @@ mod context;
 mod facts;
 mod member;
 mod pattern;
+mod projection;
 mod trait_obligation;
 
 pub(super) use call::BodyCallInference;

--- a/crates/engine/body-ir/src/resolution/infer/mod.rs
+++ b/crates/engine/body-ir/src/resolution/infer/mod.rs
@@ -4,6 +4,7 @@
 //! and binding slots to the transient inference table owned by `rg_ty`.
 
 mod call;
+mod callable_goal;
 mod context;
 mod facts;
 mod member;
@@ -11,6 +12,7 @@ mod pattern;
 mod trait_obligation;
 
 pub(super) use call::BodyCallInference;
+pub(super) use callable_goal::BodyCallableGoalSolver;
 pub(super) use context::BodyInferenceCtx;
 pub(super) use member::BodyMemberInference;
 pub(super) use pattern::BodyPatternInference;

--- a/crates/engine/body-ir/src/resolution/infer/pattern.rs
+++ b/crates/engine/body-ir/src/resolution/infer/pattern.rs
@@ -32,8 +32,13 @@ impl<'query, D, I> BodyPatternInference<'query, D, I> {
         self.link_pat(inference, pat, &initializer_ty)
     }
 
-    /// Project the current pattern from its matching initializer slot.
-    fn link_pat(&self, inference: &mut BodyInferenceCtx, pat: PatId, ty: &InferTy) -> bool {
+    /// Project the current pattern from its matching inference slot.
+    pub(crate) fn link_pat(
+        &self,
+        inference: &mut BodyInferenceCtx,
+        pat: PatId,
+        ty: &InferTy,
+    ) -> bool {
         let ty = inference.root_resolved_ty(ty);
         let Some(data) = self.context.body().pat(pat).cloned() else {
             return false;

--- a/crates/engine/body-ir/src/resolution/infer/projection.rs
+++ b/crates/engine/body-ir/src/resolution/infer/projection.rs
@@ -1,0 +1,261 @@
+//! Body-local projection from written type syntax into inference types.
+//!
+//! Plain type-ref resolution gives us stable `Ty` values, but body inference often needs a richer
+//! view: `T` should stay as the same `?T` slot that the call result uses, and associated
+//! projections such as `Self::Item` or `S::Item` may need body-local solver evidence.
+
+use rg_ir_model::items::{GenericArg as ItemGenericArg, TypeRef};
+use rg_ir_storage::{DefMapSource, ItemStoreSource};
+use rg_package_store::PackageStoreError;
+use rg_text::Name;
+use rg_ty::{
+    GenericArg, Ty,
+    inference::{InferGenericArg, InferTy, InferTypeRefProjector, InferTypeSubst},
+};
+
+use crate::resolution::{query::TypeRefResolutionQuery, support::self_associated_type_name};
+
+type SelfAssociatedTypeProjector<'a> =
+    &'a mut dyn FnMut(&str) -> Result<Option<InferTy>, PackageStoreError>;
+type AssociatedTypeProjector<'a> =
+    &'a mut dyn FnMut(&Name, &Name) -> Result<Option<InferTy>, PackageStoreError>;
+
+/// Projects written `TypeRef`s using body-local inference and associated projection evidence.
+///
+/// This is the inference-side version of "what type does this written syntax mean here?" For
+/// ordinary syntax it delegates to `InferTypeRefProjector`, so `Vec<T>` can become `Vec<?T>`.
+/// Callers provide body-local associated projection callbacks. That keeps this component focused
+/// on walking written type syntax and lets obligation code own the solver evidence.
+pub(super) struct BodyTypeRefProjector<'a, 'query, D, I> {
+    subst: &'a InferTypeSubst,
+    resolver: &'a TypeRefResolutionQuery<'query, D, I>,
+    self_associated_ty: Option<SelfAssociatedTypeProjector<'a>>,
+    type_param_associated_ty: Option<AssociatedTypeProjector<'a>>,
+}
+
+enum LocalProjection {
+    Projected(InferTy),
+    /// The written shape asked for a body-local associated projection, but we could not prove it.
+    Unsupported,
+    /// The written shape has no body-local projection syntax and should use ordinary fallback.
+    NotBodyLocal,
+}
+
+impl LocalProjection {
+    fn from_attempted_projection(ty: Option<InferTy>) -> Self {
+        match ty {
+            Some(ty) => Self::Projected(ty),
+            None => Self::Unsupported,
+        }
+    }
+
+    fn map_projected(self, f: impl FnOnce(InferTy) -> InferTy) -> Self {
+        match self {
+            Self::Projected(ty) => Self::Projected(f(ty)),
+            Self::Unsupported => Self::Unsupported,
+            Self::NotBodyLocal => Self::NotBodyLocal,
+        }
+    }
+}
+
+impl<'a, 'query, D, I> BodyTypeRefProjector<'a, 'query, D, I>
+where
+    D: DefMapSource<Error = PackageStoreError> + Copy,
+    I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
+{
+    pub(super) fn new(
+        subst: &'a InferTypeSubst,
+        resolver: &'a TypeRefResolutionQuery<'query, D, I>,
+    ) -> Self {
+        Self {
+            subst,
+            resolver,
+            self_associated_ty: None,
+            type_param_associated_ty: None,
+        }
+    }
+
+    pub(super) fn with_self_associated_ty(
+        mut self,
+        projector: SelfAssociatedTypeProjector<'a>,
+    ) -> Self {
+        self.self_associated_ty = Some(projector);
+        self
+    }
+
+    pub(super) fn with_type_param_associated_ty(
+        mut self,
+        projector: AssociatedTypeProjector<'a>,
+    ) -> Self {
+        self.type_param_associated_ty = Some(projector);
+        self
+    }
+
+    /// Project a written type ref, falling back to ordinary type-ref projection when body-local
+    /// associated projection is absent or unsupported.
+    pub(super) fn ty_or_fallback(&mut self, ty: &TypeRef) -> Result<InferTy, PackageStoreError> {
+        if let LocalProjection::Projected(projected_ty) = self.project_body_local_ty(ty)? {
+            return Ok(projected_ty);
+        }
+
+        self.fallback_ty(ty)
+    }
+
+    /// Project a written type ref when unsupported body-local projection should stop the caller.
+    ///
+    /// Impl associated aliases use this mode for shapes like `S::Item`: if no support predicate
+    /// proves which impl provides `Item`, the whole alias projection must stay unknown rather than
+    /// falling back to an ordinary `<unknown>`.
+    pub(super) fn ty_if_supported(
+        &mut self,
+        ty: &TypeRef,
+    ) -> Result<Option<InferTy>, PackageStoreError> {
+        match self.project_body_local_ty(ty)? {
+            LocalProjection::Projected(projected_ty) => Ok(Some(projected_ty)),
+            LocalProjection::Unsupported => Ok(None),
+            LocalProjection::NotBodyLocal => self.fallback_ty(ty).map(Some),
+        }
+    }
+
+    /// Project a generic argument while preserving inference slots in type arguments.
+    pub(super) fn generic_arg_or_fallback(
+        &mut self,
+        arg: &ItemGenericArg,
+        resolved_arg: &GenericArg,
+    ) -> Result<InferGenericArg, PackageStoreError> {
+        if let (ItemGenericArg::Type(ty), GenericArg::Type(resolved_ty)) = (arg, resolved_arg) {
+            let projected_ty = self.ty_from_resolved(ty, resolved_ty)?;
+            return Ok(InferGenericArg::Type(Box::new(projected_ty)));
+        }
+
+        Ok(InferTypeRefProjector::new(self.subst).generic_arg_from_arg(arg, resolved_arg))
+    }
+
+    /// Project a type ref when the caller already has the ordinary resolved `Ty`.
+    ///
+    /// This is useful for trait-bound args, where the resolver returns both written args and their
+    /// resolved counterparts together. We still give body-local associated projections a chance
+    /// before falling back to the ordinary resolved type.
+    fn ty_from_resolved(
+        &mut self,
+        ty: &TypeRef,
+        resolved_ty: &Ty,
+    ) -> Result<InferTy, PackageStoreError> {
+        if let LocalProjection::Projected(projected_ty) = self.project_body_local_ty(ty)? {
+            return Ok(projected_ty);
+        }
+
+        Ok(InferTypeRefProjector::new(self.subst).ty_from_type_ref(ty, resolved_ty))
+    }
+
+    fn fallback_ty(&mut self, ty: &TypeRef) -> Result<InferTy, PackageStoreError> {
+        let resolved_ty = self.resolver.resolve(ty)?;
+        Ok(InferTypeRefProjector::new(self.subst).ty_from_type_ref(ty, &resolved_ty))
+    }
+
+    /// Try body-local projection before ordinary resolver fallback.
+    ///
+    /// This only handles syntax that needs caller-provided evidence, such as `Self::Item`,
+    /// `S::Item`, or wrappers around them. `NotBodyLocal` means the ordinary projector should
+    /// handle the type instead.
+    fn project_body_local_ty(
+        &mut self,
+        ty: &TypeRef,
+    ) -> Result<LocalProjection, PackageStoreError> {
+        // Check `Self::Assoc`.
+        if let Some(assoc_name) = self_associated_type_name(ty) {
+            let Some(projector) = self.self_associated_ty.as_mut() else {
+                return Ok(LocalProjection::NotBodyLocal);
+            };
+            return Ok(LocalProjection::from_attempted_projection(projector(
+                assoc_name,
+            )?));
+        }
+
+        // Check `T::Assoc`.
+        if let Some((param_name, assoc_name)) = ty.as_type_param_assoc_path()
+            && self.subst.type_param(param_name.as_str()).is_some()
+            && let Some(projector) = self.type_param_associated_ty.as_mut()
+        {
+            return Ok(LocalProjection::from_attempted_projection(projector(
+                param_name, assoc_name,
+            )?));
+        }
+
+        // Check tuple.
+        if let TypeRef::Tuple(fields) = ty {
+            return self.project_body_local_tuple(fields);
+        }
+
+        // Check reference.
+        if let TypeRef::Reference {
+            mutability, inner, ..
+        } = ty
+        {
+            return Ok(self
+                .project_body_local_ty(inner)?
+                .map_projected(|inner_ty| InferTy::Reference {
+                    mutability: *mutability,
+                    inner: Box::new(inner_ty),
+                }));
+        }
+
+        // Check slice.
+        if let TypeRef::Slice(inner) = ty {
+            return Ok(self
+                .project_body_local_ty(inner)?
+                .map_projected(|inner_ty| InferTy::Slice(Box::new(inner_ty))));
+        }
+
+        // Check array.
+        if let TypeRef::Array { inner, len } = ty {
+            return Ok(self
+                .project_body_local_ty(inner)?
+                .map_projected(|inner_ty| InferTy::Array {
+                    inner: Box::new(inner_ty),
+                    len: len.clone(),
+                }));
+        }
+
+        Ok(LocalProjection::NotBodyLocal)
+    }
+
+    /// Project tuple fields when at least one field uses body-local evidence.
+    ///
+    /// Tuple projection is mixed: projected fields keep their body-local answer, and ordinary
+    /// fields use fallback projection. That lets `(S::Item, bool)` keep the projected `S::Item`
+    /// without losing the normal `bool` field.
+    fn project_body_local_tuple(
+        &mut self,
+        fields: &[TypeRef],
+    ) -> Result<LocalProjection, PackageStoreError> {
+        let mut projected_fields = Vec::with_capacity(fields.len());
+        let mut saw_projection = false;
+
+        for field in fields {
+            match self.project_body_local_ty(field)? {
+                LocalProjection::Projected(field_ty) => {
+                    saw_projection = true;
+                    projected_fields.push(Some(field_ty));
+                }
+                LocalProjection::Unsupported => return Ok(LocalProjection::Unsupported),
+                LocalProjection::NotBodyLocal => projected_fields.push(None),
+            }
+        }
+
+        if !saw_projection {
+            return Ok(LocalProjection::NotBodyLocal);
+        }
+
+        // Fill ordinary fields after body-local fields are known.
+        let fields = fields
+            .iter()
+            .zip(projected_fields)
+            .map(|(field, projected_ty)| match projected_ty {
+                Some(projected_ty) => Ok(projected_ty),
+                None => self.fallback_ty(field),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(LocalProjection::Projected(InferTy::Tuple(fields)))
+    }
+}

--- a/crates/engine/body-ir/src/resolution/infer/tests.rs
+++ b/crates/engine/body-ir/src/resolution/infer/tests.rs
@@ -29,8 +29,8 @@ fn vec_ty(inner: Ty) -> Ty {
     })
 }
 
-fn closure_ty(index: u32) -> Ty {
-    Ty::closure(ClosureTyId::new(index))
+fn closure_ty(index: usize) -> Ty {
+    Ty::closure(ClosureTyId::new(ExprId(index)))
 }
 
 fn default_int_ty() -> Ty {
@@ -49,7 +49,7 @@ fn stores_closure_types_as_body_local_facts() {
 
     assert_eq!(
         context.expr_ty(ExprId(0)),
-        InferTy::Closure(ClosureTyId::new(0))
+        InferTy::Closure(ClosureTyId::new(ExprId(0)))
     );
     assert_eq!(context.finalize_expr_ty(ExprId(0)), closure_ty(0));
 }
@@ -64,7 +64,7 @@ fn copies_closure_types_through_binding_reads() {
     assert!(context.set_expr_from_binding(ExprId(1), BindingId(0)));
     assert_eq!(
         context.expr_ty(ExprId(1)),
-        InferTy::Closure(ClosureTyId::new(0))
+        InferTy::Closure(ClosureTyId::new(ExprId(0)))
     );
     assert_eq!(context.finalize_expr_ty(ExprId(1)), closure_ty(0));
 }

--- a/crates/engine/body-ir/src/resolution/infer/tests.rs
+++ b/crates/engine/body-ir/src/resolution/infer/tests.rs
@@ -2,7 +2,9 @@ use rg_ir_model::{
     BindingId, DefMapRef, ExprId, PackageSlot, StructId, TargetRef, TypeDefId, TypeDefRef,
 };
 use rg_parse::TargetId;
-use rg_ty::{GenericArg, NominalTy, PrimitiveTy, Ty, UnsignedIntTy, inference::InferTy};
+use rg_ty::{
+    ClosureTyId, GenericArg, NominalTy, PrimitiveTy, Ty, UnsignedIntTy, inference::InferTy,
+};
 
 use super::context::BodyInferenceCtx;
 
@@ -27,12 +29,44 @@ fn vec_ty(inner: Ty) -> Ty {
     })
 }
 
+fn closure_ty(index: u32) -> Ty {
+    Ty::closure(ClosureTyId::new(index))
+}
+
 fn default_int_ty() -> Ty {
     Ty::Primitive(PrimitiveTy::DEFAULT_INT)
 }
 
 fn u64_ty() -> Ty {
     Ty::Primitive(PrimitiveTy::UnsignedInt(UnsignedIntTy::U64))
+}
+
+#[test]
+fn stores_closure_types_as_body_local_facts() {
+    let mut context = BodyInferenceCtx::new(1, 0);
+
+    assert!(context.set_expr_closure_ty(ExprId(0)));
+
+    assert_eq!(
+        context.expr_ty(ExprId(0)),
+        InferTy::Closure(ClosureTyId::new(0))
+    );
+    assert_eq!(context.finalize_expr_ty(ExprId(0)), closure_ty(0));
+}
+
+#[test]
+fn copies_closure_types_through_binding_reads() {
+    let mut context = BodyInferenceCtx::new(2, 1);
+
+    context.set_expr_closure_ty(ExprId(0));
+    context.set_binding_infer_ty(BindingId(0), context.expr_ty(ExprId(0)));
+
+    assert!(context.set_expr_from_binding(ExprId(1), BindingId(0)));
+    assert_eq!(
+        context.expr_ty(ExprId(1)),
+        InferTy::Closure(ClosureTyId::new(0))
+    );
+    assert_eq!(context.finalize_expr_ty(ExprId(1)), closure_ty(0));
 }
 
 #[test]

--- a/crates/engine/body-ir/src/resolution/infer/trait_obligation.rs
+++ b/crates/engine/body-ir/src/resolution/infer/trait_obligation.rs
@@ -6,13 +6,15 @@
 
 use rg_ir_model::{
     FunctionRef, ItemOwner,
+    hir::items::ImplData,
     items::{GenericArg as ItemGenericArg, GenericParams, TypeBound, TypeRef, WherePredicate},
 };
-use rg_ir_storage::{DefMapSource, ItemStoreSource};
+use rg_ir_storage::{DefMapSource, ItemStoreSource, TypePathContext};
 use rg_package_store::PackageStoreError;
 use rg_std::ExpectedUnique;
 use rg_ty::{
-    GenericArg, TraitGoal, TraitSelection, TraitSelectionQuery, Ty, TypeSubst,
+    GenericArg, TraitGoal, TraitSelection, TraitSelectionOptions, TraitSelectionQuery, Ty,
+    TypeSubst,
     inference::{InferGenericArg, InferTy, InferTypeRefProjector, InferTypeSubst},
 };
 
@@ -45,6 +47,12 @@ pub(super) struct SelectedCallObligationInput<'input> {
     pub(super) subst: &'input InferTypeSubst,
     pub(super) signature_subst: &'input TypeSubst,
     pub(super) selected_self_ty: Option<&'input Ty>,
+}
+
+struct CallableImplWhereObligation {
+    self_ty: InferTy,
+    params: Vec<InferTy>,
+    ret: InferTy,
 }
 
 /// Solves bounded trait obligations while preserving inference-table semantics.
@@ -322,18 +330,11 @@ where
             return Ok(None);
         };
         if let Some(assoc_name) = self_associated_type_name(ty) {
-            let assoc_projector = SelectedTraitAssocProjector::new(self.context);
-            let Some(projection) = assoc_projector.project_infer_ty(
+            return self.project_selected_trait_associated_alias(
+                inference,
                 selected_trait_method,
                 assoc_name,
-                &inference.table,
-            )?
-            else {
-                return Ok(None);
-            };
-            let (projected_ty, table) = projection.into_parts();
-            inference.table = table;
-            return Ok(Some(projected_ty));
+            );
         }
 
         // Callable bounds often wrap associated types in references, e.g. `FnMut(&Self::Item)`.
@@ -355,6 +356,156 @@ where
         }
 
         Ok(None)
+    }
+
+    /// Project `Self::Assoc` from the selected receiver impl, including shallow callable where
+    /// clauses that can solve impl-only generics.
+    ///
+    /// Example:
+    ///
+    /// ```text
+    /// impl<F, R> Produces for Adapter<F>
+    /// where
+    ///     F: FnOnce() -> R,
+    /// {
+    ///     type Output = R;
+    /// }
+    /// ```
+    ///
+    /// Matching `Adapter<Closure#n>: Produces` binds `F = Closure#n`, but `R` only appears in the
+    /// where-clause and alias. We give `R` a fresh slot, solve the callable where-clause from the
+    /// closure body, and then project `type Output = R`.
+    pub(super) fn project_selected_trait_associated_alias(
+        &self,
+        inference: &mut BodyInferenceCtx,
+        selected_trait_method: &SelectedTraitMethodContext<'_>,
+        assoc_name: &str,
+    ) -> Result<Option<InferTy>, PackageStoreError> {
+        let assoc_projector = SelectedTraitAssocProjector::new(self.context);
+        let Some(mut selection) = assoc_projector.select_infer_trait_impl(
+            selected_trait_method,
+            &inference.table,
+            TraitSelectionOptions::new().ignore_where_predicates(),
+        )?
+        else {
+            return Ok(None);
+        };
+        let Some(impl_data) = self
+            .context
+            .item_query()
+            .impl_data(selection.trait_impl.impl_ref)?
+            .cloned()
+        else {
+            return Ok(None);
+        };
+
+        self.bind_missing_impl_type_params(&mut selection, &impl_data.generics);
+        let Some(projected_ty) =
+            assoc_projector.project_associated_type_from_selection(&selection, assoc_name)?
+        else {
+            return Ok(None);
+        };
+
+        let Some(obligations) = self.callable_impl_where_obligations(&selection, &impl_data)?
+        else {
+            return Ok(None);
+        };
+        if obligations.iter().any(|obligation| {
+            !matches!(
+                selection.table.resolve_root_var(&obligation.self_ty),
+                InferTy::Closure(_)
+            )
+        }) {
+            return Ok(None);
+        }
+
+        let previous_table = inference.table.clone();
+        inference.table = selection.table;
+        for obligation in obligations {
+            if !BodyCallableGoalSolver::new(self.context).solve_fn_trait_goal(
+                inference,
+                &obligation.self_ty,
+                &obligation.params,
+                &obligation.ret,
+            )? {
+                inference.table = previous_table;
+                return Ok(None);
+            }
+        }
+
+        Ok(Some(projected_ty))
+    }
+
+    fn bind_missing_impl_type_params(
+        &self,
+        selection: &mut TraitSelection,
+        generics: &GenericParams,
+    ) {
+        for param in &generics.types {
+            if selection.subst.type_param(param.name.as_str()).is_some() {
+                continue;
+            }
+            let ty = selection.table.new_type_var();
+            selection
+                .subst
+                .push(&mut selection.table, param.name.clone(), ty);
+        }
+    }
+
+    fn callable_impl_where_obligations(
+        &self,
+        selection: &TraitSelection,
+        impl_data: &ImplData,
+    ) -> Result<Option<Vec<CallableImplWhereObligation>>, PackageStoreError> {
+        let context = TypePathContext {
+            module: impl_data.owner,
+            impl_ref: Some(selection.trait_impl.impl_ref),
+        };
+        let resolver = self
+            .context
+            .type_refs(TypeRefUseSite::OwnerContext(context));
+        let mut obligations = Vec::new();
+
+        for predicate in &impl_data.generics.where_predicates {
+            let WherePredicate::Type { ty, bounds } = predicate else {
+                return Ok(None);
+            };
+            let self_ty = self.project_impl_obligation_ty(selection, &resolver, ty)?;
+            for bound in bounds {
+                let TypeBound::Trait(bound_ty) = bound else {
+                    return Ok(None);
+                };
+                let Some(expectation) = CallableTypeRefExpectation::from_fn_trait_bound(bound_ty)
+                else {
+                    return Ok(None);
+                };
+
+                let params = expectation
+                    .params()
+                    .iter()
+                    .map(|param| self.project_impl_obligation_ty(selection, &resolver, param))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let ret =
+                    self.project_impl_obligation_ty(selection, &resolver, expectation.return_ty())?;
+                obligations.push(CallableImplWhereObligation {
+                    self_ty: self_ty.clone(),
+                    params,
+                    ret,
+                });
+            }
+        }
+
+        Ok(Some(obligations))
+    }
+
+    fn project_impl_obligation_ty(
+        &self,
+        selection: &TraitSelection,
+        resolver: &TypeRefResolutionQuery<'query, D, I>,
+        ty: &TypeRef,
+    ) -> Result<InferTy, PackageStoreError> {
+        let resolved_ty = resolver.resolve(ty)?;
+        Ok(InferTypeRefProjector::new(&selection.subst).ty_from_type_ref(ty, &resolved_ty))
     }
 
     /// Probe a trait goal using the target lookup index persisted with Body IR.

--- a/crates/engine/body-ir/src/resolution/infer/trait_obligation.rs
+++ b/crates/engine/body-ir/src/resolution/infer/trait_obligation.rs
@@ -5,10 +5,10 @@
 //! still lives in the shared type layer.
 
 use rg_ir_model::{
-    AssocItemId, FunctionRef, ItemOwner, TraitRef, TypeAliasRef,
+    FunctionRef, ItemOwner,
     items::{GenericArg as ItemGenericArg, GenericParams, TypeBound, TypeRef, WherePredicate},
 };
-use rg_ir_storage::{DefMapSource, ItemStoreSource, TypePathContext};
+use rg_ir_storage::{DefMapSource, ItemStoreSource};
 use rg_package_store::PackageStoreError;
 use rg_std::ExpectedUnique;
 use rg_ty::{
@@ -16,8 +16,11 @@ use rg_ty::{
     inference::{InferGenericArg, InferTy, InferTypeRefProjector, InferTypeSubst},
 };
 
-use crate::resolution::query::TypeRefResolutionQuery;
-use crate::resolution::{BodyResolutionContext, TypeRefUseSite};
+use crate::resolution::{
+    BodyResolutionContext, TypeRefUseSite,
+    query::TypeRefResolutionQuery,
+    support::{SelectedTraitAssocProjector, SelectedTraitMethodContext, self_associated_type_name},
+};
 
 use super::BodyInferenceCtx;
 
@@ -39,12 +42,6 @@ pub(super) struct SelectedCallObligationInput<'input> {
     pub(super) subst: &'input InferTypeSubst,
     pub(super) signature_subst: &'input TypeSubst,
     pub(super) selected_self_ty: Option<&'input Ty>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct SelectedTraitMethodObligation {
-    trait_ref: TraitRef,
-    self_ty: InferTy,
 }
 
 /// Solves bounded trait obligations while preserving inference-table semantics.
@@ -74,9 +71,10 @@ where
         // Stage 1: capture the selected trait method context. This lets later projection read
         // `Self::Item` from the unique receiver impl, while inherent calls and free functions
         // simply proceed without that extra context.
-        let selected_trait_method = self.selected_trait_method_obligation(
-            &input.owner,
-            input.function.origin,
+        let selected_trait_method = SelectedTraitMethodContext::from_function(
+            self.context,
+            input.function,
+            input.owner,
             input.selected_self_ty,
         )?;
         let bound_resolver = self
@@ -140,7 +138,7 @@ where
         inference: &mut BodyInferenceCtx,
         subst: &InferTypeSubst,
         resolver: &TypeRefResolutionQuery<'query, D, I>,
-        selected_trait_method: Option<&SelectedTraitMethodObligation>,
+        selected_trait_method: Option<&SelectedTraitMethodContext<'_>>,
         ty: &TypeRef,
     ) -> Result<InferTy, PackageStoreError> {
         if let Some(projected_ty) =
@@ -163,7 +161,7 @@ where
         inference: &mut BodyInferenceCtx,
         subst: &InferTypeSubst,
         resolver: &TypeRefResolutionQuery<'query, D, I>,
-        selected_trait_method: Option<&SelectedTraitMethodObligation>,
+        selected_trait_method: Option<&SelectedTraitMethodContext<'_>>,
         self_ty: InferTy,
         bound: &TypeBound,
     ) -> Result<(), PackageStoreError> {
@@ -210,45 +208,6 @@ where
         Ok(())
     }
 
-    /// Build the extra context needed to interpret associated types on selected trait methods.
-    ///
-    /// Example: if `iter.collect()` selected `Iterator::collect` for receiver `Iter<User>`, later
-    /// projection can ask whether exactly one `impl Iterator for Iter<User>` defines `Item`.
-    fn selected_trait_method_obligation(
-        &self,
-        owner: &ItemOwner,
-        origin: rg_ir_model::DefMapRef,
-        selected_self_ty: Option<&Ty>,
-    ) -> Result<Option<SelectedTraitMethodObligation>, PackageStoreError> {
-        let ItemOwner::Trait(trait_id) = owner else {
-            return Ok(None);
-        };
-        let Some(selected_self_ty) = selected_self_ty else {
-            return Ok(None);
-        };
-
-        let trait_ref = TraitRef {
-            origin,
-            id: *trait_id,
-        };
-        let Some(trait_data) = self.context.item_query().trait_data(trait_ref)? else {
-            return Ok(None);
-        };
-        if !trait_data.generics.lifetimes.is_empty()
-            || !trait_data.generics.types.is_empty()
-            || !trait_data.generics.consts.is_empty()
-        {
-            // TODO: Thread trait-level generic args from method selection once we need
-            // associated projections for traits shaped like `Trait<T>`.
-            return Ok(None);
-        }
-
-        Ok(Some(SelectedTraitMethodObligation {
-            trait_ref,
-            self_ty: InferTy::from_ty(selected_self_ty),
-        }))
-    }
-
     /// Project a trait-bound generic argument while preserving inference variables.
     ///
     /// Most args use the ordinary `InferTypeRefProjector`: `Vec<_>` stays `Vec<?T>`. The special
@@ -258,7 +217,7 @@ where
         &self,
         inference: &mut BodyInferenceCtx,
         subst: &InferTypeSubst,
-        selected_trait_method: Option<&SelectedTraitMethodObligation>,
+        selected_trait_method: Option<&SelectedTraitMethodContext<'_>>,
         arg: &ItemGenericArg,
         resolved_arg: &GenericArg,
     ) -> Result<InferGenericArg, PackageStoreError> {
@@ -285,86 +244,28 @@ where
     fn project_selected_trait_associated_ty(
         &self,
         inference: &mut BodyInferenceCtx,
-        selected_trait_method: Option<&SelectedTraitMethodObligation>,
+        selected_trait_method: Option<&SelectedTraitMethodContext<'_>>,
         ty: &TypeRef,
     ) -> Result<Option<InferTy>, PackageStoreError> {
         let Some(selected_trait_method) = selected_trait_method else {
             return Ok(None);
         };
-        let Some(assoc_name) = Self::self_associated_type_name(ty) else {
+        let Some(assoc_name) = self_associated_type_name(ty) else {
             return Ok(None);
         };
 
-        let goal = TraitGoal {
-            self_ty: selected_trait_method.self_ty.clone(),
-            trait_ref: selected_trait_method.trait_ref,
-            args: Vec::new(),
-        };
-        let ExpectedUnique::One(selection) = self.probe_trait_goal(&goal, inference)? else {
-            return Ok(None);
-        };
-        let Some(projected_ty) =
-            self.project_associated_type_from_selection(&selection, assoc_name)?
+        let assoc_projector = SelectedTraitAssocProjector::new(self.context);
+        let Some(projection) = assoc_projector.project_infer_ty(
+            selected_trait_method,
+            assoc_name,
+            &inference.table,
+        )?
         else {
             return Ok(None);
         };
-
-        inference.table = selection.table;
+        let (projected_ty, table) = projection.into_parts();
+        inference.table = table;
         Ok(Some(projected_ty))
-    }
-
-    /// Read one associated type from a selected impl and project it through the impl substitution.
-    ///
-    /// Example: with `impl<T> Iterator for Iter<T> { type Item = T; }` and the selection subst
-    /// `T = User`, reading `Item` returns `User` in inference form.
-    fn project_associated_type_from_selection(
-        &self,
-        selection: &TraitSelection,
-        assoc_name: &str,
-    ) -> Result<Option<InferTy>, PackageStoreError> {
-        let Some(impl_data) = self
-            .context
-            .item_query()
-            .impl_data(selection.trait_impl.impl_ref)?
-        else {
-            return Ok(None);
-        };
-
-        for item in &impl_data.items {
-            let AssocItemId::TypeAlias(type_alias_id) = item else {
-                continue;
-            };
-            let type_alias_ref = TypeAliasRef {
-                origin: selection.trait_impl.impl_ref.origin,
-                id: *type_alias_id,
-            };
-            let Some(type_alias_data) =
-                self.context.item_query().type_alias_data(type_alias_ref)?
-            else {
-                continue;
-            };
-            if type_alias_data.name.as_str() != assoc_name {
-                continue;
-            }
-            let Some(aliased_ty) = type_alias_data.signature.aliased_ty() else {
-                continue;
-            };
-
-            let context = TypePathContext {
-                module: impl_data.owner,
-                impl_ref: Some(selection.trait_impl.impl_ref),
-            };
-            let resolved_ty = self
-                .context
-                .type_refs(TypeRefUseSite::OwnerContext(context))
-                .resolve(aliased_ty)?;
-            return Ok(Some(
-                InferTypeRefProjector::new(&selection.subst)
-                    .ty_from_type_ref(aliased_ty, &resolved_ty),
-            ));
-        }
-
-        Ok(None)
     }
 
     /// Probe a trait goal using the target lookup index persisted with Body IR.
@@ -382,25 +283,5 @@ where
             self.context.semantic_index(),
         )
         .probe(goal, &inference.table)
-    }
-
-    fn self_associated_type_name(ty: &TypeRef) -> Option<&str> {
-        // TODO: Generalize this replacement to nested shapes such as `Option<Self::Item>` when
-        // selected-call obligations need them.
-        let TypeRef::Path(path) = ty else {
-            return None;
-        };
-        let [self_segment, assoc_segment] = path.segments.as_slice() else {
-            return None;
-        };
-        if path.absolute
-            || self_segment.name.as_str() != "Self"
-            || !self_segment.args.is_empty()
-            || !assoc_segment.args.is_empty()
-        {
-            return None;
-        }
-
-        Some(assoc_segment.name.as_str())
     }
 }

--- a/crates/engine/body-ir/src/resolution/infer/trait_obligation.rs
+++ b/crates/engine/body-ir/src/resolution/infer/trait_obligation.rs
@@ -22,7 +22,7 @@ use crate::resolution::{
     support::{SelectedTraitAssocProjector, SelectedTraitMethodContext, self_associated_type_name},
 };
 
-use super::BodyInferenceCtx;
+use super::{BodyCallableGoalSolver, BodyInferenceCtx};
 
 /// Signature facts from an already-selected call that can expose trait obligations.
 ///
@@ -200,6 +200,16 @@ where
             trait_ref,
             args,
         };
+
+        // Note: trait solver is not powerful enough to "properly" solve obligations typically
+        // seen in closures, like `F: FnOnce(T) -> B` where `B` does not participate in impl
+        // header directly (only exposed through callable bounds).
+        // However, it is a very common piece of functionality, so we add a "lightweight"
+        // solver that would attempt solving it through the closure evidence.
+        if BodyCallableGoalSolver::new(self.context).solve_goal(inference, &goal)? {
+            return Ok(());
+        }
+
         let selection = self.probe_trait_goal(&goal, inference)?;
         if let ExpectedUnique::One(selection) = selection {
             inference.table = selection.table;

--- a/crates/engine/body-ir/src/resolution/infer/trait_obligation.rs
+++ b/crates/engine/body-ir/src/resolution/infer/trait_obligation.rs
@@ -19,7 +19,10 @@ use rg_ty::{
 use crate::resolution::{
     BodyResolutionContext, TypeRefUseSite,
     query::TypeRefResolutionQuery,
-    support::{SelectedTraitAssocProjector, SelectedTraitMethodContext, self_associated_type_name},
+    support::{
+        CallableTypeRefExpectation, SelectedTraitAssocProjector, SelectedTraitMethodContext,
+        self_associated_type_name,
+    },
 };
 
 use super::{BodyCallableGoalSolver, BodyInferenceCtx};
@@ -168,6 +171,17 @@ where
         let TypeBound::Trait(bound_ty) = bound else {
             return Ok(());
         };
+        if self.solve_callable_syntax_obligation(
+            inference,
+            subst,
+            resolver,
+            selected_trait_method,
+            &self_ty,
+            bound_ty,
+        )? {
+            return Ok(());
+        }
+
         let Some((trait_ref, resolved_args)) = resolver.resolve_trait_bound(bound_ty)? else {
             return Ok(());
         };
@@ -218,11 +232,58 @@ where
         Ok(())
     }
 
+    /// Turn written `Fn*` bounds into closure evidence before ordinary trait solving.
+    ///
+    /// The trait solver does not model callable traits deeply enough to prove this on its own yet:
+    /// `where F: FnOnce(T) -> R`.
+    ///
+    /// But selected-call inference may already know that `F` is a particular closure:
+    /// `apply(user, |user| user.name())` gives `F = Closure#n`.
+    ///
+    /// In that case we can project `T` and `R` through the selected-call substitution and apply
+    /// the same closure-local goal as the normal trait path:
+    /// `Closure#n: FnOnce(User) -> R`.
+    fn solve_callable_syntax_obligation(
+        &self,
+        inference: &mut BodyInferenceCtx,
+        subst: &InferTypeSubst,
+        resolver: &TypeRefResolutionQuery<'query, D, I>,
+        selected_trait_method: Option<&SelectedTraitMethodContext<'_>>,
+        self_ty: &InferTy,
+        bound_ty: &TypeRef,
+    ) -> Result<bool, PackageStoreError> {
+        let Some(expectation) = CallableTypeRefExpectation::from_fn_trait_bound(bound_ty) else {
+            return Ok(false);
+        };
+        if !matches!(inference.root_resolved_ty(self_ty), InferTy::Closure(_)) {
+            return Ok(false);
+        }
+
+        let params = expectation
+            .params()
+            .iter()
+            .map(|param| {
+                self.project_obligation_ty(inference, subst, resolver, selected_trait_method, param)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let ret = self.project_obligation_ty(
+            inference,
+            subst,
+            resolver,
+            selected_trait_method,
+            expectation.return_ty(),
+        )?;
+
+        BodyCallableGoalSolver::new(self.context)
+            .solve_fn_trait_goal(inference, self_ty, &params, &ret)
+    }
+
     /// Project a trait-bound generic argument while preserving inference variables.
     ///
     /// Most args use the ordinary `InferTypeRefProjector`: `Vec<_>` stays `Vec<?T>`. The special
-    /// case is an exact `Self::Item` type arg from a selected trait method, which is replaced by
-    /// the receiver impl's associated type before matching the bound impl.
+    /// case is `Self::Item` from a selected trait method, which is replaced by the receiver impl's
+    /// associated type before matching the bound impl. Simple reference wrappers are preserved, so
+    /// `&Self::Item` can still project through bounds like `FnMut(&Self::Item)`.
     fn project_obligation_generic_arg(
         &self,
         inference: &mut BodyInferenceCtx,
@@ -246,7 +307,7 @@ where
         Ok(InferTypeRefProjector::new(subst).generic_arg_from_arg(arg, resolved_arg))
     }
 
-    /// Replace exact `Self::Assoc` with the associated type from a unique receiver impl.
+    /// Replace `Self::Assoc` with the associated type from a unique receiver impl.
     ///
     /// Example: for `Iterator::collect` on `Iter<User>`, this probes `Iter<User>: Iterator` and
     /// reads `type Item = User` from the unique impl. Ambiguous receiver impls return `None` so
@@ -260,22 +321,40 @@ where
         let Some(selected_trait_method) = selected_trait_method else {
             return Ok(None);
         };
-        let Some(assoc_name) = self_associated_type_name(ty) else {
-            return Ok(None);
-        };
+        if let Some(assoc_name) = self_associated_type_name(ty) {
+            let assoc_projector = SelectedTraitAssocProjector::new(self.context);
+            let Some(projection) = assoc_projector.project_infer_ty(
+                selected_trait_method,
+                assoc_name,
+                &inference.table,
+            )?
+            else {
+                return Ok(None);
+            };
+            let (projected_ty, table) = projection.into_parts();
+            inference.table = table;
+            return Ok(Some(projected_ty));
+        }
 
-        let assoc_projector = SelectedTraitAssocProjector::new(self.context);
-        let Some(projection) = assoc_projector.project_infer_ty(
-            selected_trait_method,
-            assoc_name,
-            &inference.table,
-        )?
-        else {
-            return Ok(None);
-        };
-        let (projected_ty, table) = projection.into_parts();
-        inference.table = table;
-        Ok(Some(projected_ty))
+        // Callable bounds often wrap associated types in references, e.g. `FnMut(&Self::Item)`.
+        // This is not autoderef: we only peel written reference wrappers until the inner type can
+        // be projected, then rebuild the same reference shape around the projected type.
+        if let TypeRef::Reference {
+            mutability, inner, ..
+        } = ty
+            && let Some(inner_ty) = self.project_selected_trait_associated_ty(
+                inference,
+                Some(selected_trait_method),
+                inner,
+            )?
+        {
+            return Ok(Some(InferTy::Reference {
+                mutability: *mutability,
+                inner: Box::new(inner_ty),
+            }));
+        }
+
+        Ok(None)
     }
 
     /// Probe a trait goal using the target lookup index persisted with Body IR.

--- a/crates/engine/body-ir/src/resolution/infer/trait_obligation/assoc_projection.rs
+++ b/crates/engine/body-ir/src/resolution/infer/trait_obligation/assoc_projection.rs
@@ -92,13 +92,18 @@ where
         };
 
         self.bind_missing_impl_type_params(&mut selection, &impl_data.generics);
-        let Some(projected_ty) =
-            assoc_projector.project_associated_type_from_selection(&selection, assoc_name)?
+        let Some((_, aliased_ty)) =
+            assoc_projector.associated_type_alias_from_selection(&selection, assoc_name)?
         else {
             return Ok(None);
         };
 
-        let Some(obligations) = self.callable_impl_where_obligations(&mut selection, &impl_data)?
+        let Some((projected_ty, obligations)) = self
+            .project_associated_alias_and_callable_impl_where(
+                &mut selection,
+                &impl_data,
+                &aliased_ty,
+            )?
         else {
             return Ok(None);
         };
@@ -144,11 +149,12 @@ where
         }
     }
 
-    fn callable_impl_where_obligations(
+    fn project_associated_alias_and_callable_impl_where(
         &self,
         selection: &mut TraitSelection,
         impl_data: &ImplData,
-    ) -> Result<Option<Vec<CallableImplWhereObligation>>, PackageStoreError> {
+        aliased_ty: &TypeRef,
+    ) -> Result<Option<(InferTy, Vec<CallableImplWhereObligation>)>, PackageStoreError> {
         let context = TypePathContext {
             module: impl_data.owner,
             impl_ref: Some(selection.trait_impl.impl_ref),
@@ -189,33 +195,35 @@ where
             supports.push(support);
         }
 
-        // Only two predicate families are accepted in this shallow projection path:
-        // callable predicates that can solve closure-return generics, and support predicates used
-        // by those callable predicates to project `S::Item`-style inputs. Anything left unused is
-        // a real extra obligation, so we keep the associated type unknown instead of ignoring it.
+        let Some(projected_ty) =
+            self.project_impl_where_ty(selection, &mut supports, &resolver, aliased_ty)?
+        else {
+            return Ok(None);
+        };
+
+        // Only two predicate families are accepted in this shallow projection path: callable
+        // predicates that can solve closure-return generics, and support predicates used to project
+        // `S::Item`-style inputs. Anything left unused is a real extra obligation, so we keep the
+        // associated type unknown instead of ignoring it.
         let mut obligations = Vec::new();
 
         for (ty, expectations) in callable_predicates {
             let Some(self_ty) =
-                self.project_callable_impl_obligation_ty(selection, &mut supports, &resolver, ty)?
+                self.project_impl_where_ty(selection, &mut supports, &resolver, ty)?
             else {
                 return Ok(None);
             };
             for expectation in expectations {
                 let mut params = Vec::new();
                 for param in expectation.params() {
-                    let Some(param) = self.project_callable_impl_obligation_ty(
-                        selection,
-                        &mut supports,
-                        &resolver,
-                        param,
-                    )?
+                    let Some(param) =
+                        self.project_impl_where_ty(selection, &mut supports, &resolver, param)?
                     else {
                         return Ok(None);
                     };
                     params.push(param);
                 }
-                let Some(ret) = self.project_callable_impl_obligation_ty(
+                let Some(ret) = self.project_impl_where_ty(
                     selection,
                     &mut supports,
                     &resolver,
@@ -236,7 +244,7 @@ where
             return Ok(None);
         }
 
-        Ok(Some(obligations))
+        Ok(Some((projected_ty, obligations)))
     }
 
     fn impl_where_projection_support(
@@ -278,7 +286,7 @@ where
         Ok(None)
     }
 
-    fn project_callable_impl_obligation_ty(
+    fn project_impl_where_ty(
         &self,
         selection: &mut TraitSelection,
         supports: &mut [ImplWhereProjectionSupport],
@@ -292,18 +300,47 @@ where
                 .project_impl_generic_associated_ty(selection, supports, param_name, assoc_name);
         }
 
+        if let TypeRef::Tuple(fields) = ty {
+            let fields = fields
+                .iter()
+                .map(|field| self.project_impl_where_ty(selection, supports, resolver, field))
+                .collect::<Result<Option<Vec<_>>, _>>()?;
+            return Ok(fields.map(InferTy::Tuple));
+        }
+
         if let TypeRef::Reference {
             mutability, inner, ..
         } = ty
         {
             let Some(inner_ty) =
-                self.project_callable_impl_obligation_ty(selection, supports, resolver, inner)?
+                self.project_impl_where_ty(selection, supports, resolver, inner)?
             else {
                 return Ok(None);
             };
             return Ok(Some(InferTy::Reference {
                 mutability: *mutability,
                 inner: Box::new(inner_ty),
+            }));
+        }
+
+        if let TypeRef::Slice(inner) = ty {
+            let Some(inner_ty) =
+                self.project_impl_where_ty(selection, supports, resolver, inner)?
+            else {
+                return Ok(None);
+            };
+            return Ok(Some(InferTy::Slice(Box::new(inner_ty))));
+        }
+
+        if let TypeRef::Array { inner, len } = ty {
+            let Some(inner_ty) =
+                self.project_impl_where_ty(selection, supports, resolver, inner)?
+            else {
+                return Ok(None);
+            };
+            return Ok(Some(InferTy::Array {
+                inner: Box::new(inner_ty),
+                len: len.clone(),
             }));
         }
 

--- a/crates/engine/body-ir/src/resolution/infer/trait_obligation/assoc_projection.rs
+++ b/crates/engine/body-ir/src/resolution/infer/trait_obligation/assoc_projection.rs
@@ -26,7 +26,7 @@ use crate::resolution::{
     },
 };
 
-use super::super::{BodyCallableGoalSolver, BodyInferenceCtx};
+use super::super::{BodyCallableGoalSolver, BodyInferenceCtx, projection::BodyTypeRefProjector};
 use super::BodyTraitObligationSolver;
 
 struct CallableImplWhereObligation {
@@ -293,59 +293,13 @@ where
         resolver: &TypeRefResolutionQuery<'query, D, I>,
         ty: &TypeRef,
     ) -> Result<Option<InferTy>, PackageStoreError> {
-        if let Some((param_name, assoc_name)) = ty.as_type_param_assoc_path()
-            && selection.subst.type_param(param_name.as_str()).is_some()
-        {
-            return self
-                .project_impl_generic_associated_ty(selection, supports, param_name, assoc_name);
-        }
-
-        if let TypeRef::Tuple(fields) = ty {
-            let fields = fields
-                .iter()
-                .map(|field| self.project_impl_where_ty(selection, supports, resolver, field))
-                .collect::<Result<Option<Vec<_>>, _>>()?;
-            return Ok(fields.map(InferTy::Tuple));
-        }
-
-        if let TypeRef::Reference {
-            mutability, inner, ..
-        } = ty
-        {
-            let Some(inner_ty) =
-                self.project_impl_where_ty(selection, supports, resolver, inner)?
-            else {
-                return Ok(None);
-            };
-            return Ok(Some(InferTy::Reference {
-                mutability: *mutability,
-                inner: Box::new(inner_ty),
-            }));
-        }
-
-        if let TypeRef::Slice(inner) = ty {
-            let Some(inner_ty) =
-                self.project_impl_where_ty(selection, supports, resolver, inner)?
-            else {
-                return Ok(None);
-            };
-            return Ok(Some(InferTy::Slice(Box::new(inner_ty))));
-        }
-
-        if let TypeRef::Array { inner, len } = ty {
-            let Some(inner_ty) =
-                self.project_impl_where_ty(selection, supports, resolver, inner)?
-            else {
-                return Ok(None);
-            };
-            return Ok(Some(InferTy::Array {
-                inner: Box::new(inner_ty),
-                len: len.clone(),
-            }));
-        }
-
-        self.project_impl_obligation_ty(selection, resolver, ty)
-            .map(Some)
+        let subst = selection.subst.clone();
+        let mut associated_ty = |param_name: &Name, assoc_name: &Name| {
+            self.project_impl_generic_associated_ty(selection, supports, param_name, assoc_name)
+        };
+        BodyTypeRefProjector::new(&subst, resolver)
+            .with_type_param_associated_ty(&mut associated_ty)
+            .ty_if_supported(ty)
     }
 
     fn project_impl_generic_associated_ty(
@@ -383,15 +337,5 @@ where
         selection.table = support_selection.table;
         supports[support_idx].used = true;
         Ok(Some(projected_ty))
-    }
-
-    fn project_impl_obligation_ty(
-        &self,
-        selection: &TraitSelection,
-        resolver: &TypeRefResolutionQuery<'query, D, I>,
-        ty: &TypeRef,
-    ) -> Result<InferTy, PackageStoreError> {
-        let resolved_ty = resolver.resolve(ty)?;
-        Ok(InferTypeRefProjector::new(&selection.subst).ty_from_type_ref(ty, &resolved_ty))
     }
 }

--- a/crates/engine/body-ir/src/resolution/infer/trait_obligation/assoc_projection.rs
+++ b/crates/engine/body-ir/src/resolution/infer/trait_obligation/assoc_projection.rs
@@ -1,0 +1,360 @@
+//! Associated alias projection through selected impl where-clauses.
+//!
+//! This module handles the second step after trait selection has picked a receiver impl:
+//! projecting a selected trait method return such as `Self::Item`. The harder cases are adapter
+//! impls where the associated alias mentions an impl-only generic, and a callable where-clause
+//! must solve that generic from a closure witness before the alias is useful.
+
+use rg_ir_model::{
+    hir::items::ImplData,
+    items::{GenericParams, TypeBound, TypeRef, WherePredicate},
+};
+use rg_ir_storage::{DefMapSource, ItemStoreSource, TypePathContext};
+use rg_package_store::PackageStoreError;
+use rg_std::ExpectedUnique;
+use rg_text::Name;
+use rg_ty::{
+    TraitGoal, TraitSelection, TraitSelectionOptions,
+    inference::{InferTy, InferTypeRefProjector},
+};
+
+use crate::resolution::{
+    TypeRefUseSite,
+    query::TypeRefResolutionQuery,
+    support::{
+        CallableTypeRefExpectation, SelectedTraitAssocProjector, SelectedTraitMethodContext,
+    },
+};
+
+use super::super::{BodyCallableGoalSolver, BodyInferenceCtx};
+use super::BodyTraitObligationSolver;
+
+struct CallableImplWhereObligation {
+    self_ty: InferTy,
+    params: Vec<InferTy>,
+    ret: InferTy,
+}
+
+/// Non-callable where-predicate that exists to project an associated type used by a callable one.
+///
+/// Example: in `S: Stream, F: FnMut(S::Item) -> B`, the `S: Stream` predicate lets us resolve
+/// `S::Item` before applying the callable predicate to the closure witness.
+struct ImplWhereProjectionSupport {
+    param_name: Name,
+    goal: TraitGoal,
+    used: bool,
+}
+
+impl<'query, D, I> BodyTraitObligationSolver<'query, D, I>
+where
+    D: DefMapSource<Error = PackageStoreError> + Copy,
+    I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
+{
+    /// Project `Self::Assoc` from the selected receiver impl, including shallow callable where
+    /// clauses that can solve impl-only generics.
+    ///
+    /// Example:
+    ///
+    /// ```text
+    /// impl<F, R> Produces for Adapter<F>
+    /// where
+    ///     F: FnOnce() -> R,
+    /// {
+    ///     type Output = R;
+    /// }
+    /// ```
+    ///
+    /// Matching `Adapter<Closure#n>: Produces` binds `F = Closure#n`, but `R` only appears in the
+    /// where-clause and alias. We give `R` a fresh slot, solve the callable where-clause from the
+    /// closure body, and then project `type Output = R`.
+    pub(crate) fn project_selected_trait_associated_alias(
+        &self,
+        inference: &mut BodyInferenceCtx,
+        selected_trait_method: &SelectedTraitMethodContext<'_>,
+        assoc_name: &str,
+    ) -> Result<Option<InferTy>, PackageStoreError> {
+        let assoc_projector = SelectedTraitAssocProjector::new(self.context);
+        let Some(mut selection) = assoc_projector.select_infer_trait_impl(
+            selected_trait_method,
+            &inference.table,
+            TraitSelectionOptions::new().ignore_where_predicates(),
+        )?
+        else {
+            return Ok(None);
+        };
+        let Some(impl_data) = self
+            .context
+            .item_query()
+            .impl_data(selection.trait_impl.impl_ref)?
+            .cloned()
+        else {
+            return Ok(None);
+        };
+
+        self.bind_missing_impl_type_params(&mut selection, &impl_data.generics);
+        let Some(projected_ty) =
+            assoc_projector.project_associated_type_from_selection(&selection, assoc_name)?
+        else {
+            return Ok(None);
+        };
+
+        let Some(obligations) = self.callable_impl_where_obligations(&mut selection, &impl_data)?
+        else {
+            return Ok(None);
+        };
+        if obligations.iter().any(|obligation| {
+            !matches!(
+                selection.table.resolve_root_var(&obligation.self_ty),
+                InferTy::Closure(_)
+            )
+        }) {
+            return Ok(None);
+        }
+
+        let previous_table = inference.table.clone();
+        inference.table = selection.table;
+        for obligation in obligations {
+            if !BodyCallableGoalSolver::new(self.context).solve_fn_trait_goal(
+                inference,
+                &obligation.self_ty,
+                &obligation.params,
+                &obligation.ret,
+            )? {
+                inference.table = previous_table;
+                return Ok(None);
+            }
+        }
+
+        Ok(Some(projected_ty))
+    }
+
+    fn bind_missing_impl_type_params(
+        &self,
+        selection: &mut TraitSelection,
+        generics: &GenericParams,
+    ) {
+        for param in &generics.types {
+            if selection.subst.type_param(param.name.as_str()).is_some() {
+                continue;
+            }
+            let ty = selection.table.new_type_var();
+            selection
+                .subst
+                .push(&mut selection.table, param.name.clone(), ty);
+        }
+    }
+
+    fn callable_impl_where_obligations(
+        &self,
+        selection: &mut TraitSelection,
+        impl_data: &ImplData,
+    ) -> Result<Option<Vec<CallableImplWhereObligation>>, PackageStoreError> {
+        let context = TypePathContext {
+            module: impl_data.owner,
+            impl_ref: Some(selection.trait_impl.impl_ref),
+        };
+        let resolver = self
+            .context
+            .type_refs(TypeRefUseSite::OwnerContext(context));
+
+        let mut supports = Vec::new();
+        let mut callable_predicates = Vec::new();
+        for predicate in &impl_data.generics.where_predicates {
+            let WherePredicate::Type { ty, bounds } = predicate else {
+                return Ok(None);
+            };
+            if bounds.is_empty() {
+                return Ok(None);
+            }
+
+            let callable_expectations = bounds
+                .iter()
+                .map(|bound| match bound {
+                    TypeBound::Trait(bound_ty) => {
+                        CallableTypeRefExpectation::from_fn_trait_bound(bound_ty)
+                    }
+                    TypeBound::Lifetime(_) | TypeBound::Unsupported(_) => None,
+                })
+                .collect::<Option<Vec<_>>>();
+            if let Some(expectations) = callable_expectations {
+                callable_predicates.push((ty, expectations));
+                continue;
+            }
+
+            let Some(support) =
+                self.impl_where_projection_support(selection, &resolver, ty, bounds)?
+            else {
+                return Ok(None);
+            };
+            supports.push(support);
+        }
+
+        // Only two predicate families are accepted in this shallow projection path:
+        // callable predicates that can solve closure-return generics, and support predicates used
+        // by those callable predicates to project `S::Item`-style inputs. Anything left unused is
+        // a real extra obligation, so we keep the associated type unknown instead of ignoring it.
+        let mut obligations = Vec::new();
+
+        for (ty, expectations) in callable_predicates {
+            let Some(self_ty) =
+                self.project_callable_impl_obligation_ty(selection, &mut supports, &resolver, ty)?
+            else {
+                return Ok(None);
+            };
+            for expectation in expectations {
+                let mut params = Vec::new();
+                for param in expectation.params() {
+                    let Some(param) = self.project_callable_impl_obligation_ty(
+                        selection,
+                        &mut supports,
+                        &resolver,
+                        param,
+                    )?
+                    else {
+                        return Ok(None);
+                    };
+                    params.push(param);
+                }
+                let Some(ret) = self.project_callable_impl_obligation_ty(
+                    selection,
+                    &mut supports,
+                    &resolver,
+                    expectation.return_ty(),
+                )?
+                else {
+                    return Ok(None);
+                };
+                obligations.push(CallableImplWhereObligation {
+                    self_ty: self_ty.clone(),
+                    params,
+                    ret,
+                });
+            }
+        }
+
+        if supports.iter().any(|support| !support.used) {
+            return Ok(None);
+        }
+
+        Ok(Some(obligations))
+    }
+
+    fn impl_where_projection_support(
+        &self,
+        selection: &TraitSelection,
+        resolver: &TypeRefResolutionQuery<'query, D, I>,
+        ty: &TypeRef,
+        bounds: &[TypeBound],
+    ) -> Result<Option<ImplWhereProjectionSupport>, PackageStoreError> {
+        if let Some(param_name) = ty.type_param_name()
+            && let Some(self_ty) = selection.subst.type_param(param_name.as_str())
+            && let [TypeBound::Trait(bound_ty)] = bounds
+            && CallableTypeRefExpectation::from_fn_trait_bound(bound_ty).is_none()
+            && let Some((trait_ref, resolved_args)) = resolver.resolve_trait_bound(bound_ty)?
+            && let TypeRef::Path(bound_path) = bound_ty
+            && let Some(segment) = bound_path.segments.last()
+            && segment.args.len() == resolved_args.len()
+        {
+            let args = segment
+                .args
+                .iter()
+                .zip(&resolved_args)
+                .map(|(arg, resolved_arg)| {
+                    InferTypeRefProjector::new(&selection.subst)
+                        .generic_arg_from_arg(arg, resolved_arg)
+                })
+                .collect();
+            return Ok(Some(ImplWhereProjectionSupport {
+                param_name,
+                goal: TraitGoal {
+                    self_ty,
+                    trait_ref,
+                    args,
+                },
+                used: false,
+            }));
+        }
+
+        Ok(None)
+    }
+
+    fn project_callable_impl_obligation_ty(
+        &self,
+        selection: &mut TraitSelection,
+        supports: &mut [ImplWhereProjectionSupport],
+        resolver: &TypeRefResolutionQuery<'query, D, I>,
+        ty: &TypeRef,
+    ) -> Result<Option<InferTy>, PackageStoreError> {
+        if let Some((param_name, assoc_name)) = ty.as_type_param_assoc_path()
+            && selection.subst.type_param(param_name.as_str()).is_some()
+        {
+            return self
+                .project_impl_generic_associated_ty(selection, supports, param_name, assoc_name);
+        }
+
+        if let TypeRef::Reference {
+            mutability, inner, ..
+        } = ty
+        {
+            let Some(inner_ty) =
+                self.project_callable_impl_obligation_ty(selection, supports, resolver, inner)?
+            else {
+                return Ok(None);
+            };
+            return Ok(Some(InferTy::Reference {
+                mutability: *mutability,
+                inner: Box::new(inner_ty),
+            }));
+        }
+
+        self.project_impl_obligation_ty(selection, resolver, ty)
+            .map(Some)
+    }
+
+    fn project_impl_generic_associated_ty(
+        &self,
+        selection: &mut TraitSelection,
+        supports: &mut [ImplWhereProjectionSupport],
+        param_name: &Name,
+        assoc_name: &Name,
+    ) -> Result<Option<InferTy>, PackageStoreError> {
+        // `S::Item` is useful only if some support predicate proves which `Stream` impl applies
+        // to `S`. We probe those predicates in the same trial table as the outer impl selection,
+        // so any inference refinements stay local until the whole projection succeeds.
+        let mut candidate = None;
+        let assoc_projector = SelectedTraitAssocProjector::new(self.context);
+
+        for (support_idx, support) in supports.iter().enumerate() {
+            if support.param_name.as_str() == param_name.as_str()
+                && let ExpectedUnique::One(support_selection) =
+                    self.probe_trait_goal_in_table(&support.goal, &selection.table)?
+                && let Some(projected_ty) = assoc_projector.project_associated_type_from_selection(
+                    &support_selection,
+                    assoc_name.as_str(),
+                )?
+            {
+                if candidate.is_some() {
+                    return Ok(None);
+                }
+                candidate = Some((support_idx, support_selection, projected_ty));
+            }
+        }
+
+        let Some((support_idx, support_selection, projected_ty)) = candidate else {
+            return Ok(None);
+        };
+        selection.table = support_selection.table;
+        supports[support_idx].used = true;
+        Ok(Some(projected_ty))
+    }
+
+    fn project_impl_obligation_ty(
+        &self,
+        selection: &TraitSelection,
+        resolver: &TypeRefResolutionQuery<'query, D, I>,
+        ty: &TypeRef,
+    ) -> Result<InferTy, PackageStoreError> {
+        let resolved_ty = resolver.resolve(ty)?;
+        Ok(InferTypeRefProjector::new(&selection.subst).ty_from_type_ref(ty, &resolved_ty))
+    }
+}

--- a/crates/engine/body-ir/src/resolution/infer/trait_obligation/mod.rs
+++ b/crates/engine/body-ir/src/resolution/infer/trait_obligation/mod.rs
@@ -1,0 +1,68 @@
+//! Trait-obligation solving that is allowed to interact with body inference.
+//!
+//! This layer is intentionally between Body IR and `rg_ty::TraitSelectionQuery`: it understands
+//! where bounds were written and can commit inference-table changes, but the actual impl matching
+//! still lives in the shared type layer.
+//!
+//! There are two related flows here:
+//!
+//! - selected-call obligations, such as `where B: FromIterator<Self::Item>` on a selected method;
+//! - selected-impl associated alias projection, such as projecting `Self::Item` through an impl
+//!   whose where-clause contains `F: FnMut(S::Item) -> B`.
+//!
+//! Both flows need the same body-local trait probing and inference-table commit semantics, so they
+//! share this facade. The detailed steps live in child modules so each file can read as one story.
+
+mod assoc_projection;
+mod selected_call;
+
+use rg_ir_storage::{DefMapSource, ItemStoreSource};
+use rg_package_store::PackageStoreError;
+use rg_std::ExpectedUnique;
+use rg_ty::{TraitGoal, TraitSelection, TraitSelectionQuery, inference::InferenceTable};
+
+use crate::resolution::BodyResolutionContext;
+
+use super::BodyInferenceCtx;
+
+pub(super) use selected_call::SelectedCallObligationInput;
+
+/// Solves bounded trait obligations while preserving inference-table semantics.
+pub(super) struct BodyTraitObligationSolver<'query, D, I> {
+    context: BodyResolutionContext<'query, D, I>,
+}
+
+impl<'query, D, I> BodyTraitObligationSolver<'query, D, I>
+where
+    D: DefMapSource<Error = PackageStoreError> + Copy,
+    I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
+{
+    pub(super) fn new(context: BodyResolutionContext<'query, D, I>) -> Self {
+        Self { context }
+    }
+
+    /// Probe a trait goal using the target lookup index persisted with Body IR.
+    ///
+    /// Keeping this as probe mode matters: callers decide when an `ExpectedUnique::One` result is
+    /// strong enough to commit the returned inference table.
+    fn probe_trait_goal(
+        &self,
+        goal: &TraitGoal,
+        inference: &BodyInferenceCtx,
+    ) -> Result<ExpectedUnique<TraitSelection>, PackageStoreError> {
+        self.probe_trait_goal_in_table(goal, &inference.table)
+    }
+
+    fn probe_trait_goal_in_table(
+        &self,
+        goal: &TraitGoal,
+        table: &InferenceTable,
+    ) -> Result<ExpectedUnique<TraitSelection>, PackageStoreError> {
+        TraitSelectionQuery::with_index(
+            self.context.item_paths(),
+            self.context.target_items(),
+            self.context.semantic_index(),
+        )
+        .probe(goal, table)
+    }
+}

--- a/crates/engine/body-ir/src/resolution/infer/trait_obligation/selected_call.rs
+++ b/crates/engine/body-ir/src/resolution/infer/trait_obligation/selected_call.rs
@@ -6,23 +6,23 @@
 
 use rg_ir_model::{
     FunctionRef, ItemOwner,
-    items::{GenericArg as ItemGenericArg, GenericParams, TypeBound, TypeRef, WherePredicate},
+    items::{GenericParams, TypeBound, TypeRef, WherePredicate},
 };
 use rg_ir_storage::{DefMapSource, ItemStoreSource};
 use rg_package_store::PackageStoreError;
 use rg_std::ExpectedUnique;
 use rg_ty::{
-    GenericArg, TraitGoal, Ty, TypeSubst,
-    inference::{InferGenericArg, InferTy, InferTypeRefProjector, InferTypeSubst},
+    TraitGoal, Ty, TypeSubst,
+    inference::{InferTy, InferTypeSubst},
 };
 
 use crate::resolution::{
     TypeRefUseSite,
     query::TypeRefResolutionQuery,
-    support::{CallableTypeRefExpectation, SelectedTraitMethodContext, self_associated_type_name},
+    support::{CallableTypeRefExpectation, SelectedTraitMethodContext},
 };
 
-use super::super::{BodyCallableGoalSolver, BodyInferenceCtx};
+use super::super::{BodyCallableGoalSolver, BodyInferenceCtx, projection::BodyTypeRefProjector};
 use super::BodyTraitObligationSolver;
 
 /// Signature facts from an already-selected call that can expose trait obligations.
@@ -118,13 +118,21 @@ where
             let WherePredicate::Type { ty, bounds } = predicate else {
                 continue;
             };
-            let subject_ty = self.project_obligation_ty(
-                inference,
-                input.subst,
-                &bound_resolver,
-                selected_trait_method.as_ref(),
-                ty,
-            )?;
+            let subject_ty = {
+                let mut self_assoc = |assoc_name: &str| {
+                    let Some(selected_trait_method) = selected_trait_method.as_ref() else {
+                        return Ok(None);
+                    };
+                    self.project_selected_trait_associated_alias(
+                        inference,
+                        selected_trait_method,
+                        assoc_name,
+                    )
+                };
+                let mut projector = BodyTypeRefProjector::new(input.subst, &bound_resolver)
+                    .with_self_associated_ty(&mut self_assoc);
+                projector.ty_or_fallback(ty)?
+            };
             for bound in bounds {
                 self.solve_trait_bound_obligation(
                     inference,
@@ -138,29 +146,6 @@ where
         }
 
         Ok(())
-    }
-
-    /// Project the subject type of a where-predicate into inference form.
-    ///
-    /// For `where B: FromIterator<T>`, this returns the current binding for `B`, such as
-    /// `Vec<?T>`. For a selected trait method, it can also turn an exact `Self::Item` subject into
-    /// the associated type from the uniquely matched receiver impl.
-    fn project_obligation_ty(
-        &self,
-        inference: &mut BodyInferenceCtx,
-        subst: &InferTypeSubst,
-        resolver: &TypeRefResolutionQuery<'query, D, I>,
-        selected_trait_method: Option<&SelectedTraitMethodContext<'_>>,
-        ty: &TypeRef,
-    ) -> Result<InferTy, PackageStoreError> {
-        if let Some(projected_ty) =
-            self.project_selected_trait_associated_ty(inference, selected_trait_method, ty)?
-        {
-            return Ok(projected_ty);
-        }
-
-        let resolved_ty = resolver.resolve(ty)?;
-        Ok(InferTypeRefProjector::new(subst).ty_from_type_ref(ty, &resolved_ty))
     }
 
     /// Solve one trait bound after the subject type is already known.
@@ -204,20 +189,26 @@ where
             return Ok(());
         }
 
-        let args = segment
-            .args
-            .iter()
-            .zip(&resolved_args)
-            .map(|(arg, resolved_arg)| {
-                self.project_obligation_generic_arg(
+        let args = {
+            let mut self_assoc = |assoc_name: &str| {
+                let Some(selected_trait_method) = selected_trait_method else {
+                    return Ok(None);
+                };
+                self.project_selected_trait_associated_alias(
                     inference,
-                    subst,
                     selected_trait_method,
-                    arg,
-                    resolved_arg,
+                    assoc_name,
                 )
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+            };
+            let mut projector =
+                BodyTypeRefProjector::new(subst, resolver).with_self_associated_ty(&mut self_assoc);
+            segment
+                .args
+                .iter()
+                .zip(&resolved_args)
+                .map(|(arg, resolved_arg)| projector.generic_arg_or_fallback(arg, resolved_arg))
+                .collect::<Result<Vec<_>, _>>()?
+        };
         let goal = TraitGoal {
             self_ty,
             trait_ref,
@@ -268,94 +259,29 @@ where
             return Ok(false);
         }
 
-        let params = expectation
-            .params()
-            .iter()
-            .map(|param| {
-                self.project_obligation_ty(inference, subst, resolver, selected_trait_method, param)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        let ret = self.project_obligation_ty(
-            inference,
-            subst,
-            resolver,
-            selected_trait_method,
-            expectation.return_ty(),
-        )?;
+        let (params, ret) = {
+            let mut self_assoc = |assoc_name: &str| {
+                let Some(selected_trait_method) = selected_trait_method else {
+                    return Ok(None);
+                };
+                self.project_selected_trait_associated_alias(
+                    inference,
+                    selected_trait_method,
+                    assoc_name,
+                )
+            };
+            let mut projector =
+                BodyTypeRefProjector::new(subst, resolver).with_self_associated_ty(&mut self_assoc);
+            let params = expectation
+                .params()
+                .iter()
+                .map(|param| projector.ty_or_fallback(param))
+                .collect::<Result<Vec<_>, _>>()?;
+            let ret = projector.ty_or_fallback(expectation.return_ty())?;
+            (params, ret)
+        };
 
         BodyCallableGoalSolver::new(self.context)
             .solve_fn_trait_goal(inference, self_ty, &params, &ret)
-    }
-
-    /// Project a trait-bound generic argument while preserving inference variables.
-    ///
-    /// Most args use the ordinary `InferTypeRefProjector`: `Vec<_>` stays `Vec<?T>`. The special
-    /// case is `Self::Item` from a selected trait method, which is replaced by the receiver impl's
-    /// associated type before matching the bound impl. Simple reference wrappers are preserved, so
-    /// `&Self::Item` can still project through bounds like `FnMut(&Self::Item)`.
-    fn project_obligation_generic_arg(
-        &self,
-        inference: &mut BodyInferenceCtx,
-        subst: &InferTypeSubst,
-        selected_trait_method: Option<&SelectedTraitMethodContext<'_>>,
-        arg: &ItemGenericArg,
-        resolved_arg: &GenericArg,
-    ) -> Result<InferGenericArg, PackageStoreError> {
-        if let (ItemGenericArg::Type(ty), GenericArg::Type(resolved_ty)) = (arg, resolved_arg) {
-            let projected_ty = match self.project_selected_trait_associated_ty(
-                inference,
-                selected_trait_method,
-                ty,
-            )? {
-                Some(ty) => ty,
-                None => InferTypeRefProjector::new(subst).ty_from_type_ref(ty, resolved_ty),
-            };
-            return Ok(InferGenericArg::Type(Box::new(projected_ty)));
-        }
-
-        Ok(InferTypeRefProjector::new(subst).generic_arg_from_arg(arg, resolved_arg))
-    }
-
-    /// Replace `Self::Assoc` with the associated type from a unique receiver impl.
-    ///
-    /// Example: for `Iterator::collect` on `Iter<User>`, this probes `Iter<User>: Iterator` and
-    /// reads `type Item = User` from the unique impl. Ambiguous receiver impls return `None` so
-    /// the outer obligation remains unsolved instead of guessing.
-    fn project_selected_trait_associated_ty(
-        &self,
-        inference: &mut BodyInferenceCtx,
-        selected_trait_method: Option<&SelectedTraitMethodContext<'_>>,
-        ty: &TypeRef,
-    ) -> Result<Option<InferTy>, PackageStoreError> {
-        let Some(selected_trait_method) = selected_trait_method else {
-            return Ok(None);
-        };
-        if let Some(assoc_name) = self_associated_type_name(ty) {
-            return self.project_selected_trait_associated_alias(
-                inference,
-                selected_trait_method,
-                assoc_name,
-            );
-        }
-
-        // Callable bounds often wrap associated types in references, e.g. `FnMut(&Self::Item)`.
-        // This is not autoderef: we only peel written reference wrappers until the inner type can
-        // be projected, then rebuild the same reference shape around the projected type.
-        if let TypeRef::Reference {
-            mutability, inner, ..
-        } = ty
-            && let Some(inner_ty) = self.project_selected_trait_associated_ty(
-                inference,
-                Some(selected_trait_method),
-                inner,
-            )?
-        {
-            return Ok(Some(InferTy::Reference {
-                mutability: *mutability,
-                inner: Box::new(inner_ty),
-            }));
-        }
-
-        Ok(None)
     }
 }

--- a/crates/engine/body-ir/src/resolution/infer/trait_obligation/selected_call.rs
+++ b/crates/engine/body-ir/src/resolution/infer/trait_obligation/selected_call.rs
@@ -1,33 +1,29 @@
-//! Trait-obligation solving that is allowed to interact with body inference.
+//! Trait obligations exposed by already-selected calls.
 //!
-//! This layer is intentionally between Body IR and `rg_ty::TraitSelectionQuery`: it understands
-//! where bounds were written and can commit inference-table changes, but the actual impl matching
-//! still lives in the shared type layer.
+//! Selected calls give us precise signature facts: which function was called, how its generics
+//! were instantiated, and which receiver type selected a trait method. This module turns those
+//! facts into shallow trait goals and commits only unique solutions back into body inference.
 
 use rg_ir_model::{
     FunctionRef, ItemOwner,
-    hir::items::ImplData,
     items::{GenericArg as ItemGenericArg, GenericParams, TypeBound, TypeRef, WherePredicate},
 };
-use rg_ir_storage::{DefMapSource, ItemStoreSource, TypePathContext};
+use rg_ir_storage::{DefMapSource, ItemStoreSource};
 use rg_package_store::PackageStoreError;
 use rg_std::ExpectedUnique;
 use rg_ty::{
-    GenericArg, TraitGoal, TraitSelection, TraitSelectionOptions, TraitSelectionQuery, Ty,
-    TypeSubst,
+    GenericArg, TraitGoal, Ty, TypeSubst,
     inference::{InferGenericArg, InferTy, InferTypeRefProjector, InferTypeSubst},
 };
 
 use crate::resolution::{
-    BodyResolutionContext, TypeRefUseSite,
+    TypeRefUseSite,
     query::TypeRefResolutionQuery,
-    support::{
-        CallableTypeRefExpectation, SelectedTraitAssocProjector, SelectedTraitMethodContext,
-        self_associated_type_name,
-    },
+    support::{CallableTypeRefExpectation, SelectedTraitMethodContext, self_associated_type_name},
 };
 
-use super::{BodyCallableGoalSolver, BodyInferenceCtx};
+use super::super::{BodyCallableGoalSolver, BodyInferenceCtx};
+use super::BodyTraitObligationSolver;
 
 /// Signature facts from an already-selected call that can expose trait obligations.
 ///
@@ -40,24 +36,33 @@ use super::{BodyCallableGoalSolver, BodyInferenceCtx};
 /// - `subst`: inference bindings such as `B = Vec<?T>`;
 /// - `signature_subst`: ordinary signature substitutions used to resolve written paths;
 /// - `selected_self_ty`: the receiver iterator type, such as `Iter<BarItem>`.
-pub(super) struct SelectedCallObligationInput<'input> {
-    pub(super) function: FunctionRef,
-    pub(super) owner: ItemOwner,
-    pub(super) generics: &'input GenericParams,
-    pub(super) subst: &'input InferTypeSubst,
-    pub(super) signature_subst: &'input TypeSubst,
-    pub(super) selected_self_ty: Option<&'input Ty>,
+pub(crate) struct SelectedCallObligationInput<'input> {
+    function: FunctionRef,
+    owner: ItemOwner,
+    generics: &'input GenericParams,
+    subst: &'input InferTypeSubst,
+    signature_subst: &'input TypeSubst,
+    selected_self_ty: Option<&'input Ty>,
 }
 
-struct CallableImplWhereObligation {
-    self_ty: InferTy,
-    params: Vec<InferTy>,
-    ret: InferTy,
-}
-
-/// Solves bounded trait obligations while preserving inference-table semantics.
-pub(super) struct BodyTraitObligationSolver<'query, D, I> {
-    context: BodyResolutionContext<'query, D, I>,
+impl<'input> SelectedCallObligationInput<'input> {
+    pub(crate) fn new(
+        function: FunctionRef,
+        owner: ItemOwner,
+        generics: &'input GenericParams,
+        subst: &'input InferTypeSubst,
+        signature_subst: &'input TypeSubst,
+        selected_self_ty: Option<&'input Ty>,
+    ) -> Self {
+        Self {
+            function,
+            owner,
+            generics,
+            subst,
+            signature_subst,
+            selected_self_ty,
+        }
+    }
 }
 
 impl<'query, D, I> BodyTraitObligationSolver<'query, D, I>
@@ -65,16 +70,12 @@ where
     D: DefMapSource<Error = PackageStoreError> + Copy,
     I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
 {
-    pub(super) fn new(context: BodyResolutionContext<'query, D, I>) -> Self {
-        Self { context }
-    }
-
     /// Solve obligations exposed by one already-selected generic call.
     ///
     /// Continuing `bar.iter().collect::<Vec<_>>()`, this lowers collect's where-clause into the
     /// goal `Vec<?T>: FromIterator<IterItem>` and commits the resulting `?T = IterItem` only when
     /// exactly one visible impl proves the goal.
-    pub(super) fn solve_selected_call(
+    pub(crate) fn solve_selected_call(
         &self,
         inference: &mut BodyInferenceCtx,
         input: SelectedCallObligationInput<'_>,
@@ -356,172 +357,5 @@ where
         }
 
         Ok(None)
-    }
-
-    /// Project `Self::Assoc` from the selected receiver impl, including shallow callable where
-    /// clauses that can solve impl-only generics.
-    ///
-    /// Example:
-    ///
-    /// ```text
-    /// impl<F, R> Produces for Adapter<F>
-    /// where
-    ///     F: FnOnce() -> R,
-    /// {
-    ///     type Output = R;
-    /// }
-    /// ```
-    ///
-    /// Matching `Adapter<Closure#n>: Produces` binds `F = Closure#n`, but `R` only appears in the
-    /// where-clause and alias. We give `R` a fresh slot, solve the callable where-clause from the
-    /// closure body, and then project `type Output = R`.
-    pub(super) fn project_selected_trait_associated_alias(
-        &self,
-        inference: &mut BodyInferenceCtx,
-        selected_trait_method: &SelectedTraitMethodContext<'_>,
-        assoc_name: &str,
-    ) -> Result<Option<InferTy>, PackageStoreError> {
-        let assoc_projector = SelectedTraitAssocProjector::new(self.context);
-        let Some(mut selection) = assoc_projector.select_infer_trait_impl(
-            selected_trait_method,
-            &inference.table,
-            TraitSelectionOptions::new().ignore_where_predicates(),
-        )?
-        else {
-            return Ok(None);
-        };
-        let Some(impl_data) = self
-            .context
-            .item_query()
-            .impl_data(selection.trait_impl.impl_ref)?
-            .cloned()
-        else {
-            return Ok(None);
-        };
-
-        self.bind_missing_impl_type_params(&mut selection, &impl_data.generics);
-        let Some(projected_ty) =
-            assoc_projector.project_associated_type_from_selection(&selection, assoc_name)?
-        else {
-            return Ok(None);
-        };
-
-        let Some(obligations) = self.callable_impl_where_obligations(&selection, &impl_data)?
-        else {
-            return Ok(None);
-        };
-        if obligations.iter().any(|obligation| {
-            !matches!(
-                selection.table.resolve_root_var(&obligation.self_ty),
-                InferTy::Closure(_)
-            )
-        }) {
-            return Ok(None);
-        }
-
-        let previous_table = inference.table.clone();
-        inference.table = selection.table;
-        for obligation in obligations {
-            if !BodyCallableGoalSolver::new(self.context).solve_fn_trait_goal(
-                inference,
-                &obligation.self_ty,
-                &obligation.params,
-                &obligation.ret,
-            )? {
-                inference.table = previous_table;
-                return Ok(None);
-            }
-        }
-
-        Ok(Some(projected_ty))
-    }
-
-    fn bind_missing_impl_type_params(
-        &self,
-        selection: &mut TraitSelection,
-        generics: &GenericParams,
-    ) {
-        for param in &generics.types {
-            if selection.subst.type_param(param.name.as_str()).is_some() {
-                continue;
-            }
-            let ty = selection.table.new_type_var();
-            selection
-                .subst
-                .push(&mut selection.table, param.name.clone(), ty);
-        }
-    }
-
-    fn callable_impl_where_obligations(
-        &self,
-        selection: &TraitSelection,
-        impl_data: &ImplData,
-    ) -> Result<Option<Vec<CallableImplWhereObligation>>, PackageStoreError> {
-        let context = TypePathContext {
-            module: impl_data.owner,
-            impl_ref: Some(selection.trait_impl.impl_ref),
-        };
-        let resolver = self
-            .context
-            .type_refs(TypeRefUseSite::OwnerContext(context));
-        let mut obligations = Vec::new();
-
-        for predicate in &impl_data.generics.where_predicates {
-            let WherePredicate::Type { ty, bounds } = predicate else {
-                return Ok(None);
-            };
-            let self_ty = self.project_impl_obligation_ty(selection, &resolver, ty)?;
-            for bound in bounds {
-                let TypeBound::Trait(bound_ty) = bound else {
-                    return Ok(None);
-                };
-                let Some(expectation) = CallableTypeRefExpectation::from_fn_trait_bound(bound_ty)
-                else {
-                    return Ok(None);
-                };
-
-                let params = expectation
-                    .params()
-                    .iter()
-                    .map(|param| self.project_impl_obligation_ty(selection, &resolver, param))
-                    .collect::<Result<Vec<_>, _>>()?;
-                let ret =
-                    self.project_impl_obligation_ty(selection, &resolver, expectation.return_ty())?;
-                obligations.push(CallableImplWhereObligation {
-                    self_ty: self_ty.clone(),
-                    params,
-                    ret,
-                });
-            }
-        }
-
-        Ok(Some(obligations))
-    }
-
-    fn project_impl_obligation_ty(
-        &self,
-        selection: &TraitSelection,
-        resolver: &TypeRefResolutionQuery<'query, D, I>,
-        ty: &TypeRef,
-    ) -> Result<InferTy, PackageStoreError> {
-        let resolved_ty = resolver.resolve(ty)?;
-        Ok(InferTypeRefProjector::new(&selection.subst).ty_from_type_ref(ty, &resolved_ty))
-    }
-
-    /// Probe a trait goal using the target lookup index persisted with Body IR.
-    ///
-    /// Keeping this as probe mode matters: callers decide when an `ExpectedUnique::One` result is
-    /// strong enough to commit the returned inference table.
-    fn probe_trait_goal(
-        &self,
-        goal: &TraitGoal,
-        inference: &BodyInferenceCtx,
-    ) -> Result<ExpectedUnique<TraitSelection>, PackageStoreError> {
-        TraitSelectionQuery::with_index(
-            self.context.item_paths(),
-            self.context.target_items(),
-            self.context.semantic_index(),
-        )
-        .probe(goal, &inference.table)
     }
 }

--- a/crates/engine/body-ir/src/resolution/pass/inference.rs
+++ b/crates/engine/body-ir/src/resolution/pass/inference.rs
@@ -64,11 +64,29 @@ where
         Ok(())
     }
 
-    /// Instantiate inference-only facts that ordinary `Ty` cannot represent.
+    /// Instantiate facts that need the inference pass to add body-local identity or slots.
     fn instantiate_inference_facts(&mut self) -> Result<(), PackageStoreError> {
+        // TODO: These could be one body walk, but later instantiation steps can depend on facts
+        // from earlier ones. For example, call instantiation may eventually need closure
+        // witnesses to exist before processing a call argument. We keep the passes explicit until
+        // this code is more mature and there is a clearer reason to optimize the extra scans.
+        self.instantiate_closure_type_facts();
         self.instantiate_generic_call_result_facts()?;
         self.instantiate_record_result_facts();
         Ok(())
+    }
+
+    /// Give every closure expression its own anonymous body-local type.
+    fn instantiate_closure_type_facts(&mut self) {
+        for expr_idx in 0..self.pass.body.exprs().len() {
+            let expr = ExprId(expr_idx);
+            if matches!(
+                &self.pass.body.expr_unchecked(expr).kind,
+                ExprKind::Closure { .. }
+            ) {
+                self.pass.inference.set_expr_closure_ty(expr);
+            }
+        }
     }
 
     /// Turn generic call results such as `Vec<T>` or `Option<T>` into `Vec<?T>` / `Option<?T>`.

--- a/crates/engine/body-ir/src/resolution/pass/inference.rs
+++ b/crates/engine/body-ir/src/resolution/pass/inference.rs
@@ -24,7 +24,7 @@ use crate::{
     resolution::{
         TypeRefUseSite,
         infer::{BodyCallInference, BodyMemberInference, BodyPatternInference},
-        support::direct_callable_arg_expectations,
+        support::callable_arg_expectations,
     },
 };
 
@@ -378,14 +378,14 @@ where
         )
     }
 
-    /// Use direct callable return syntax to constrain matching closure bodies.
+    /// Use callable return syntax to constrain matching closure bodies.
     ///
     /// Parameter expectations run earlier because they can affect method lookup
     /// inside the closure body. Return expectations are different: by this
     /// point the closure body has already been selected and shaped, so this hook
-    /// only pushes a concrete `impl FnOnce(...) -> User` result into the body
-    /// expression and lets normal result-expression propagation do the rest.
-    fn constrain_direct_closure_return_expected_types(
+    /// only pushes a concrete `FnOnce(...) -> User` result into the body expression
+    /// and lets normal result-expression propagation do the rest.
+    fn constrain_closure_return_expected_types(
         &mut self,
         call: ExprId,
         args: &[ExprId],
@@ -397,7 +397,7 @@ where
             // Collect first while the read-only body context is alive, then
             // apply constraints after it is dropped and the inference table can
             // be mutably borrowed.
-            for (arg, expectation) in direct_callable_arg_expectations(context, call, args)? {
+            for (arg, expectation) in callable_arg_expectations(context, call, args)? {
                 let ExprKind::Closure {
                     body: Some(body), ..
                 } = context.body().expr_unchecked(arg).kind.clone()
@@ -405,9 +405,9 @@ where
                     continue;
                 };
 
-                // Direct generic returns such as `<unknown>` are not useful as
-                // concrete expectations. Shared return variables need a
-                // callable-bound expectation that preserves inference slots.
+                // Generic returns such as `<unknown>` are not useful as concrete expectations.
+                // Shared return variables need a callable-bound expectation that preserves
+                // inference slots.
                 if expectation.return_ty.has_unknown() {
                     continue;
                 }
@@ -545,7 +545,7 @@ where
                 args,
             } => {
                 self.constrain_call_target_argument_expected_types(expr, &args)?;
-                self.constrain_direct_closure_return_expected_types(expr, &args)?;
+                self.constrain_closure_return_expected_types(expr, &args)?;
                 self.solve_call_target_generic_trait_obligations(expr, &args, None)?;
                 self.constrain_enum_variant_payload_expected_types(expr, callee, args)
             }
@@ -555,7 +555,7 @@ where
                 ..
             } => {
                 self.constrain_call_target_argument_expected_types(expr, &args)?;
-                self.constrain_direct_closure_return_expected_types(expr, &args)?;
+                self.constrain_closure_return_expected_types(expr, &args)?;
 
                 let context = self.pass.providers.context(self.pass.body);
                 BodyCallInference::new(context).constrain_selected_method_receiver_and_arguments(
@@ -568,7 +568,7 @@ where
             }
             ExprKind::MethodCall { args, .. } => {
                 self.constrain_call_target_argument_expected_types(expr, &args)?;
-                self.constrain_direct_closure_return_expected_types(expr, &args)?;
+                self.constrain_closure_return_expected_types(expr, &args)?;
                 self.solve_call_target_generic_trait_obligations(expr, &args, None)
             }
             ExprKind::Record { fields, .. } => {

--- a/crates/engine/body-ir/src/resolution/pass/inference.rs
+++ b/crates/engine/body-ir/src/resolution/pass/inference.rs
@@ -428,6 +428,21 @@ where
         )
     }
 
+    fn project_selected_trait_associated_return_type(
+        &mut self,
+        call: ExprId,
+        args: &[ExprId],
+        receiver: Option<ExprId>,
+    ) -> Result<(), PackageStoreError> {
+        let context = self.pass.providers.context(self.pass.body);
+        BodyCallInference::new(context).project_selected_trait_associated_return_type(
+            &mut self.pass.inference,
+            call,
+            args,
+            receiver,
+        )
+    }
+
     /// Visit all places that can provide expected types to already-created inference slots.
     fn constrain_expected_types(&mut self) -> Result<(), PackageStoreError> {
         for statement_idx in 0..self.pass.body.statements().len() {
@@ -534,6 +549,7 @@ where
             } => {
                 self.constrain_call_target_argument_expected_types(expr, &args)?;
                 self.solve_direct_callable_closure_arguments(expr, &args)?;
+                self.project_selected_trait_associated_return_type(expr, &args, None)?;
                 self.solve_call_target_generic_trait_obligations(expr, &args, None)?;
                 self.constrain_enum_variant_payload_expected_types(expr, callee, args)
             }
@@ -552,11 +568,13 @@ where
                     receiver,
                     &args,
                 )?;
+                self.project_selected_trait_associated_return_type(expr, &args, Some(receiver))?;
                 self.solve_call_target_generic_trait_obligations(expr, &args, Some(receiver))
             }
             ExprKind::MethodCall { args, .. } => {
                 self.constrain_call_target_argument_expected_types(expr, &args)?;
                 self.solve_direct_callable_closure_arguments(expr, &args)?;
+                self.project_selected_trait_associated_return_type(expr, &args, None)?;
                 self.solve_call_target_generic_trait_obligations(expr, &args, None)
             }
             ExprKind::Record { fields, .. } => {

--- a/crates/engine/body-ir/src/resolution/pass/inference.rs
+++ b/crates/engine/body-ir/src/resolution/pass/inference.rs
@@ -24,7 +24,6 @@ use crate::{
     resolution::{
         TypeRefUseSite,
         infer::{BodyCallInference, BodyMemberInference, BodyPatternInference},
-        support::callable_arg_expectations,
     },
 };
 
@@ -381,48 +380,20 @@ where
     /// Use callable return syntax to constrain matching closure bodies.
     ///
     /// Parameter expectations run earlier because they can affect method lookup
-    /// inside the closure body. Return expectations are different: by this
-    /// point the closure body has already been selected and shaped, so this hook
-    /// only pushes a concrete `FnOnce(...) -> User` result into the body expression
-    /// and lets normal result-expression propagation do the rest.
+    /// inside the closure body. Return expectations are different: this final
+    /// inference hook can preserve shared slots such as `?R`, so closure body
+    /// evidence can solve the selected call result.
     fn constrain_closure_return_expected_types(
         &mut self,
         call: ExprId,
         args: &[ExprId],
     ) -> Result<(), PackageStoreError> {
-        let expected_returns = {
-            let context = self.pass.context();
-            let mut expected_returns = Vec::new();
-
-            // Collect first while the read-only body context is alive, then
-            // apply constraints after it is dropped and the inference table can
-            // be mutably borrowed.
-            for (arg, expectation) in callable_arg_expectations(context, call, args)? {
-                let ExprKind::Closure {
-                    body: Some(body), ..
-                } = context.body().expr_unchecked(arg).kind.clone()
-                else {
-                    continue;
-                };
-
-                // Generic returns such as `<unknown>` are not useful as concrete expectations.
-                // Shared return variables need a callable-bound expectation that preserves
-                // inference slots.
-                if expectation.return_ty.has_unknown() {
-                    continue;
-                }
-
-                expected_returns.push((body, expectation.return_ty));
-            }
-
-            expected_returns
-        };
-
-        for (body, expected_ty) in expected_returns {
-            self.constrain_expr_with_expected(body, &expected_ty);
-        }
-
-        Ok(())
+        let context = self.pass.providers.context(self.pass.body);
+        BodyCallInference::new(context).constrain_closure_return_expected_types(
+            &mut self.pass.inference,
+            call,
+            args,
+        )
     }
 
     fn solve_call_target_generic_trait_obligations(

--- a/crates/engine/body-ir/src/resolution/pass/inference.rs
+++ b/crates/engine/body-ir/src/resolution/pass/inference.rs
@@ -24,6 +24,7 @@ use crate::{
     resolution::{
         TypeRefUseSite,
         infer::{BodyCallInference, BodyMemberInference, BodyPatternInference},
+        support::direct_callable_arg_expectations,
     },
 };
 
@@ -377,6 +378,53 @@ where
         )
     }
 
+    /// Use direct callable return syntax to constrain matching closure bodies.
+    ///
+    /// Parameter expectations run earlier because they can affect method lookup
+    /// inside the closure body. Return expectations are different: by this
+    /// point the closure body has already been selected and shaped, so this hook
+    /// only pushes a concrete `impl FnOnce(...) -> User` result into the body
+    /// expression and lets normal result-expression propagation do the rest.
+    fn constrain_direct_closure_return_expected_types(
+        &mut self,
+        call: ExprId,
+        args: &[ExprId],
+    ) -> Result<(), PackageStoreError> {
+        let expected_returns = {
+            let context = self.pass.context();
+            let mut expected_returns = Vec::new();
+
+            // Collect first while the read-only body context is alive, then
+            // apply constraints after it is dropped and the inference table can
+            // be mutably borrowed.
+            for (arg, expectation) in direct_callable_arg_expectations(context, call, args)? {
+                let ExprKind::Closure {
+                    body: Some(body), ..
+                } = context.body().expr_unchecked(arg).kind.clone()
+                else {
+                    continue;
+                };
+
+                // Direct generic returns such as `<unknown>` are not useful as
+                // concrete expectations. Shared return variables need a
+                // callable-bound expectation that preserves inference slots.
+                if expectation.return_ty.has_unknown() {
+                    continue;
+                }
+
+                expected_returns.push((body, expectation.return_ty));
+            }
+
+            expected_returns
+        };
+
+        for (body, expected_ty) in expected_returns {
+            self.constrain_expr_with_expected(body, &expected_ty);
+        }
+
+        Ok(())
+    }
+
     fn solve_call_target_generic_trait_obligations(
         &mut self,
         call: ExprId,
@@ -497,6 +545,7 @@ where
                 args,
             } => {
                 self.constrain_call_target_argument_expected_types(expr, &args)?;
+                self.constrain_direct_closure_return_expected_types(expr, &args)?;
                 self.solve_call_target_generic_trait_obligations(expr, &args, None)?;
                 self.constrain_enum_variant_payload_expected_types(expr, callee, args)
             }
@@ -506,6 +555,7 @@ where
                 ..
             } => {
                 self.constrain_call_target_argument_expected_types(expr, &args)?;
+                self.constrain_direct_closure_return_expected_types(expr, &args)?;
 
                 let context = self.pass.providers.context(self.pass.body);
                 BodyCallInference::new(context).constrain_selected_method_receiver_and_arguments(
@@ -518,6 +568,7 @@ where
             }
             ExprKind::MethodCall { args, .. } => {
                 self.constrain_call_target_argument_expected_types(expr, &args)?;
+                self.constrain_direct_closure_return_expected_types(expr, &args)?;
                 self.solve_call_target_generic_trait_obligations(expr, &args, None)
             }
             ExprKind::Record { fields, .. } => {

--- a/crates/engine/body-ir/src/resolution/pass/inference.rs
+++ b/crates/engine/body-ir/src/resolution/pass/inference.rs
@@ -101,17 +101,19 @@ where
                         &mut self.pass.inference,
                         expr,
                         &args,
+                        None,
                     )?;
                     if let Some(callee) = callee {
                         self.instantiate_enum_variant_call_result_fact(expr, callee);
                     }
                 }
-                ExprKind::MethodCall { args, .. } => {
+                ExprKind::MethodCall { receiver, args, .. } => {
                     let context = self.pass.providers.context(self.pass.body);
                     BodyCallInference::new(context).instantiate_return_fact(
                         &mut self.pass.inference,
                         expr,
                         &args,
+                        receiver,
                     )?;
                 }
                 _ => {}

--- a/crates/engine/body-ir/src/resolution/pass/inference.rs
+++ b/crates/engine/body-ir/src/resolution/pass/inference.rs
@@ -395,19 +395,18 @@ where
         )
     }
 
-    /// Use callable return syntax to constrain matching closure bodies.
+    /// Use inline `impl Fn*` syntax to solve matching closure arguments.
     ///
-    /// Parameter expectations run earlier because they can affect method lookup
-    /// inside the closure body. Return expectations are different: this final
-    /// inference hook can preserve shared slots such as `?R`, so closure body
-    /// evidence can solve the selected call result.
-    fn constrain_closure_return_expected_types(
+    /// Parameter expectations run earlier because they can affect method lookup inside the
+    /// closure body. This final inference hook exists for the inline `impl FnOnce(...) -> R`
+    /// shape: it can preserve shared slots such as `?R` and then reuse the callable-goal solver.
+    fn solve_direct_callable_closure_arguments(
         &mut self,
         call: ExprId,
         args: &[ExprId],
     ) -> Result<(), PackageStoreError> {
         let context = self.pass.providers.context(self.pass.body);
-        BodyCallInference::new(context).constrain_closure_return_expected_types(
+        BodyCallInference::new(context).solve_direct_callable_closure_arguments(
             &mut self.pass.inference,
             call,
             args,
@@ -534,7 +533,7 @@ where
                 args,
             } => {
                 self.constrain_call_target_argument_expected_types(expr, &args)?;
-                self.constrain_closure_return_expected_types(expr, &args)?;
+                self.solve_direct_callable_closure_arguments(expr, &args)?;
                 self.solve_call_target_generic_trait_obligations(expr, &args, None)?;
                 self.constrain_enum_variant_payload_expected_types(expr, callee, args)
             }
@@ -544,7 +543,7 @@ where
                 ..
             } => {
                 self.constrain_call_target_argument_expected_types(expr, &args)?;
-                self.constrain_closure_return_expected_types(expr, &args)?;
+                self.solve_direct_callable_closure_arguments(expr, &args)?;
 
                 let context = self.pass.providers.context(self.pass.body);
                 BodyCallInference::new(context).constrain_selected_method_receiver_and_arguments(
@@ -557,7 +556,7 @@ where
             }
             ExprKind::MethodCall { args, .. } => {
                 self.constrain_call_target_argument_expected_types(expr, &args)?;
-                self.constrain_closure_return_expected_types(expr, &args)?;
+                self.solve_direct_callable_closure_arguments(expr, &args)?;
                 self.solve_call_target_generic_trait_obligations(expr, &args, None)
             }
             ExprKind::Record { fields, .. } => {

--- a/crates/engine/body-ir/src/resolution/pass/pattern_type.rs
+++ b/crates/engine/body-ir/src/resolution/pass/pattern_type.rs
@@ -6,7 +6,7 @@
 
 use rg_ir_model::{
     BindingId, BodyPath, ExprId, Mutability, PatId, Path, PathSegment, ScopeId, StmtId, TypeDefId,
-    items::{FieldKey, GenericArg, TypeBound, TypeRef},
+    items::{FieldKey, TypeRef},
 };
 use rg_ir_storage::{DefMapSource, ItemStoreSource};
 use rg_package_store::PackageStoreError;
@@ -14,7 +14,9 @@ use rg_std::ExpectedUnique;
 use rg_ty::{ReferencePeelingCandidates, Ty};
 
 use crate::ir::{ExprKind, PatKind, RecordPatField, StmtKind};
-use crate::resolution::{BodyResolutionContext, TypeRefUseSite, query::TypeRefResolutionQuery};
+use crate::resolution::{
+    BodyResolutionContext, TypeRefUseSite, support::direct_callable_arg_expectations,
+};
 
 pub(super) struct PatternTypePropagationPass<'query, D, I> {
     context: BodyResolutionContext<'query, D, I>,
@@ -163,41 +165,19 @@ where
         args: &[ExprId],
         updates: &mut Vec<(BindingId, Ty)>,
     ) -> Result<(), PackageStoreError> {
-        let calls = self.context.calls();
-        let Some(target) = calls.target(call)? else {
-            return Ok(());
-        };
-        let projection = calls.signature(&target).project(args)?;
-        if projection.written_param_refs().len() != args.len() {
-            return Ok(());
-        }
-
-        let resolver = self
-            .context
-            .type_refs(TypeRefUseSite::Function(target.function()))
-            .with_subst(projection.subst());
-
-        for (arg, param_ty) in args.iter().zip(projection.written_param_refs()) {
-            let Some(param_ty) = param_ty else {
-                continue;
-            };
-            let Some(expected_params) = Self::direct_callable_param_tys(param_ty, &resolver)?
-            else {
-                continue;
-            };
-
+        for (arg, expectation) in direct_callable_arg_expectations(self.context, call, args)? {
             // Only direct closure arguments can receive callable parameter expectations here.
             // Other expression kinds still get ordinary call-argument expectations elsewhere.
             let ExprKind::Closure { params, .. } =
-                self.context.body().expr_unchecked(*arg).kind.clone()
+                self.context.body().expr_unchecked(arg).kind.clone()
             else {
                 continue;
             };
-            if params.len() != expected_params.len() {
+            if params.len() != expectation.params.len() {
                 continue;
             };
 
-            for (param, expected_ty) in params.iter().zip(&expected_params) {
+            for (param, expected_ty) in params.iter().zip(&expectation.params) {
                 let Some(pat) = param.pat else {
                     continue;
                 };
@@ -206,33 +186,6 @@ where
         }
 
         Ok(())
-    }
-
-    /// Extract one unambiguous parenthesized `Fn`, `FnMut`, or `FnOnce` argument list.
-    fn direct_callable_param_tys(
-        ty: &TypeRef,
-        resolver: &TypeRefResolutionQuery<'query, D, I>,
-    ) -> Result<Option<Vec<Ty>>, PackageStoreError> {
-        let TypeRef::ImplTrait(bounds) = ty else {
-            return Ok(None);
-        };
-
-        let mut candidates = ExpectedUnique::new();
-        for bound in bounds {
-            if let TypeBound::Trait(TypeRef::Path(path)) = bound
-                && let Some(segment) = path.segments.last()
-                && matches!(segment.name.as_str(), "Fn" | "FnMut" | "FnOnce")
-                && let [GenericArg::FnTraitArgs { params, .. }] = segment.args.as_slice()
-            {
-                let param_tys = params
-                    .iter()
-                    .map(|param| resolver.resolve(param))
-                    .collect::<Result<Vec<_>, _>>()?;
-                candidates.push(param_tys);
-            }
-        }
-
-        Ok(candidates.into_option())
     }
 
     fn expected_ty_for_let(

--- a/crates/engine/body-ir/src/resolution/pass/pattern_type.rs
+++ b/crates/engine/body-ir/src/resolution/pass/pattern_type.rs
@@ -6,7 +6,7 @@
 
 use rg_ir_model::{
     BindingId, BodyPath, ExprId, Mutability, PatId, Path, PathSegment, ScopeId, StmtId, TypeDefId,
-    items::{FieldKey, TypeRef},
+    items::{FieldKey, GenericArg, TypeBound, TypeRef},
 };
 use rg_ir_storage::{DefMapSource, ItemStoreSource};
 use rg_package_store::PackageStoreError;
@@ -14,7 +14,7 @@ use rg_std::ExpectedUnique;
 use rg_ty::{ReferencePeelingCandidates, Ty};
 
 use crate::ir::{ExprKind, PatKind, RecordPatField, StmtKind};
-use crate::resolution::{BodyResolutionContext, TypeRefUseSite};
+use crate::resolution::{BodyResolutionContext, TypeRefUseSite, query::TypeRefResolutionQuery};
 
 pub(super) struct PatternTypePropagationPass<'query, D, I> {
     context: BodyResolutionContext<'query, D, I>,
@@ -112,8 +112,10 @@ where
                         self.propagate_pat(pat, &expected_ty, &mut updates)?;
                     }
                 }
+                ExprKind::Call { args, .. } | ExprKind::MethodCall { args, .. } => {
+                    self.propagate_closure_arg_expectations(expr, &args, &mut updates)?;
+                }
                 ExprKind::Path { .. }
-                | ExprKind::Call { .. }
                 | ExprKind::Tuple { .. }
                 | ExprKind::Array { .. }
                 | ExprKind::RepeatArray { .. }
@@ -132,7 +134,6 @@ where
                 | ExprKind::Block { .. }
                 | ExprKind::Field { .. }
                 | ExprKind::Record { .. }
-                | ExprKind::MethodCall { .. }
                 | ExprKind::Wrapper { .. }
                 | ExprKind::BuiltinMacro { .. }
                 | ExprKind::Literal { .. }
@@ -146,6 +147,92 @@ where
         }
 
         Ok(updates)
+    }
+
+    /// Check if call has:
+    /// 1. `impl Fn*(...)` arguments in its target fn
+    /// 2. closures passed as arguments in matching positions.
+    ///
+    /// If so, propagate types from the (1) types to arguments in (2) closure.
+    ///
+    /// Example: we do `invoke(|a| a + 1)`, where `invoke` is `fn invoke(f: impl FnOnce(usize))`,
+    /// we match `f` to the closure and propagate `a` type to `usize`.
+    fn propagate_closure_arg_expectations(
+        &self,
+        call: ExprId,
+        args: &[ExprId],
+        updates: &mut Vec<(BindingId, Ty)>,
+    ) -> Result<(), PackageStoreError> {
+        let calls = self.context.calls();
+        let Some(target) = calls.target(call)? else {
+            return Ok(());
+        };
+        let projection = calls.signature(&target).project(args)?;
+        if projection.written_param_refs().len() != args.len() {
+            return Ok(());
+        }
+
+        let resolver = self
+            .context
+            .type_refs(TypeRefUseSite::Function(target.function()))
+            .with_subst(projection.subst());
+
+        for (arg, param_ty) in args.iter().zip(projection.written_param_refs()) {
+            let Some(param_ty) = param_ty else {
+                continue;
+            };
+            let Some(expected_params) = Self::direct_callable_param_tys(param_ty, &resolver)?
+            else {
+                continue;
+            };
+
+            // Only direct closure arguments can receive callable parameter expectations here.
+            // Other expression kinds still get ordinary call-argument expectations elsewhere.
+            let ExprKind::Closure { params, .. } =
+                self.context.body().expr_unchecked(*arg).kind.clone()
+            else {
+                continue;
+            };
+            if params.len() != expected_params.len() {
+                continue;
+            };
+
+            for (param, expected_ty) in params.iter().zip(&expected_params) {
+                let Some(pat) = param.pat else {
+                    continue;
+                };
+                self.propagate_pat(pat, expected_ty, updates)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Extract one unambiguous parenthesized `Fn`, `FnMut`, or `FnOnce` argument list.
+    fn direct_callable_param_tys(
+        ty: &TypeRef,
+        resolver: &TypeRefResolutionQuery<'query, D, I>,
+    ) -> Result<Option<Vec<Ty>>, PackageStoreError> {
+        let TypeRef::ImplTrait(bounds) = ty else {
+            return Ok(None);
+        };
+
+        let mut candidates = ExpectedUnique::new();
+        for bound in bounds {
+            if let TypeBound::Trait(TypeRef::Path(path)) = bound
+                && let Some(segment) = path.segments.last()
+                && matches!(segment.name.as_str(), "Fn" | "FnMut" | "FnOnce")
+                && let [GenericArg::FnTraitArgs { params, .. }] = segment.args.as_slice()
+            {
+                let param_tys = params
+                    .iter()
+                    .map(|param| resolver.resolve(param))
+                    .collect::<Result<Vec<_>, _>>()?;
+                candidates.push(param_tys);
+            }
+        }
+
+        Ok(candidates.into_option())
     }
 
     fn expected_ty_for_let(

--- a/crates/engine/body-ir/src/resolution/pass/pattern_type.rs
+++ b/crates/engine/body-ir/src/resolution/pass/pattern_type.rs
@@ -15,7 +15,7 @@ use rg_ty::{ReferencePeelingCandidates, Ty};
 
 use crate::ir::{ExprKind, PatKind, RecordPatField, StmtKind};
 use crate::resolution::{
-    BodyResolutionContext, TypeRefUseSite, support::direct_callable_arg_expectations,
+    BodyResolutionContext, TypeRefUseSite, support::callable_arg_expectations,
 };
 
 pub(super) struct PatternTypePropagationPass<'query, D, I> {
@@ -152,7 +152,7 @@ where
     }
 
     /// Check if call has:
-    /// 1. `impl Fn*(...)` arguments in its target fn
+    /// 1. `impl Fn*(...)` or `F: Fn*(...)` arguments in its target fn
     /// 2. closures passed as arguments in matching positions.
     ///
     /// If so, propagate types from the (1) types to arguments in (2) closure.
@@ -165,8 +165,8 @@ where
         args: &[ExprId],
         updates: &mut Vec<(BindingId, Ty)>,
     ) -> Result<(), PackageStoreError> {
-        for (arg, expectation) in direct_callable_arg_expectations(self.context, call, args)? {
-            // Only direct closure arguments can receive callable parameter expectations here.
+        for (arg, expectation) in callable_arg_expectations(self.context, call, args)? {
+            // Only closure arguments can receive these types here.
             // Other expression kinds still get ordinary call-argument expectations elsewhere.
             let ExprKind::Closure { params, .. } =
                 self.context.body().expr_unchecked(arg).kind.clone()

--- a/crates/engine/body-ir/src/resolution/query/call.rs
+++ b/crates/engine/body-ir/src/resolution/query/call.rs
@@ -232,6 +232,7 @@ pub(crate) struct CallSignature<'call, 'query, D, I> {
 /// Signature facts projected for one selected call target.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CallProjection {
+    written_param_refs: Vec<Option<TypeRef>>,
     written_param_tys: Vec<Ty>,
     return_ty: Ty,
     declared_return_ty: Option<TypeRef>,
@@ -244,6 +245,7 @@ pub(crate) struct CallProjection {
 impl CallProjection {
     fn unknown(explicit_args: &[ItemGenericArg]) -> Self {
         Self {
+            written_param_refs: Vec::new(),
             written_param_tys: Vec::new(),
             return_ty: Ty::Unknown,
             declared_return_ty: None,
@@ -252,6 +254,11 @@ impl CallProjection {
             selected_self_ty: None,
             subst: TypeSubst::new(),
         }
+    }
+
+    /// Return declared parameter syntax for arguments written at the call site.
+    pub(crate) fn written_param_refs(&self) -> &[Option<TypeRef>] {
+        &self.written_param_refs
     }
 
     /// Return parameter types for arguments written at the call site.
@@ -540,11 +547,18 @@ where
 
         // Keep one expected type per written argument. Missing parameter annotations are not
         // useful evidence, but `Unknown` preserves arity so the caller can still zip safely.
-        let written_param_tys = function_data
+        let written_params = function_data
             .signature
             .params()
             .iter()
             .skip(self.target.self_source.first_written_param_idx())
+            .collect::<Vec<_>>();
+        let written_param_refs = written_params
+            .iter()
+            .map(|param| param.ty.clone())
+            .collect::<Vec<_>>();
+        let written_param_tys = written_params
+            .iter()
             .map(|param| {
                 let Some(param_ty) = &param.ty else {
                     return Ok(Ty::Unknown);
@@ -577,6 +591,7 @@ where
         };
 
         Ok(CallProjection {
+            written_param_refs,
             written_param_tys,
             return_ty,
             declared_return_ty,

--- a/crates/engine/body-ir/src/resolution/query/mod.rs
+++ b/crates/engine/body-ir/src/resolution/query/mod.rs
@@ -28,4 +28,4 @@ pub(crate) use self::{
     type_ref::{TypeRefResolutionQuery, TypeRefUseSite},
 };
 
-pub(crate) use self::call::{BodyCallQuery, CallSite, MethodCallSite};
+pub(crate) use self::call::{BodyCallQuery, CallSite, MethodCallSite, ResolvedCallTarget};

--- a/crates/engine/body-ir/src/resolution/support/callable.rs
+++ b/crates/engine/body-ir/src/resolution/support/callable.rs
@@ -5,6 +5,10 @@
 //! parameter `F` whose selected function declares `F: FnOnce(T) -> R`. This
 //! module keeps that syntax handling in one place so early pattern propagation
 //! and final inference agree on the parameter and return types they see.
+//!
+//! This module stops at selected signature syntax. It does not decide whether a
+//! closure really implements `Fn`, `FnMut`, or `FnOnce`; final inference turns
+//! the parsed syntax into body-local callable goals.
 
 use rg_ir_model::{
     ExprId, FunctionRef, ItemOwner,
@@ -212,9 +216,10 @@ where
 
 /// Callable expectation that still points at the written signature syntax.
 ///
-/// This is the shared parser output. The fixed-point pattern pass resolves it
-/// into plain `Ty`; final inference can project the same syntax into `InferTy`
-/// so generic returns such as `R` keep their `?R` slot.
+/// This is the shared parser output for parenthesized Fn-trait syntax. For
+/// `F: FnMut(&T) -> R`, it keeps `&T` and `R` as written `TypeRef`s. The early
+/// pattern pass can resolve those refs into plain `Ty`, while final inference
+/// can project them into `InferTy` so a return such as `R` keeps its `?R` slot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct CallableTypeRefExpectation<'ty> {
     params: &'ty [TypeRef],

--- a/crates/engine/body-ir/src/resolution/support/callable.rs
+++ b/crates/engine/body-ir/src/resolution/support/callable.rs
@@ -113,11 +113,50 @@ impl CallableExpectation {
         D: DefMapSource<Error = PackageStoreError> + Copy,
         I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
     {
-        if let Some(expectation) = Self::from_direct_impl_trait(ty, resolver)? {
-            return Ok(Some(expectation));
+        let Some(expectation) = CallableTypeRefExpectation::from_written_param(ty, generics) else {
+            return Ok(None);
+        };
+
+        let params = expectation
+            .params()
+            .iter()
+            .map(|param| resolver.resolve(param))
+            .collect::<Result<Vec<_>, _>>()?;
+        let return_ty = resolver.resolve(expectation.return_ty())?;
+        Ok(Some(Self { params, return_ty }))
+    }
+}
+
+/// Callable expectation that still points at the written signature syntax.
+///
+/// This is the shared parser output. The fixed-point pattern pass resolves it
+/// into plain `Ty`; final inference can project the same syntax into `InferTy`
+/// so generic returns such as `R` keep their `?R` slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CallableTypeRefExpectation<'ty> {
+    params: &'ty [TypeRef],
+    return_ty: &'ty TypeRef,
+}
+
+impl<'ty> CallableTypeRefExpectation<'ty> {
+    pub(crate) fn params(&self) -> &'ty [TypeRef] {
+        self.params
+    }
+
+    pub(crate) fn return_ty(&self) -> &'ty TypeRef {
+        self.return_ty
+    }
+
+    /// Resolve a selected parameter's callable syntax.
+    pub(crate) fn from_written_param(
+        ty: &'ty TypeRef,
+        generics: Option<&'ty GenericParams>,
+    ) -> Option<Self> {
+        if let Some(expectation) = Self::from_direct_impl_trait(ty) {
+            return Some(expectation);
         }
 
-        Self::from_generic_param_bounds(ty, generics, resolver)
+        Self::from_generic_param_bounds(ty, generics)
     }
 
     /// Resolve one unambiguous parenthesized `Fn`, `FnMut`, or `FnOnce` bound.
@@ -125,22 +164,15 @@ impl CallableExpectation {
     /// This intentionally handles the direct argument shape only. Generic
     /// callable params are handled separately after we know which generic
     /// parameter the written argument uses.
-    fn from_direct_impl_trait<'query, D, I>(
-        ty: &TypeRef,
-        resolver: &TypeRefResolutionQuery<'query, D, I>,
-    ) -> Result<Option<Self>, PackageStoreError>
-    where
-        D: DefMapSource<Error = PackageStoreError> + Copy,
-        I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
-    {
+    fn from_direct_impl_trait(ty: &'ty TypeRef) -> Option<Self> {
         let TypeRef::ImplTrait(bounds) = ty else {
-            return Ok(None);
+            return None;
         };
 
         let mut candidates = ExpectedUnique::new();
-        Self::push_fn_trait_bound_expectations(bounds, resolver, &mut candidates)?;
+        Self::push_fn_trait_bound_expectations(bounds, &mut candidates);
 
-        Ok(candidates.into_option())
+        candidates.into_option()
     }
 
     /// Resolve callable bounds from a generic parameter used as a call argument.
@@ -149,26 +181,21 @@ impl CallableExpectation {
     /// argument lines up with written param `F`. By the time this runs, the call
     /// projection may already know `T = User` from the ordinary `value` arg, so
     /// resolving `F`'s bound through that projection gives the closure param type.
-    fn from_generic_param_bounds<'query, D, I>(
-        ty: &TypeRef,
-        generics: Option<&GenericParams>,
-        resolver: &TypeRefResolutionQuery<'query, D, I>,
-    ) -> Result<Option<Self>, PackageStoreError>
-    where
-        D: DefMapSource<Error = PackageStoreError> + Copy,
-        I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
-    {
+    fn from_generic_param_bounds(
+        ty: &'ty TypeRef,
+        generics: Option<&'ty GenericParams>,
+    ) -> Option<Self> {
         let Some(generics) = generics else {
-            return Ok(None);
+            return None;
         };
         let Some(param_name) = ty.type_param_name() else {
-            return Ok(None);
+            return None;
         };
 
         let mut candidates = ExpectedUnique::new();
         for param in &generics.types {
             if param.name.as_str() == param_name.as_str() {
-                Self::push_fn_trait_bound_expectations(&param.bounds, resolver, &mut candidates)?;
+                Self::push_fn_trait_bound_expectations(&param.bounds, &mut candidates);
             }
         }
 
@@ -181,37 +208,28 @@ impl CallableExpectation {
                     .type_param_name()
                     .is_some_and(|name| name.as_str() == param_name.as_str())
             {
-                Self::push_fn_trait_bound_expectations(bounds, resolver, &mut candidates)?;
+                Self::push_fn_trait_bound_expectations(bounds, &mut candidates);
             }
         }
 
-        Ok(candidates.into_option())
+        candidates.into_option()
     }
 
-    fn push_fn_trait_bound_expectations<'query, D, I>(
-        bounds: &[TypeBound],
-        resolver: &TypeRefResolutionQuery<'query, D, I>,
+    fn push_fn_trait_bound_expectations(
+        bounds: &'ty [TypeBound],
         candidates: &mut ExpectedUnique<Self>,
-    ) -> Result<(), PackageStoreError>
-    where
-        D: DefMapSource<Error = PackageStoreError> + Copy,
-        I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
-    {
+    ) {
         for bound in bounds {
             if let TypeBound::Trait(TypeRef::Path(path)) = bound
                 && let Some(segment) = path.segments.last()
                 && matches!(segment.name.as_str(), "Fn" | "FnMut" | "FnOnce")
                 && let [GenericArg::FnTraitArgs { params, ret }] = segment.args.as_slice()
             {
-                let params = params
-                    .iter()
-                    .map(|param| resolver.resolve(param))
-                    .collect::<Result<Vec<_>, _>>()?;
-                let return_ty = resolver.resolve(ret)?;
-                candidates.push(Self { params, return_ty });
+                candidates.push(Self {
+                    params,
+                    return_ty: ret,
+                });
             }
         }
-
-        Ok(())
     }
 }

--- a/crates/engine/body-ir/src/resolution/support/callable.rs
+++ b/crates/engine/body-ir/src/resolution/support/callable.rs
@@ -125,7 +125,9 @@ impl CallableExpectation {
         D: DefMapSource<Error = PackageStoreError> + Copy,
         I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
     {
-        let Some(expectation) = CallableTypeRefExpectation::from_written_param(ty, generics) else {
+        let Some(expectation) =
+            CallableTypeRefExpectation::from_written_param(ty, generics).into_option()
+        else {
             return Ok(None);
         };
 
@@ -232,12 +234,34 @@ impl<'ty> CallableTypeRefExpectation<'ty> {
     pub(crate) fn from_written_param(
         ty: &'ty TypeRef,
         generics: Option<&'ty GenericParams>,
-    ) -> Option<Self> {
-        if let Some(expectation) = Self::from_direct_impl_trait(ty) {
-            return Some(expectation);
+    ) -> ExpectedUnique<Self> {
+        let direct = Self::from_direct_impl_trait(ty);
+        if !direct.is_empty() {
+            return direct;
         }
 
         Self::from_generic_param_bounds(ty, generics)
+    }
+
+    /// Resolve one parenthesized `Fn`, `FnMut`, or `FnOnce` trait bound.
+    pub(crate) fn from_fn_trait_bound(ty: &'ty TypeRef) -> Option<Self> {
+        let TypeRef::Path(path) = ty else {
+            return None;
+        };
+        let Some(segment) = path.segments.last() else {
+            return None;
+        };
+        if !matches!(segment.name.as_str(), "Fn" | "FnMut" | "FnOnce") {
+            return None;
+        }
+        let [GenericArg::FnTraitArgs { params, ret }] = segment.args.as_slice() else {
+            return None;
+        };
+
+        Some(Self {
+            params,
+            return_ty: ret,
+        })
     }
 
     /// Resolve one unambiguous parenthesized `Fn`, `FnMut`, or `FnOnce` bound.
@@ -245,15 +269,14 @@ impl<'ty> CallableTypeRefExpectation<'ty> {
     /// This intentionally handles the direct argument shape only. Generic
     /// callable params are handled separately after we know which generic
     /// parameter the written argument uses.
-    fn from_direct_impl_trait(ty: &'ty TypeRef) -> Option<Self> {
+    fn from_direct_impl_trait(ty: &'ty TypeRef) -> ExpectedUnique<Self> {
         let TypeRef::ImplTrait(bounds) = ty else {
-            return None;
+            return ExpectedUnique::new();
         };
 
         let mut candidates = ExpectedUnique::new();
         Self::push_fn_trait_bound_expectations(bounds, &mut candidates);
-
-        candidates.into_option()
+        candidates
     }
 
     /// Resolve callable bounds from a generic parameter used as a call argument.
@@ -265,12 +288,12 @@ impl<'ty> CallableTypeRefExpectation<'ty> {
     fn from_generic_param_bounds(
         ty: &'ty TypeRef,
         generics: Option<&'ty GenericParams>,
-    ) -> Option<Self> {
+    ) -> ExpectedUnique<Self> {
         let Some(generics) = generics else {
-            return None;
+            return ExpectedUnique::new();
         };
         let Some(param_name) = ty.type_param_name() else {
-            return None;
+            return ExpectedUnique::new();
         };
 
         let mut candidates = ExpectedUnique::new();
@@ -293,7 +316,7 @@ impl<'ty> CallableTypeRefExpectation<'ty> {
             }
         }
 
-        candidates.into_option()
+        candidates
     }
 
     fn push_fn_trait_bound_expectations(
@@ -301,15 +324,10 @@ impl<'ty> CallableTypeRefExpectation<'ty> {
         candidates: &mut ExpectedUnique<Self>,
     ) {
         for bound in bounds {
-            if let TypeBound::Trait(TypeRef::Path(path)) = bound
-                && let Some(segment) = path.segments.last()
-                && matches!(segment.name.as_str(), "Fn" | "FnMut" | "FnOnce")
-                && let [GenericArg::FnTraitArgs { params, ret }] = segment.args.as_slice()
+            if let TypeBound::Trait(ty) = bound
+                && let Some(expectation) = Self::from_fn_trait_bound(ty)
             {
-                candidates.push(Self {
-                    params,
-                    return_ty: ret,
-                });
+                candidates.push(expectation);
             }
         }
     }

--- a/crates/engine/body-ir/src/resolution/support/callable.rs
+++ b/crates/engine/body-ir/src/resolution/support/callable.rs
@@ -7,7 +7,7 @@
 //! and final inference agree on the parameter and return types they see.
 
 use rg_ir_model::{
-    ExprId,
+    ExprId, FunctionRef, ItemOwner,
     items::{GenericArg, GenericParams, TypeBound, TypeRef, WherePredicate},
 };
 use rg_ir_storage::{DefMapSource, ItemStoreSource};
@@ -20,6 +20,10 @@ use crate::{
     resolution::{BodyResolutionContext, TypeRefUseSite, query::TypeRefResolutionQuery},
 };
 
+use super::selected_trait_assoc::{
+    SelectedTraitAssocProjector, SelectedTraitMethodContext, self_associated_type_name,
+};
+
 /// Return callable expectations aligned to closure arguments written at a call site.
 ///
 /// This owns the shared call-site setup:
@@ -27,10 +31,6 @@ use crate::{
 /// 1. Use only the unique selected target for the call.
 /// 2. Project the selected signature so written params line up with written args.
 /// 3. Resolve callable shapes at the selected function use site.
-///
-/// Most calls do not pass closures, so the helper checks that first and avoids the selected-call
-/// work when there is nothing for closure inference to consume. Callers can then decide what part
-/// of the expectation matters: pattern propagation uses `params`; final inference uses `return_ty`.
 pub(crate) fn callable_arg_expectations<'query, D, I>(
     context: BodyResolutionContext<'query, D, I>,
     call: ExprId,
@@ -40,6 +40,8 @@ where
     D: DefMapSource<Error = PackageStoreError> + Copy,
     I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
 {
+    // Most call arguments are not closures, so it makes sense to quickly check
+    // before doing any work.
     if !args.iter().any(|arg| {
         matches!(
             &context.body().expr_unchecked(*arg).kind,
@@ -53,6 +55,9 @@ where
     let Some(target) = calls.target(call)? else {
         return Ok(Vec::new());
     };
+    let Some(function_data) = context.item_query().function_data(target.function())? else {
+        return Ok(Vec::new());
+    };
     let projection = calls.signature(&target).project(args)?;
     if projection.written_param_refs().len() != args.len() {
         return Ok(Vec::new());
@@ -61,6 +66,13 @@ where
     let resolver = context
         .type_refs(TypeRefUseSite::Function(target.function()))
         .with_subst(projection.subst());
+    let callable_resolver = CallableTypeResolver::new(
+        context,
+        &resolver,
+        target.function(),
+        function_data.owner,
+        projection.selected_self_ty(),
+    )?;
     let mut expectations = Vec::new();
     for (arg, param_ty) in args.iter().copied().zip(projection.written_param_refs()) {
         if !matches!(
@@ -75,7 +87,7 @@ where
         let Some(expectation) = CallableExpectation::from_written_param(
             param_ty,
             projection.function_generics(),
-            &resolver,
+            &callable_resolver,
         )?
         else {
             continue;
@@ -107,7 +119,7 @@ impl CallableExpectation {
     fn from_written_param<'query, D, I>(
         ty: &TypeRef,
         generics: Option<&GenericParams>,
-        resolver: &TypeRefResolutionQuery<'query, D, I>,
+        resolver: &CallableTypeResolver<'_, 'query, D, I>,
     ) -> Result<Option<Self>, PackageStoreError>
     where
         D: DefMapSource<Error = PackageStoreError> + Copy,
@@ -124,6 +136,75 @@ impl CallableExpectation {
             .collect::<Result<Vec<_>, _>>()?;
         let return_ty = resolver.resolve(expectation.return_ty())?;
         Ok(Some(Self { params, return_ty }))
+    }
+}
+
+/// Resolves callable expectation syntax in the selected-call context.
+///
+/// Most callable expectation types are ordinary type refs, so this is a thin
+/// wrapper over `TypeRefResolutionQuery`. The extra selected-trait context is
+/// for signatures like `Iterator::map`, where the closure param or return is
+/// written as `Self::Item`. Plain type-ref resolution cannot know which
+/// receiver impl selected the method, but the call projection can.
+pub(crate) struct CallableTypeResolver<'a, 'query, D, I> {
+    context: BodyResolutionContext<'query, D, I>,
+    resolver: &'a TypeRefResolutionQuery<'query, D, I>,
+    selected_trait_method: Option<SelectedTraitMethodContext<'a>>,
+}
+
+impl<'a, 'query, D, I> CallableTypeResolver<'a, 'query, D, I>
+where
+    D: DefMapSource<Error = PackageStoreError> + Copy,
+    I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
+{
+    pub(crate) fn new(
+        context: BodyResolutionContext<'query, D, I>,
+        resolver: &'a TypeRefResolutionQuery<'query, D, I>,
+        function: FunctionRef,
+        owner: ItemOwner,
+        selected_self_ty: Option<&'a Ty>,
+    ) -> Result<Self, PackageStoreError> {
+        let selected_trait_method =
+            SelectedTraitMethodContext::from_function(context, function, owner, selected_self_ty)?;
+        Ok(Self {
+            context,
+            resolver,
+            selected_trait_method,
+        })
+    }
+
+    pub(crate) fn resolve(&self, ty: &TypeRef) -> Result<Ty, PackageStoreError> {
+        if let Some(projected_ty) = self.project_selected_trait_associated_ty(ty)? {
+            return Ok(projected_ty);
+        }
+
+        self.resolver.resolve(ty)
+    }
+
+    fn project_selected_trait_associated_ty(
+        &self,
+        ty: &TypeRef,
+    ) -> Result<Option<Ty>, PackageStoreError> {
+        if let Some(assoc_name) = self_associated_type_name(ty) {
+            let Some(selected_trait_method) = self.selected_trait_method.as_ref() else {
+                return Ok(None);
+            };
+            return SelectedTraitAssocProjector::new(self.context)
+                .project_concrete_ty(selected_trait_method, assoc_name)
+                .map(|ty| Some(ty.unwrap_or(Ty::Unknown)));
+        }
+
+        // Predicate adapters such as `filter` usually write `FnMut(&Self::Item)`.
+        // Keep that reference wrapper instead of smoothing it into just the item type.
+        if let TypeRef::Reference {
+            mutability, inner, ..
+        } = ty
+            && let Some(inner_ty) = self.project_selected_trait_associated_ty(inner)?
+        {
+            return Ok(Some(Ty::reference(*mutability, inner_ty)));
+        }
+
+        Ok(None)
     }
 }
 

--- a/crates/engine/body-ir/src/resolution/support/callable.rs
+++ b/crates/engine/body-ir/src/resolution/support/callable.rs
@@ -269,7 +269,7 @@ impl<'ty> CallableTypeRefExpectation<'ty> {
     /// This intentionally handles the direct argument shape only. Generic
     /// callable params are handled separately after we know which generic
     /// parameter the written argument uses.
-    fn from_direct_impl_trait(ty: &'ty TypeRef) -> ExpectedUnique<Self> {
+    pub(crate) fn from_direct_impl_trait(ty: &'ty TypeRef) -> ExpectedUnique<Self> {
         let TypeRef::ImplTrait(bounds) = ty else {
             return ExpectedUnique::new();
         };

--- a/crates/engine/body-ir/src/resolution/support/callable.rs
+++ b/crates/engine/body-ir/src/resolution/support/callable.rs
@@ -1,13 +1,14 @@
-//! Direct callable syntax extracted from selected signatures.
+//! Callable syntax extracted from selected signatures.
 //!
 //! Several body-resolution stages need to understand the same source shape:
-//! a selected function parameter written as `impl FnOnce(T) -> R`. This module
-//! keeps that syntax handling in one place so early pattern propagation and
-//! final inference agree on the parameter and return types they see.
+//! a selected function parameter written as `impl FnOnce(T) -> R`, or a generic
+//! parameter `F` whose selected function declares `F: FnOnce(T) -> R`. This
+//! module keeps that syntax handling in one place so early pattern propagation
+//! and final inference agree on the parameter and return types they see.
 
 use rg_ir_model::{
     ExprId,
-    items::{GenericArg, TypeBound, TypeRef},
+    items::{GenericArg, GenericParams, TypeBound, TypeRef, WherePredicate},
 };
 use rg_ir_storage::{DefMapSource, ItemStoreSource};
 use rg_package_store::PackageStoreError;
@@ -19,22 +20,22 @@ use crate::{
     resolution::{BodyResolutionContext, TypeRefUseSite, query::TypeRefResolutionQuery},
 };
 
-/// Return direct callable expectations aligned to closure arguments written at a call site.
+/// Return callable expectations aligned to closure arguments written at a call site.
 ///
 /// This owns the shared call-site setup:
 ///
 /// 1. Use only the unique selected target for the call.
 /// 2. Project the selected signature so written params line up with written args.
-/// 3. Resolve direct `impl Fn*(...) -> R` syntax at the selected function use site.
+/// 3. Resolve callable shapes at the selected function use site.
 ///
 /// Most calls do not pass closures, so the helper checks that first and avoids the selected-call
 /// work when there is nothing for closure inference to consume. Callers can then decide what part
 /// of the expectation matters: pattern propagation uses `params`; final inference uses `return_ty`.
-pub(crate) fn direct_callable_arg_expectations<'query, D, I>(
+pub(crate) fn callable_arg_expectations<'query, D, I>(
     context: BodyResolutionContext<'query, D, I>,
     call: ExprId,
     args: &[ExprId],
-) -> Result<Vec<(ExprId, DirectCallableExpectation)>, PackageStoreError>
+) -> Result<Vec<(ExprId, CallableExpectation)>, PackageStoreError>
 where
     D: DefMapSource<Error = PackageStoreError> + Copy,
     I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
@@ -71,8 +72,11 @@ where
         let Some(param_ty) = param_ty else {
             continue;
         };
-        let Some(expectation) =
-            DirectCallableExpectation::from_direct_impl_trait(param_ty, &resolver)?
+        let Some(expectation) = CallableExpectation::from_written_param(
+            param_ty,
+            projection.function_generics(),
+            &resolver,
+        )?
         else {
             continue;
         };
@@ -82,24 +86,46 @@ where
     Ok(expectations)
 }
 
-/// Parameter and return expectations promised by direct callable syntax.
+/// Parameter and return expectations promised by callable syntax.
 ///
-/// Example: `impl FnOnce(User) -> bool` becomes `params = [User]` and
-/// `return_ty = bool`. This is not a closure type; it is the expectation a
-/// selected call can push into a closure argument.
+/// Example: `impl FnOnce(User) -> bool`, or `F` plus `F: FnOnce(User) -> bool`,
+/// becomes `params = [User]` and `return_ty = bool`. This is not a closure
+/// type; it is the expectation a selected call can push into a closure
+/// argument.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct DirectCallableExpectation {
+pub(crate) struct CallableExpectation {
     pub(crate) params: Vec<Ty>,
     pub(crate) return_ty: Ty,
 }
 
-impl DirectCallableExpectation {
+impl CallableExpectation {
+    /// Resolve a selected parameter's callable shape.
+    ///
+    /// Direct `impl Fn*(...)` params carry the callable syntax inline. Generic
+    /// callable params need one extra hop: the selected parameter is `F`, and
+    /// the callable syntax lives on `F`'s inline bounds or where predicates.
+    fn from_written_param<'query, D, I>(
+        ty: &TypeRef,
+        generics: Option<&GenericParams>,
+        resolver: &TypeRefResolutionQuery<'query, D, I>,
+    ) -> Result<Option<Self>, PackageStoreError>
+    where
+        D: DefMapSource<Error = PackageStoreError> + Copy,
+        I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
+    {
+        if let Some(expectation) = Self::from_direct_impl_trait(ty, resolver)? {
+            return Ok(Some(expectation));
+        }
+
+        Self::from_generic_param_bounds(ty, generics, resolver)
+    }
+
     /// Resolve one unambiguous parenthesized `Fn`, `FnMut`, or `FnOnce` bound.
     ///
     /// This intentionally handles the direct argument shape only. Generic
-    /// callable params such as `F: FnOnce(T) -> R` need inference variables from
-    /// the selected call instead of plain resolved syntax.
-    pub(crate) fn from_direct_impl_trait<'query, D, I>(
+    /// callable params are handled separately after we know which generic
+    /// parameter the written argument uses.
+    fn from_direct_impl_trait<'query, D, I>(
         ty: &TypeRef,
         resolver: &TypeRefResolutionQuery<'query, D, I>,
     ) -> Result<Option<Self>, PackageStoreError>
@@ -112,6 +138,65 @@ impl DirectCallableExpectation {
         };
 
         let mut candidates = ExpectedUnique::new();
+        Self::push_fn_trait_bound_expectations(bounds, resolver, &mut candidates)?;
+
+        Ok(candidates.into_option())
+    }
+
+    /// Resolve callable bounds from a generic parameter used as a call argument.
+    ///
+    /// Example: for `fn visit<T, F: FnOnce(T)>(value: T, f: F)`, the closure
+    /// argument lines up with written param `F`. By the time this runs, the call
+    /// projection may already know `T = User` from the ordinary `value` arg, so
+    /// resolving `F`'s bound through that projection gives the closure param type.
+    fn from_generic_param_bounds<'query, D, I>(
+        ty: &TypeRef,
+        generics: Option<&GenericParams>,
+        resolver: &TypeRefResolutionQuery<'query, D, I>,
+    ) -> Result<Option<Self>, PackageStoreError>
+    where
+        D: DefMapSource<Error = PackageStoreError> + Copy,
+        I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
+    {
+        let Some(generics) = generics else {
+            return Ok(None);
+        };
+        let Some(param_name) = ty.type_param_name() else {
+            return Ok(None);
+        };
+
+        let mut candidates = ExpectedUnique::new();
+        for param in &generics.types {
+            if param.name.as_str() == param_name.as_str() {
+                Self::push_fn_trait_bound_expectations(&param.bounds, resolver, &mut candidates)?;
+            }
+        }
+
+        for predicate in &generics.where_predicates {
+            if let WherePredicate::Type {
+                ty: predicate_ty,
+                bounds,
+            } = predicate
+                && predicate_ty
+                    .type_param_name()
+                    .is_some_and(|name| name.as_str() == param_name.as_str())
+            {
+                Self::push_fn_trait_bound_expectations(bounds, resolver, &mut candidates)?;
+            }
+        }
+
+        Ok(candidates.into_option())
+    }
+
+    fn push_fn_trait_bound_expectations<'query, D, I>(
+        bounds: &[TypeBound],
+        resolver: &TypeRefResolutionQuery<'query, D, I>,
+        candidates: &mut ExpectedUnique<Self>,
+    ) -> Result<(), PackageStoreError>
+    where
+        D: DefMapSource<Error = PackageStoreError> + Copy,
+        I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
+    {
         for bound in bounds {
             if let TypeBound::Trait(TypeRef::Path(path)) = bound
                 && let Some(segment) = path.segments.last()
@@ -127,6 +212,6 @@ impl DirectCallableExpectation {
             }
         }
 
-        Ok(candidates.into_option())
+        Ok(())
     }
 }

--- a/crates/engine/body-ir/src/resolution/support/callable.rs
+++ b/crates/engine/body-ir/src/resolution/support/callable.rs
@@ -1,0 +1,132 @@
+//! Direct callable syntax extracted from selected signatures.
+//!
+//! Several body-resolution stages need to understand the same source shape:
+//! a selected function parameter written as `impl FnOnce(T) -> R`. This module
+//! keeps that syntax handling in one place so early pattern propagation and
+//! final inference agree on the parameter and return types they see.
+
+use rg_ir_model::{
+    ExprId,
+    items::{GenericArg, TypeBound, TypeRef},
+};
+use rg_ir_storage::{DefMapSource, ItemStoreSource};
+use rg_package_store::PackageStoreError;
+use rg_std::ExpectedUnique;
+use rg_ty::Ty;
+
+use crate::{
+    ir::ExprKind,
+    resolution::{BodyResolutionContext, TypeRefUseSite, query::TypeRefResolutionQuery},
+};
+
+/// Return direct callable expectations aligned to closure arguments written at a call site.
+///
+/// This owns the shared call-site setup:
+///
+/// 1. Use only the unique selected target for the call.
+/// 2. Project the selected signature so written params line up with written args.
+/// 3. Resolve direct `impl Fn*(...) -> R` syntax at the selected function use site.
+///
+/// Most calls do not pass closures, so the helper checks that first and avoids the selected-call
+/// work when there is nothing for closure inference to consume. Callers can then decide what part
+/// of the expectation matters: pattern propagation uses `params`; final inference uses `return_ty`.
+pub(crate) fn direct_callable_arg_expectations<'query, D, I>(
+    context: BodyResolutionContext<'query, D, I>,
+    call: ExprId,
+    args: &[ExprId],
+) -> Result<Vec<(ExprId, DirectCallableExpectation)>, PackageStoreError>
+where
+    D: DefMapSource<Error = PackageStoreError> + Copy,
+    I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
+{
+    if !args.iter().any(|arg| {
+        matches!(
+            &context.body().expr_unchecked(*arg).kind,
+            ExprKind::Closure { .. }
+        )
+    }) {
+        return Ok(Vec::new());
+    }
+
+    let calls = context.calls();
+    let Some(target) = calls.target(call)? else {
+        return Ok(Vec::new());
+    };
+    let projection = calls.signature(&target).project(args)?;
+    if projection.written_param_refs().len() != args.len() {
+        return Ok(Vec::new());
+    }
+
+    let resolver = context
+        .type_refs(TypeRefUseSite::Function(target.function()))
+        .with_subst(projection.subst());
+    let mut expectations = Vec::new();
+    for (arg, param_ty) in args.iter().copied().zip(projection.written_param_refs()) {
+        if !matches!(
+            &context.body().expr_unchecked(arg).kind,
+            ExprKind::Closure { .. }
+        ) {
+            continue;
+        }
+        let Some(param_ty) = param_ty else {
+            continue;
+        };
+        let Some(expectation) =
+            DirectCallableExpectation::from_direct_impl_trait(param_ty, &resolver)?
+        else {
+            continue;
+        };
+        expectations.push((arg, expectation));
+    }
+
+    Ok(expectations)
+}
+
+/// Parameter and return expectations promised by direct callable syntax.
+///
+/// Example: `impl FnOnce(User) -> bool` becomes `params = [User]` and
+/// `return_ty = bool`. This is not a closure type; it is the expectation a
+/// selected call can push into a closure argument.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DirectCallableExpectation {
+    pub(crate) params: Vec<Ty>,
+    pub(crate) return_ty: Ty,
+}
+
+impl DirectCallableExpectation {
+    /// Resolve one unambiguous parenthesized `Fn`, `FnMut`, or `FnOnce` bound.
+    ///
+    /// This intentionally handles the direct argument shape only. Generic
+    /// callable params such as `F: FnOnce(T) -> R` need inference variables from
+    /// the selected call instead of plain resolved syntax.
+    pub(crate) fn from_direct_impl_trait<'query, D, I>(
+        ty: &TypeRef,
+        resolver: &TypeRefResolutionQuery<'query, D, I>,
+    ) -> Result<Option<Self>, PackageStoreError>
+    where
+        D: DefMapSource<Error = PackageStoreError> + Copy,
+        I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
+    {
+        let TypeRef::ImplTrait(bounds) = ty else {
+            return Ok(None);
+        };
+
+        let mut candidates = ExpectedUnique::new();
+        for bound in bounds {
+            if let TypeBound::Trait(TypeRef::Path(path)) = bound
+                && let Some(segment) = path.segments.last()
+                && matches!(segment.name.as_str(), "Fn" | "FnMut" | "FnOnce")
+                && let [GenericArg::FnTraitArgs { params, ret }] = segment.args.as_slice()
+            {
+                let params = params
+                    .iter()
+                    .map(|param| resolver.resolve(param))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let return_ty = resolver.resolve(ret)?;
+                candidates.push(Self { params, return_ty });
+            }
+        }
+
+        Ok(candidates.into_option())
+    }
+}

--- a/crates/engine/body-ir/src/resolution/support/callable.rs
+++ b/crates/engine/body-ir/src/resolution/support/callable.rs
@@ -253,9 +253,7 @@ impl<'ty> CallableTypeRefExpectation<'ty> {
         let TypeRef::Path(path) = ty else {
             return None;
         };
-        let Some(segment) = path.segments.last() else {
-            return None;
-        };
+        let segment = path.segments.last()?;
         if !matches!(segment.name.as_str(), "Fn" | "FnMut" | "FnOnce") {
             return None;
         }

--- a/crates/engine/body-ir/src/resolution/support/mod.rs
+++ b/crates/engine/body-ir/src/resolution/support/mod.rs
@@ -1,5 +1,16 @@
+//! Shared resolution helpers that are used by more than one resolution stage.
+//!
+//! This module is not a generic utils junkyard. Helpers here should model a
+//! resolution concept that does not belong to only one pass/query/inference step.
+
 mod callable;
+mod selected_trait_assoc;
 mod ty_normalize;
 
-pub(crate) use self::callable::{CallableTypeRefExpectation, callable_arg_expectations};
+pub(crate) use self::callable::{
+    CallableTypeRefExpectation, CallableTypeResolver, callable_arg_expectations,
+};
+pub(crate) use self::selected_trait_assoc::{
+    SelectedTraitAssocProjector, SelectedTraitMethodContext, self_associated_type_name,
+};
 pub(crate) use self::ty_normalize::TyNormalizer;

--- a/crates/engine/body-ir/src/resolution/support/mod.rs
+++ b/crates/engine/body-ir/src/resolution/support/mod.rs
@@ -1,5 +1,5 @@
 mod callable;
 mod ty_normalize;
 
-pub(crate) use self::callable::direct_callable_arg_expectations;
+pub(crate) use self::callable::callable_arg_expectations;
 pub(crate) use self::ty_normalize::TyNormalizer;

--- a/crates/engine/body-ir/src/resolution/support/mod.rs
+++ b/crates/engine/body-ir/src/resolution/support/mod.rs
@@ -1,5 +1,5 @@
 mod callable;
 mod ty_normalize;
 
-pub(crate) use self::callable::callable_arg_expectations;
+pub(crate) use self::callable::{CallableTypeRefExpectation, callable_arg_expectations};
 pub(crate) use self::ty_normalize::TyNormalizer;

--- a/crates/engine/body-ir/src/resolution/support/mod.rs
+++ b/crates/engine/body-ir/src/resolution/support/mod.rs
@@ -1,3 +1,5 @@
+mod callable;
 mod ty_normalize;
 
+pub(crate) use self::callable::direct_callable_arg_expectations;
 pub(crate) use self::ty_normalize::TyNormalizer;

--- a/crates/engine/body-ir/src/resolution/support/selected_trait_assoc.rs
+++ b/crates/engine/body-ir/src/resolution/support/selected_trait_assoc.rs
@@ -194,6 +194,26 @@ where
         selection: &TraitSelection,
         assoc_name: &str,
     ) -> Result<Option<InferTy>, PackageStoreError> {
+        let Some((context, aliased_ty)) =
+            self.associated_type_alias_from_selection(selection, assoc_name)?
+        else {
+            return Ok(None);
+        };
+        let resolved_ty = self
+            .context
+            .type_refs(TypeRefUseSite::OwnerContext(context))
+            .resolve(&aliased_ty)?;
+        Ok(Some(
+            InferTypeRefProjector::new(&selection.subst)
+                .ty_from_type_ref(&aliased_ty, &resolved_ty),
+        ))
+    }
+
+    pub(crate) fn associated_type_alias_from_selection(
+        &self,
+        selection: &TraitSelection,
+        assoc_name: &str,
+    ) -> Result<Option<(TypePathContext, TypeRef)>, PackageStoreError> {
         let Some(impl_data) = self
             .context
             .item_query()
@@ -226,14 +246,7 @@ where
                 module: impl_data.owner,
                 impl_ref: Some(selection.trait_impl.impl_ref),
             };
-            let resolved_ty = self
-                .context
-                .type_refs(TypeRefUseSite::OwnerContext(context))
-                .resolve(aliased_ty)?;
-            return Ok(Some(
-                InferTypeRefProjector::new(&selection.subst)
-                    .ty_from_type_ref(aliased_ty, &resolved_ty),
-            ));
+            return Ok(Some((context, aliased_ty.clone())));
         }
 
         Ok(None)

--- a/crates/engine/body-ir/src/resolution/support/selected_trait_assoc.rs
+++ b/crates/engine/body-ir/src/resolution/support/selected_trait_assoc.rs
@@ -18,7 +18,7 @@ use rg_ir_storage::{DefMapSource, ItemStoreSource, TypePathContext};
 use rg_package_store::PackageStoreError;
 use rg_std::ExpectedUnique;
 use rg_ty::{
-    TraitGoal, TraitSelection, TraitSelectionQuery, Ty,
+    TraitGoal, TraitSelection, TraitSelectionOptions, TraitSelectionQuery, Ty,
     inference::{InferTy, InferTypeRefProjector, InferenceTable},
 };
 
@@ -135,7 +135,9 @@ where
             trait_ref: selected_method.trait_ref,
             args: Vec::new(),
         };
-        let ExpectedUnique::One(selection) = self.probe_trait_goal(&goal, table)? else {
+        let ExpectedUnique::One(selection) =
+            self.probe_trait_goal(&goal, table, TraitSelectionOptions::new())?
+        else {
             return Ok(None);
         };
         let Some(projected_ty) =
@@ -148,6 +150,24 @@ where
             ty: projected_ty,
             table: selection.table,
         }))
+    }
+
+    /// Select the receiver impl using caller-provided trait-selection options.
+    pub(crate) fn select_infer_trait_impl(
+        &self,
+        selected_method: &SelectedTraitMethodContext<'_>,
+        table: &InferenceTable,
+        options: TraitSelectionOptions,
+    ) -> Result<Option<TraitSelection>, PackageStoreError> {
+        let goal = TraitGoal {
+            self_ty: InferTy::from_ty(selected_method.selected_self_ty),
+            trait_ref: selected_method.trait_ref,
+            args: Vec::new(),
+        };
+        let ExpectedUnique::One(selection) = self.probe_trait_goal(&goal, table, options)? else {
+            return Ok(None);
+        };
+        Ok(Some(selection))
     }
 
     /// Project an associated type into a stable concrete type for non-mutating callers.
@@ -169,7 +189,7 @@ where
         Ok(Some(projected_ty))
     }
 
-    fn project_associated_type_from_selection(
+    pub(crate) fn project_associated_type_from_selection(
         &self,
         selection: &TraitSelection,
         assoc_name: &str,
@@ -223,12 +243,14 @@ where
         &self,
         goal: &TraitGoal,
         table: &InferenceTable,
+        options: TraitSelectionOptions,
     ) -> Result<ExpectedUnique<TraitSelection>, PackageStoreError> {
         TraitSelectionQuery::with_index(
             self.context.item_paths(),
             self.context.target_items(),
             self.context.semantic_index(),
         )
+        .with_options(options)
         .probe(goal, table)
     }
 }

--- a/crates/engine/body-ir/src/resolution/support/selected_trait_assoc.rs
+++ b/crates/engine/body-ir/src/resolution/support/selected_trait_assoc.rs
@@ -1,0 +1,254 @@
+//! Projection for associated types written on selected trait methods.
+//!
+//! Selected trait methods have one extra fact that plain type-ref resolution does not carry:
+//! which receiver type selected the trait method. That matters for syntax such as
+//! `Self::Item` in `Iterator::collect` or `Iterator::map`, because the `Item` alias has to be
+//! read from the receiver impl for that selected `Self` type.
+//!
+//! In simple words: imagine that you have `foo.iter().map(..)`. You know that `foo` is `Vec<u8>`,
+//! and you know that `map()` comes from `Iterator` trait. But `map` talks about `Self::Item`,
+//! so what is `Self` here? It might not be the type that you're invoking `map()` on -- trait can
+//! be selected through autoderef or the receiver type might not match `Self` overall.
+//!
+//! To resolve that, we need an extra hop to find a unique trait impl for this method invocation
+//! and resolve associated item through it.
+
+use rg_ir_model::{AssocItemId, FunctionRef, ItemOwner, TraitRef, TypeAliasRef, items::TypeRef};
+use rg_ir_storage::{DefMapSource, ItemStoreSource, TypePathContext};
+use rg_package_store::PackageStoreError;
+use rg_std::ExpectedUnique;
+use rg_ty::{
+    TraitGoal, TraitSelection, TraitSelectionQuery, Ty,
+    inference::{InferTy, InferTypeRefProjector, InferenceTable},
+};
+
+use crate::resolution::{BodyResolutionContext, TypeRefUseSite};
+
+/// Selected trait-method context needed to interpret `Self::Assoc` syntax.
+///
+/// Basically, "we think the method comes from this trait, and we have this
+/// receiver type at call site", e.g. for `users.iter().map(...)`
+/// - `trait_ref` would correspond to `Iterator`
+/// - `selected_self_ty` would correspond to `slice::Iter<'_, User>`
+///
+/// Note that at this stage we have not done impl matching yet, so Self ty
+/// is not necessarily `Foo` from `impl Iterator for Foo`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SelectedTraitMethodContext<'a> {
+    trait_ref: TraitRef,
+    selected_self_ty: &'a Ty,
+}
+
+impl<'a> SelectedTraitMethodContext<'a> {
+    /// Build selected-trait context from an already selected associated function.
+    ///
+    /// Inherent calls and free functions have no trait `Self`, so they cannot project `Self::Assoc`
+    /// through this helper. Trait-level generics are intentionally left unsupported until method
+    /// selection carries their concrete arguments.
+    pub(crate) fn from_function<'query, D, I>(
+        context: BodyResolutionContext<'query, D, I>,
+        function: FunctionRef,
+        owner: ItemOwner,
+        selected_self_ty: Option<&'a Ty>,
+    ) -> Result<Option<Self>, PackageStoreError>
+    where
+        D: DefMapSource<Error = PackageStoreError> + Copy,
+        I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
+    {
+        let ItemOwner::Trait(trait_id) = owner else {
+            return Ok(None);
+        };
+        let Some(selected_self_ty) = selected_self_ty else {
+            return Ok(None);
+        };
+
+        let trait_ref = TraitRef {
+            origin: function.origin,
+            id: trait_id,
+        };
+        let Some(trait_data) = context.item_query().trait_data(trait_ref)? else {
+            return Ok(None);
+        };
+        if !trait_data.generics.lifetimes.is_empty()
+            || !trait_data.generics.types.is_empty()
+            || !trait_data.generics.consts.is_empty()
+        {
+            // TODO: Thread trait-level generic args from method selection before projecting
+            // `Self::Assoc` for traits shaped like `Trait<T>`.
+            return Ok(None);
+        }
+
+        Ok(Some(Self {
+            trait_ref,
+            selected_self_ty,
+        }))
+    }
+}
+
+/// Result of projecting one associated type through a selected receiver impl.
+///
+/// Roughly "we have done trait solving and here's what we found together with
+/// evidence".
+pub(crate) struct SelectedTraitAssocProjection {
+    ty: InferTy,
+    table: InferenceTable,
+}
+
+impl SelectedTraitAssocProjection {
+    pub(crate) fn into_parts(self) -> (InferTy, InferenceTable) {
+        (self.ty, self.table)
+    }
+}
+
+/// Projects `Self::Assoc` through the unique impl selected by a trait method receiver.
+// TODO/watch: this entity is basically two things glued together: probe an impl, and then
+// fetch an associated item from it. It kinda feels like two separate concepts wanting
+// to be born, but right now we have a domain problem that fits the shape, and no demand
+// for either of its halved being generic. In the future, if demand for trait probing at
+// callsite grows, we potentially want to split this thing rather than reimplement probing
+// everywhere.
+pub(crate) struct SelectedTraitAssocProjector<'query, D, I> {
+    context: BodyResolutionContext<'query, D, I>,
+}
+
+impl<'query, D, I> SelectedTraitAssocProjector<'query, D, I>
+where
+    D: DefMapSource<Error = PackageStoreError> + Copy,
+    I: ItemStoreSource<'query, Error = PackageStoreError> + Copy,
+{
+    pub(crate) fn new(context: BodyResolutionContext<'query, D, I>) -> Self {
+        Self { context }
+    }
+
+    /// Project an associated type into inference form using the caller's table.
+    ///
+    /// Callers that are allowed to commit receiver evidence can adopt the returned table. Callers
+    /// that only need a concrete fallback can use `project_concrete_ty` instead.
+    pub(crate) fn project_infer_ty(
+        &self,
+        selected_method: &SelectedTraitMethodContext<'_>,
+        assoc_name: &str,
+        table: &InferenceTable,
+    ) -> Result<Option<SelectedTraitAssocProjection>, PackageStoreError> {
+        let goal = TraitGoal {
+            self_ty: InferTy::from_ty(selected_method.selected_self_ty),
+            trait_ref: selected_method.trait_ref,
+            args: Vec::new(),
+        };
+        let ExpectedUnique::One(selection) = self.probe_trait_goal(&goal, table)? else {
+            return Ok(None);
+        };
+        let Some(projected_ty) =
+            self.project_associated_type_from_selection(&selection, assoc_name)?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(SelectedTraitAssocProjection {
+            ty: projected_ty,
+            table: selection.table,
+        }))
+    }
+
+    /// Project an associated type into a stable concrete type for non-mutating callers.
+    pub(crate) fn project_concrete_ty(
+        &self,
+        selected_method: &SelectedTraitMethodContext<'_>,
+        assoc_name: &str,
+    ) -> Result<Option<Ty>, PackageStoreError> {
+        let table = InferenceTable::new();
+        let Some(projection) = self.project_infer_ty(selected_method, assoc_name, &table)? else {
+            return Ok(None);
+        };
+        let (projected_ty, table) = projection.into_parts();
+        let projected_ty = table.finalize(&projected_ty);
+        if matches!(projected_ty, Ty::Syntax(_)) || projected_ty.has_unknown() {
+            return Ok(Some(Ty::Unknown));
+        }
+
+        Ok(Some(projected_ty))
+    }
+
+    fn project_associated_type_from_selection(
+        &self,
+        selection: &TraitSelection,
+        assoc_name: &str,
+    ) -> Result<Option<InferTy>, PackageStoreError> {
+        let Some(impl_data) = self
+            .context
+            .item_query()
+            .impl_data(selection.trait_impl.impl_ref)?
+        else {
+            return Ok(None);
+        };
+
+        for item in &impl_data.items {
+            let AssocItemId::TypeAlias(type_alias_id) = item else {
+                continue;
+            };
+            let type_alias_ref = TypeAliasRef {
+                origin: selection.trait_impl.impl_ref.origin,
+                id: *type_alias_id,
+            };
+            let Some(type_alias_data) =
+                self.context.item_query().type_alias_data(type_alias_ref)?
+            else {
+                continue;
+            };
+            if type_alias_data.name.as_str() != assoc_name {
+                continue;
+            }
+            let Some(aliased_ty) = type_alias_data.signature.aliased_ty() else {
+                continue;
+            };
+
+            let context = TypePathContext {
+                module: impl_data.owner,
+                impl_ref: Some(selection.trait_impl.impl_ref),
+            };
+            let resolved_ty = self
+                .context
+                .type_refs(TypeRefUseSite::OwnerContext(context))
+                .resolve(aliased_ty)?;
+            return Ok(Some(
+                InferTypeRefProjector::new(&selection.subst)
+                    .ty_from_type_ref(aliased_ty, &resolved_ty),
+            ));
+        }
+
+        Ok(None)
+    }
+
+    fn probe_trait_goal(
+        &self,
+        goal: &TraitGoal,
+        table: &InferenceTable,
+    ) -> Result<ExpectedUnique<TraitSelection>, PackageStoreError> {
+        TraitSelectionQuery::with_index(
+            self.context.item_paths(),
+            self.context.target_items(),
+            self.context.semantic_index(),
+        )
+        .probe(goal, table)
+    }
+}
+
+pub(crate) fn self_associated_type_name(ty: &TypeRef) -> Option<&str> {
+    // TODO: Generalize this replacement to nested shapes such as `Option<Self::Item>` when
+    // selected-call obligations need them.
+    let TypeRef::Path(path) = ty else {
+        return None;
+    };
+    let [self_segment, assoc_segment] = path.segments.as_slice() else {
+        return None;
+    };
+    if path.absolute
+        || self_segment.name.as_str() != "Self"
+        || !self_segment.args.is_empty()
+        || !assoc_segment.args.is_empty()
+    {
+        return None;
+    }
+
+    Some(assoc_segment.name.as_str())
+}

--- a/crates/engine/body-ir/src/tests/closures.rs
+++ b/crates/engine/body-ir/src/tests/closures.rs
@@ -35,22 +35,22 @@ pub fn use_it(user: User) -> User {
             bindings
             - v0 param user `user`: User => nominal struct body_closure_fixture[lib]::crate::User @ 3:15-3:19
             - v1 param user `user`: User => nominal struct body_closure_fixture[lib]::crate::User @ 4:28-4:32
-            - v2 let pick `pick` => <unknown> @ 4:9-4:13
+            - v2 let pick `pick` => closure #2 @ 4:9-4:13
             - v3 param left `left` => nominal struct body_closure_fixture[lib]::crate::User @ 5:18-5:22
             - v4 param right `right` => nominal struct body_closure_fixture[lib]::crate::User @ 5:24-5:29
-            - v5 let pair `pair` => <unknown> @ 5:9-5:13
+            - v5 let pair `pair` => closure #4 @ 5:9-5:13
             body
             expr e6 block s1 => nominal struct body_closure_fixture[lib]::crate::User @ 3:35-7:2
               stmt s0 let v2 @ 4:5-4:57
                 initializer
-                  expr e2 closure async move s2 (v1: User) -> User => <unknown> @ 4:16-4:56
+                  expr e2 closure async move s2 (v1: User) -> User => closure #2 @ 4:16-4:56
                     body
                       expr e1 block s3 => nominal struct body_closure_fixture[lib]::crate::User @ 4:48-4:56
                         tail
                           expr e0 path user -> local v1 => nominal struct body_closure_fixture[lib]::crate::User @ 4:50-4:54
               stmt s1 let v5 @ 5:5-5:51
                 initializer
-                  expr e4 closure s4 (v3, v4: (User, User)) => <unknown> @ 5:16-5:50
+                  expr e4 closure s4 (v3, v4: (User, User)) => closure #4 @ 5:16-5:50
                     body
                       expr e3 path left -> local v3 => nominal struct body_closure_fixture[lib]::crate::User @ 5:46-5:50
               tail
@@ -89,12 +89,12 @@ pub fn use_it(user: User) -> User {
             bindings
             - v0 param user `user`: User => nominal struct body_untyped_closure_fixture[lib]::crate::User @ 3:15-3:19
             - v1 param user `user` => <unknown> @ 4:17-4:21
-            - v2 let echo `echo` => <unknown> @ 4:9-4:13
+            - v2 let echo `echo` => closure #1 @ 4:9-4:13
             body
             expr e3 block s1 => nominal struct body_untyped_closure_fixture[lib]::crate::User @ 3:35-6:2
               stmt s0 let v2 @ 4:5-4:28
                 initializer
-                  expr e1 closure s2 (v1) => <unknown> @ 4:16-4:27
+                  expr e1 closure s2 (v1) => closure #1 @ 4:16-4:27
                     body
                       expr e0 path user -> local v1 => <unknown> @ 4:23-4:27
               tail
@@ -174,7 +174,7 @@ pub fn use_it(attr: Attr) {
                   callee
                     expr e0 path with_attrs -> item fn body_direct_closure_expectation_fixture[lib]::crate::with_attrs => <unknown> @ 15:5-15:15
                   arg
-                    expr e4 closure s2 (v1) => <unknown> @ 15:16-15:40
+                    expr e4 closure s2 (v1) => closure #4 @ 15:16-15:40
                       body
                         expr e3 method_call push -> fn impl AttrVec::push => () @ 15:24-15:40
                           receiver
@@ -186,7 +186,7 @@ pub fn use_it(attr: Attr) {
                   callee
                     expr e6 path with_pair -> item fn body_direct_closure_expectation_fixture[lib]::crate::with_pair => <unknown> @ 16:5-16:14
                   arg
-                    expr e8 closure s3 (v2, v3) => <unknown> @ 16:15-16:35
+                    expr e8 closure s3 (v2, v3) => closure #8 @ 16:15-16:35
                       body
                         expr e7 path left -> local v2 => nominal struct body_direct_closure_expectation_fixture[lib]::crate::User @ 16:31-16:35
 

--- a/crates/engine/body-ir/src/tests/closures.rs
+++ b/crates/engine/body-ir/src/tests/closures.rs
@@ -172,7 +172,7 @@ pub fn use_it(attr: Attr) {
               stmt s0 expr; @ 15:5-15:42
                 expr e5 call => () @ 15:5-15:41
                   callee
-                    expr e0 path with_attrs -> item fn body_direct_closure_expectation_fixture[lib]::crate::with_attrs => <unknown> @ 15:5-15:15
+                    expr e0 path with_attrs -> fn body_direct_closure_expectation_fixture[lib]::crate::with_attrs => <unknown> @ 15:5-15:15
                   arg
                     expr e4 closure s2 (v1) => closure #4 @ 15:16-15:40
                       body
@@ -184,7 +184,7 @@ pub fn use_it(attr: Attr) {
               stmt s1 expr; @ 16:5-16:37
                 expr e9 call => () @ 16:5-16:36
                   callee
-                    expr e6 path with_pair -> item fn body_direct_closure_expectation_fixture[lib]::crate::with_pair => <unknown> @ 16:5-16:14
+                    expr e6 path with_pair -> fn body_direct_closure_expectation_fixture[lib]::crate::with_pair => <unknown> @ 16:5-16:14
                   arg
                     expr e8 closure s3 (v2, v3) => closure #8 @ 16:15-16:35
                       body

--- a/crates/engine/body-ir/src/tests/closures.rs
+++ b/crates/engine/body-ir/src/tests/closures.rs
@@ -102,3 +102,104 @@ pub fn use_it(user: User) -> User {
         "#]],
     );
 }
+
+#[test]
+fn infers_closure_params_from_direct_fn_trait_expectations() {
+    check_project_body_ir(
+        r#"
+//- /Cargo.toml
+[package]
+name = "body_direct_closure_expectation_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct Attr;
+
+pub struct AttrVec;
+
+impl AttrVec {
+    pub fn push(&mut self, attr: Attr) {}
+}
+
+pub struct User;
+
+pub fn with_attrs(f: impl FnOnce(&mut AttrVec)) {}
+pub fn with_pair(f: impl FnOnce((User, User)) -> User) {}
+
+pub fn use_it(attr: Attr) {
+    with_attrs(|attrs| attrs.push(attr));
+    with_pair(|(left, right)| left);
+}
+"#,
+        expect![[r#"
+            package body_direct_closure_expectation_fixture
+
+            body_direct_closure_expectation_fixture [lib]
+            body b0 fn body_direct_closure_expectation_fixture[lib]::crate::with_attrs @ 11:1-11:51
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: <none>
+            bindings
+            - v0 param f `f`: impl FnOnce(&mut AttrVec) => syntax impl FnOnce(&mut AttrVec) @ 11:19-11:20
+            body
+            expr e0 block s1 => () @ 11:49-11:51
+
+
+            body b1 fn body_direct_closure_expectation_fixture[lib]::crate::with_pair @ 12:1-12:58
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: <none>
+            bindings
+            - v0 param f `f`: impl FnOnce((User, User)) -> User => syntax impl FnOnce((User, User)) -> User @ 12:18-12:19
+            body
+            expr e0 block s1 => () @ 12:56-12:58
+
+
+            body b2 fn body_direct_closure_expectation_fixture[lib]::crate::use_it @ 14:1-17:2
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: <none>
+            - s2 parent s1: v1
+            - s3 parent s1: v2, v3
+            bindings
+            - v0 param attr `attr`: Attr => nominal struct body_direct_closure_expectation_fixture[lib]::crate::Attr @ 14:15-14:19
+            - v1 param attrs `attrs` => &mut nominal struct body_direct_closure_expectation_fixture[lib]::crate::AttrVec @ 15:17-15:22
+            - v2 param left `left` => nominal struct body_direct_closure_expectation_fixture[lib]::crate::User @ 16:17-16:21
+            - v3 param right `right` => nominal struct body_direct_closure_expectation_fixture[lib]::crate::User @ 16:23-16:28
+            body
+            expr e10 block s1 => () @ 14:27-17:2
+              stmt s0 expr; @ 15:5-15:42
+                expr e5 call => () @ 15:5-15:41
+                  callee
+                    expr e0 path with_attrs -> item fn body_direct_closure_expectation_fixture[lib]::crate::with_attrs => <unknown> @ 15:5-15:15
+                  arg
+                    expr e4 closure s2 (v1) => <unknown> @ 15:16-15:40
+                      body
+                        expr e3 method_call push -> fn impl AttrVec::push => () @ 15:24-15:40
+                          receiver
+                            expr e1 path attrs -> local v1 => &mut nominal struct body_direct_closure_expectation_fixture[lib]::crate::AttrVec @ 15:24-15:29
+                          arg
+                            expr e2 path attr -> local v0 => nominal struct body_direct_closure_expectation_fixture[lib]::crate::Attr @ 15:35-15:39
+              stmt s1 expr; @ 16:5-16:37
+                expr e9 call => () @ 16:5-16:36
+                  callee
+                    expr e6 path with_pair -> item fn body_direct_closure_expectation_fixture[lib]::crate::with_pair => <unknown> @ 16:5-16:14
+                  arg
+                    expr e8 closure s3 (v2, v3) => <unknown> @ 16:15-16:35
+                      body
+                        expr e7 path left -> local v2 => nominal struct body_direct_closure_expectation_fixture[lib]::crate::User @ 16:31-16:35
+
+
+            body b3 fn impl AttrVec::push @ 6:5-6:42
+            scopes
+            - s0 parent <none>: v0, v1
+            - s1 parent s0: <none>
+            bindings
+            - v0 self_param self `&mut self` => &mut Self struct body_direct_closure_expectation_fixture[lib]::crate::AttrVec @ 6:17-6:26
+            - v1 param attr `attr`: Attr => nominal struct body_direct_closure_expectation_fixture[lib]::crate::Attr @ 6:28-6:32
+            body
+            expr e0 block s1 => () @ 6:40-6:42
+        "#]],
+    );
+}

--- a/crates/engine/body-ir/src/tests/expressions.rs
+++ b/crates/engine/body-ir/src/tests/expressions.rs
@@ -1396,7 +1396,7 @@ pub fn use_cfg(
             - v5 let kept `kept` => u8 @ 55:17-55:21
             - v6 let fallback `fallback` => u8 @ 59:9-59:17
             - v7 param kept `kept`: u8 => u8 @ 62:44-62:48
-            - v8 let closure `closure` => <unknown> @ 62:9-62:16
+            - v8 let closure `closure` => closure #21 @ 62:9-62:16
             - v9 let matched `matched` => u8 @ 64:9-64:16
             body
             expr e25 block s1 => () @ 11:3-70:2
@@ -1446,7 +1446,7 @@ pub fn use_cfg(
                   expr e19 path pair -> local v4 => nominal struct body_cfg_list_fixture[lib]::crate::Pair @ 60:9-60:13
               stmt s6 let v8 @ 62:5-62:59
                 initializer
-                  expr e21 closure s2 (v7: u8) => <unknown> @ 62:19-62:58
+                  expr e21 closure s2 (v7: u8) => closure #21 @ 62:19-62:58
                     body
                       expr e20 path kept -> local v7 => u8 @ 62:54-62:58
               stmt s7 let v9 @ 64:5-69:7

--- a/crates/engine/body-ir/src/tests/utils.rs
+++ b/crates/engine/body-ir/src/tests/utils.rs
@@ -1027,6 +1027,7 @@ impl TargetBodyIrSnapshot<'_> {
                 bounds.sort();
                 format!("impl {}", bounds.join(" + "))
             }
+            Ty::Closure(id) => format!("closure #{}", id.index()),
             Ty::Nominal(ty) => format!("nominal {}", self.render_body_nominal_ty(ty)),
             Ty::SelfTy(ty) => format!("Self {}", self.render_body_nominal_ty(ty)),
             Ty::Unknown => "<unknown>".to_string(),

--- a/crates/engine/body-ir/src/tests/utils.rs
+++ b/crates/engine/body-ir/src/tests/utils.rs
@@ -1027,7 +1027,7 @@ impl TargetBodyIrSnapshot<'_> {
                 bounds.sort();
                 format!("impl {}", bounds.join(" + "))
             }
-            Ty::Closure(id) => format!("closure #{}", id.index()),
+            Ty::Closure(id) => format!("closure #{id}"),
             Ty::Nominal(ty) => format!("nominal {}", self.render_body_nominal_ty(ty)),
             Ty::SelfTy(ty) => format!("Self {}", self.render_body_nominal_ty(ty)),
             Ty::Unknown => "<unknown>".to_string(),

--- a/crates/engine/ir-model/src/items/type_ref.rs
+++ b/crates/engine/ir-model/src/items/type_ref.rs
@@ -65,6 +65,23 @@ impl TypeRef {
         }
     }
 
+    /// Returns the simple associated path shape `T::Assoc`.
+    ///
+    /// This is syntax-only: for `S::Item`, this returns `S` and `Item`, but the caller still has
+    /// to decide whether `S` is actually one of the relevant type parameters.
+    pub fn as_type_param_assoc_path(&self) -> Option<(&Name, &Name)> {
+        if let Self::Path(path) = self
+            && !path.absolute
+            && let [param_segment, assoc_segment] = path.segments.as_slice()
+            && param_segment.args.is_empty()
+            && assoc_segment.args.is_empty()
+        {
+            return Some((&param_segment.name, &assoc_segment.name));
+        }
+
+        None
+    }
+
     /// Returns true when this type syntax contains explicit generic arguments anywhere inside it.
     pub fn has_generic_args(&self) -> bool {
         match self {

--- a/crates/engine/ir-view/src/display/ty_label.rs
+++ b/crates/engine/ir-view/src/display/ty_label.rs
@@ -54,7 +54,7 @@ impl<'a, 'db> TypeRenderer<'a, 'db> {
                     .collect::<anyhow::Result<Vec<_>>>()?;
                 Ok((!bounds.is_empty()).then(|| format!("impl {}", bounds.join(" + "))))
             }
-            Ty::Closure(id) => Ok(Some(format!("{{closure#{}}}", id.index()))),
+            Ty::Closure(id) => Ok(Some(format!("{{closure#{id}}}"))),
             Ty::Nominal(ty) | Ty::SelfTy(ty) => self.render_nominal(ty),
             Ty::Unknown => Ok(None),
         }

--- a/crates/engine/ir-view/src/display/ty_label.rs
+++ b/crates/engine/ir-view/src/display/ty_label.rs
@@ -54,6 +54,7 @@ impl<'a, 'db> TypeRenderer<'a, 'db> {
                     .collect::<anyhow::Result<Vec<_>>>()?;
                 Ok((!bounds.is_empty()).then(|| format!("impl {}", bounds.join(" + "))))
             }
+            Ty::Closure(id) => Ok(Some(format!("{{closure#{}}}", id.index()))),
             Ty::Nominal(ty) | Ty::SelfTy(ty) => self.render_nominal(ty),
             Ty::Unknown => Ok(None),
         }

--- a/crates/engine/ty/src/generic_arg.rs
+++ b/crates/engine/ty/src/generic_arg.rs
@@ -49,6 +49,18 @@ impl GenericArg {
         }
     }
 
+    /// Returns true when this generic argument contains `Ty::Unknown` or unresolved syntax.
+    pub fn has_unknown_or_syntax(&self) -> bool {
+        match self {
+            Self::Type(ty) => ty.has_unknown_or_syntax(),
+            Self::FnTraitArgs { params, ret } => {
+                params.iter().any(Ty::has_unknown_or_syntax) || ret.has_unknown_or_syntax()
+            }
+            Self::AssocType { ty, .. } => ty.as_deref().is_some_and(Ty::has_unknown_or_syntax),
+            Self::Lifetime(_) | Self::Const(_) | Self::Unsupported(_) => false,
+        }
+    }
+
     pub(crate) fn is_projectable(&self) -> bool {
         match self {
             Self::Type(ty) => ty.is_projectable(),

--- a/crates/engine/ty/src/impl_match/mod.rs
+++ b/crates/engine/ty/src/impl_match/mod.rs
@@ -197,7 +197,12 @@ where
             }
             Ty::Reference { inner, .. } => Self::type_arg_comparison_is_uncertain(inner),
             Ty::Opaque { .. } => true,
-            Ty::Unit | Ty::Never | Ty::Primitive(_) | Ty::Nominal(_) | Ty::SelfTy(_) => false,
+            Ty::Unit
+            | Ty::Never
+            | Ty::Primitive(_)
+            | Ty::Closure(_)
+            | Ty::Nominal(_)
+            | Ty::SelfTy(_) => false,
         }
     }
 }

--- a/crates/engine/ty/src/impl_match/trait_methods.rs
+++ b/crates/engine/ty/src/impl_match/trait_methods.rs
@@ -4,7 +4,9 @@
 //! deeper solving. Simple direct cases still reuse bounded trait selection for consistency.
 
 use crate::inference::{InferTy, InferenceTable};
-use crate::{GenericArg, NominalTy, TraitGoal, TraitSelectionQuery, Ty, TypeSubst};
+use crate::{
+    GenericArg, NominalTy, TraitGoal, TraitSelectionOptions, TraitSelectionQuery, Ty, TypeSubst,
+};
 use rg_ir_model::hir::items::ImplData;
 use rg_ir_model::items::{GenericArg as ItemGenericArg, TypeRef};
 use rg_ir_model::{FunctionRef, ImplRef, TraitApplicability, TraitImplRef};
@@ -208,6 +210,7 @@ where
             &goal,
             &table,
             trait_impl,
+            TraitSelectionOptions::new(),
         )?
         else {
             return Ok(None);

--- a/crates/engine/ty/src/inference/family.rs
+++ b/crates/engine/ty/src/inference/family.rs
@@ -36,6 +36,7 @@ pub(crate) trait TyToInferMapper {
                     .map(|bound| self.map_opaque_bound(bound))
                     .collect::<UniqueVec<_>>(),
             },
+            Ty::Closure(id) => InferTy::Closure(*id),
             Ty::Syntax(ty) => InferTy::Syntax(Box::new(ty.clone())),
             Ty::Nominal(ty) => InferTy::Nominal(self.map_nominal_ty(ty)),
             Ty::SelfTy(ty) => InferTy::SelfTy(self.map_nominal_ty(ty)),
@@ -127,6 +128,7 @@ pub(super) trait InferTyMapper {
                     .map(|bound| self.map_infer_opaque_bound(bound))
                     .collect::<UniqueVec<_>>(),
             },
+            InferTy::Closure(id) => InferTy::Closure(*id),
             InferTy::Syntax(ty) => InferTy::Syntax(ty.clone()),
             InferTy::Nominal(ty) => InferTy::Nominal(self.map_infer_nominal_ty(ty)),
             InferTy::SelfTy(ty) => InferTy::SelfTy(self.map_infer_nominal_ty(ty)),
@@ -360,6 +362,7 @@ pub(super) trait InferToTyMapper {
                     .map(|bound| self.map_infer_opaque_bound(bound))
                     .collect(),
             ),
+            InferTy::Closure(id) => Ty::closure(*id),
             InferTy::Syntax(ty) => Ty::syntax(ty.as_ref().clone()),
             InferTy::Nominal(ty) => Ty::nominal(self.map_infer_nominal_ty(ty)),
             InferTy::SelfTy(ty) => Ty::self_ty(self.map_infer_nominal_ty(ty)),

--- a/crates/engine/ty/src/inference/model.rs
+++ b/crates/engine/ty/src/inference/model.rs
@@ -5,7 +5,7 @@ use rg_text::Name;
 
 use super::family::{PlainTyToInferMapper, TyToInferMapper};
 use super::table::{InferVarId, InferVarKind};
-use crate::{GenericArg, Mutability, PrimitiveTy, Ty};
+use crate::{ClosureTyId, GenericArg, Mutability, PrimitiveTy, Ty};
 
 /// Inference-aware mirror of `Ty`.
 ///
@@ -34,6 +34,7 @@ pub enum InferTy {
     Opaque {
         bounds: UniqueVec<InferOpaqueTraitBound>,
     },
+    Closure(ClosureTyId),
     Syntax(Box<TypeRef>),
     Nominal(InferNominalTy),
     SelfTy(InferNominalTy),
@@ -57,6 +58,7 @@ impl InferTy {
             | Self::Slice(_)
             | Self::Reference { .. }
             | Self::Opaque { .. }
+            | Self::Closure(_)
             | Self::Syntax(_)
             | Self::Nominal(_)
             | Self::SelfTy(_)
@@ -88,6 +90,7 @@ impl InferTy {
             InferTy::Unit
             | InferTy::Never
             | InferTy::Primitive(_)
+            | InferTy::Closure(_)
             | InferTy::Syntax(_)
             | InferTy::Unknown => false,
         }
@@ -105,6 +108,7 @@ impl InferTy {
             | (InferTy::Slice(_), InferTy::Slice(_))
             | (InferTy::Unknown, InferTy::Unknown) => true,
             (InferTy::Primitive(lhs), InferTy::Primitive(rhs)) => lhs == rhs,
+            (InferTy::Closure(lhs), InferTy::Closure(rhs)) => lhs == rhs,
             (InferTy::Tuple(lhs), InferTy::Tuple(rhs)) => lhs.len() == rhs.len(),
             (InferTy::Array { len: lhs_len, .. }, InferTy::Array { len: rhs_len, .. }) => {
                 lhs_len == rhs_len
@@ -143,6 +147,7 @@ impl InferTy {
             InferTy::Unit
             | InferTy::Never
             | InferTy::Primitive(_)
+            | InferTy::Closure(_)
             | InferTy::Syntax(_)
             | InferTy::Unknown => false,
         }
@@ -168,6 +173,7 @@ impl InferTy {
             | InferTy::Unit
             | InferTy::Never
             | InferTy::Primitive(_)
+            | InferTy::Closure(_)
             | InferTy::Syntax(_) => false,
         }
     }

--- a/crates/engine/ty/src/inference/model.rs
+++ b/crates/engine/ty/src/inference/model.rs
@@ -177,6 +177,33 @@ impl InferTy {
             | InferTy::Syntax(_) => false,
         }
     }
+
+    /// Return whether this type still contains unknown gaps or unresolved source syntax.
+    pub fn has_unknown_or_syntax(&self) -> bool {
+        match self {
+            InferTy::Unknown | InferTy::Syntax(_) => true,
+            InferTy::Tuple(fields) => fields.iter().any(Self::has_unknown_or_syntax),
+            InferTy::Array { inner, .. }
+            | InferTy::Slice(inner)
+            | InferTy::Reference { inner, .. } => inner.has_unknown_or_syntax(),
+            InferTy::Opaque { bounds } => bounds.iter().any(|bound| {
+                bound
+                    .args
+                    .iter()
+                    .any(InferGenericArg::has_unknown_or_syntax)
+            }),
+            InferTy::Nominal(ty) | InferTy::SelfTy(ty) => {
+                ty.args.iter().any(InferGenericArg::has_unknown_or_syntax)
+            }
+            InferTy::Var(_)
+            | InferTy::IntegerVar(_)
+            | InferTy::FloatVar(_)
+            | InferTy::Unit
+            | InferTy::Never
+            | InferTy::Primitive(_)
+            | InferTy::Closure(_) => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -290,6 +317,22 @@ impl InferGenericArg {
             }
             InferGenericArg::AssocType { ty, .. } => {
                 ty.as_deref().is_some_and(InferTy::has_unknown)
+            }
+            InferGenericArg::Lifetime(_)
+            | InferGenericArg::Const(_)
+            | InferGenericArg::Unsupported(_) => false,
+        }
+    }
+
+    /// Return whether this generic arg still contains unknown gaps or unresolved source syntax.
+    pub fn has_unknown_or_syntax(&self) -> bool {
+        match self {
+            InferGenericArg::Type(ty) => ty.has_unknown_or_syntax(),
+            InferGenericArg::FnTraitArgs { params, ret } => {
+                params.iter().any(InferTy::has_unknown_or_syntax) || ret.has_unknown_or_syntax()
+            }
+            InferGenericArg::AssocType { ty, .. } => {
+                ty.as_deref().is_some_and(InferTy::has_unknown_or_syntax)
             }
             InferGenericArg::Lifetime(_)
             | InferGenericArg::Const(_)

--- a/crates/engine/ty/src/inference/table.rs
+++ b/crates/engine/ty/src/inference/table.rs
@@ -206,6 +206,7 @@ impl InferenceTable {
             | InferTy::Slice(_)
             | InferTy::Reference { .. }
             | InferTy::Opaque { .. }
+            | InferTy::Closure(_)
             | InferTy::Syntax(_)
             | InferTy::Nominal(_)
             | InferTy::SelfTy(_)
@@ -278,6 +279,7 @@ impl InferenceTable {
             (InferTy::Unit, InferTy::Unit)
             | (InferTy::Never, InferTy::Never)
             | (InferTy::Primitive(_), InferTy::Primitive(_))
+            | (InferTy::Closure(_), InferTy::Closure(_))
             | (InferTy::Syntax(_), InferTy::Syntax(_)) => UnifyResult::compatible(),
             (InferTy::Tuple(lhs_fields), InferTy::Tuple(rhs_fields)) => {
                 self.unify_iter(lhs_fields.iter(), rhs_fields.iter())

--- a/crates/engine/ty/src/inference/tests.rs
+++ b/crates/engine/ty/src/inference/tests.rs
@@ -1,5 +1,5 @@
 use rg_ir_model::{
-    DefMapRef, PackageSlot, StructId, TargetId, TargetRef, TraitId, TraitRef, TypeDefId,
+    DefMapRef, ExprId, PackageSlot, StructId, TargetId, TargetRef, TraitId, TraitRef, TypeDefId,
     TypeDefRef,
     items::{FloatTy, SignedIntTy, TypeRef, UnsignedIntTy},
 };
@@ -42,8 +42,8 @@ fn project_ty() -> Ty {
     Ty::nominal(NominalTy::bare(type_def(1)))
 }
 
-fn closure_ty(index: u32) -> Ty {
-    Ty::closure(ClosureTyId::new(index))
+fn closure_ty(index: usize) -> Ty {
+    Ty::closure(ClosureTyId::new(ExprId(index)))
 }
 
 fn vec_ty(inner: InferTy) -> InferTy {
@@ -182,7 +182,7 @@ fn closure_types_round_trip_through_inference_family() {
     let ty = closure_ty(7);
     let infer_ty = InferTy::from_ty(&ty);
 
-    assert_eq!(infer_ty, InferTy::Closure(ClosureTyId::new(7)));
+    assert_eq!(infer_ty, InferTy::Closure(ClosureTyId::new(ExprId(7))));
     assert_eq!(table.finalize(&infer_ty), ty);
 }
 

--- a/crates/engine/ty/src/inference/tests.rs
+++ b/crates/engine/ty/src/inference/tests.rs
@@ -6,7 +6,7 @@ use rg_ir_model::{
 
 use super::{InferTy, InferenceTable};
 use crate::{
-    GenericArg, NominalTy, PrimitiveTy, Ty,
+    ClosureTyId, GenericArg, NominalTy, PrimitiveTy, Ty,
     inference::{
         ExplicitTypeArgInstantiationBuilder, InferGenericArg, InferNominalTy,
         InferOpaqueTraitBound, UnknownTypeInstantiationBuilder,
@@ -40,6 +40,10 @@ fn user_ty() -> Ty {
 
 fn project_ty() -> Ty {
     Ty::nominal(NominalTy::bare(type_def(1)))
+}
+
+fn closure_ty(index: u32) -> Ty {
+    Ty::closure(ClosureTyId::new(index))
 }
 
 fn vec_ty(inner: InferTy) -> InferTy {
@@ -170,6 +174,16 @@ fn finalizes_solved_variables_inside_nominal_containers() {
             args: vec![GenericArg::Type(Box::new(user_ty()))],
         })
     );
+}
+
+#[test]
+fn closure_types_round_trip_through_inference_family() {
+    let table = InferenceTable::new();
+    let ty = closure_ty(7);
+    let infer_ty = InferTy::from_ty(&ty);
+
+    assert_eq!(infer_ty, InferTy::Closure(ClosureTyId::new(7)));
+    assert_eq!(table.finalize(&infer_ty), ty);
 }
 
 #[test]

--- a/crates/engine/ty/src/iteration.rs
+++ b/crates/engine/ty/src/iteration.rs
@@ -4,7 +4,7 @@
 //! traits and projects their associated `Item` type for impls whose self type can be matched
 //! without a solver.
 
-use rg_ir_model::items::{TypeBound, TypeRef};
+use rg_ir_model::items::TypeBound;
 use rg_ir_model::{
     AssocItemId, ImplRef, Path, PathSegment, TraitImplRef, TraitRef, TypeAliasRef,
     hir::items::ImplData,
@@ -290,28 +290,13 @@ where
                 continue;
             }
 
-            return Ok(type_alias_data
-                .signature
-                .aliased_ty()
-                .is_some_and(|ty| Self::is_type_param_assoc_item(ty, param_name, "Item")));
+            return Ok(type_alias_data.signature.aliased_ty().is_some_and(|ty| {
+                ty.as_type_param_assoc_path()
+                    .is_some_and(|(param, assoc)| param == param_name && assoc.as_str() == "Item")
+            }));
         }
 
         Ok(false)
-    }
-
-    fn is_type_param_assoc_item(ty: &TypeRef, param_name: &Name, assoc_name: &str) -> bool {
-        let TypeRef::Path(path) = ty else {
-            return false;
-        };
-        let [param_segment, assoc_segment] = path.segments.as_slice() else {
-            return false;
-        };
-
-        !path.absolute
-            && param_segment.name == *param_name
-            && param_segment.args.is_empty()
-            && assoc_segment.name.as_str() == assoc_name
-            && assoc_segment.args.is_empty()
     }
 }
 

--- a/crates/engine/ty/src/lib.rs
+++ b/crates/engine/ty/src/lib.rs
@@ -33,7 +33,7 @@ pub use self::{
     iteration::IterationItemResolver,
     member::{MemberMethodCandidateRef, MemberMethodOrigin, MemberQuery},
     primitive_expr::{ty_for_binary, ty_for_literal, ty_for_unary},
-    trait_selection::{TraitGoal, TraitSelection, TraitSelectionQuery},
+    trait_selection::{TraitGoal, TraitSelection, TraitSelectionOptions, TraitSelectionQuery},
     ty::{
         ClosureTyId, ExpectedNominalTyExt, ExpectedTyExt, NominalTy, OpaqueTraitBound, Ty,
         TypeSubst,

--- a/crates/engine/ty/src/lib.rs
+++ b/crates/engine/ty/src/lib.rs
@@ -34,5 +34,8 @@ pub use self::{
     member::{MemberMethodCandidateRef, MemberMethodOrigin, MemberQuery},
     primitive_expr::{ty_for_binary, ty_for_literal, ty_for_unary},
     trait_selection::{TraitGoal, TraitSelection, TraitSelectionQuery},
-    ty::{ExpectedNominalTyExt, ExpectedTyExt, NominalTy, OpaqueTraitBound, Ty, TypeSubst},
+    ty::{
+        ClosureTyId, ExpectedNominalTyExt, ExpectedTyExt, NominalTy, OpaqueTraitBound, Ty,
+        TypeSubst,
+    },
 };

--- a/crates/engine/ty/src/trait_selection/header.rs
+++ b/crates/engine/ty/src/trait_selection/header.rs
@@ -1,11 +1,33 @@
 use rg_ir_model::hir::items::ImplData;
 
-pub(super) struct SupportedImplHeader;
+/// Controls how much of an impl header the shallow selector is allowed to accept.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TraitSelectionOptions {
+    where_predicates_allowed: bool,
+}
 
-impl SupportedImplHeader {
-    /// Keep the first slice on direct impl headers. More complex headers need recursive goals.
-    pub(super) fn accepts(impl_data: &ImplData) -> bool {
-        impl_data.generics.where_predicates.is_empty()
+impl Default for TraitSelectionOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TraitSelectionOptions {
+    /// Keep trait selection strict by default: impl `where` predicates require more solving.
+    pub fn new() -> Self {
+        Self {
+            where_predicates_allowed: false,
+        }
+    }
+
+    /// Accept the impl header while leaving `where` predicates for a caller to solve separately.
+    pub fn ignore_where_predicates(mut self) -> Self {
+        self.where_predicates_allowed = true;
+        self
+    }
+
+    pub(super) fn accepts_impl_header(self, impl_data: &ImplData) -> bool {
+        (self.where_predicates_allowed || impl_data.generics.where_predicates.is_empty())
             && impl_data
                 .generics
                 .lifetimes

--- a/crates/engine/ty/src/trait_selection/matcher.rs
+++ b/crates/engine/ty/src/trait_selection/matcher.rs
@@ -127,6 +127,7 @@ where
             | InferTy::Slice(_)
             | InferTy::Reference { .. }
             | InferTy::Opaque { .. }
+            | InferTy::Closure(_)
             | InferTy::Nominal(_)
             | InferTy::SelfTy(_) => None,
         }
@@ -365,6 +366,7 @@ where
             | InferTy::Unit
             | InferTy::Never
             | InferTy::Primitive(_)
+            | InferTy::Closure(_)
             | InferTy::Nominal(_)
             | InferTy::SelfTy(_) => false,
         }

--- a/crates/engine/ty/src/trait_selection/mod.rs
+++ b/crates/engine/ty/src/trait_selection/mod.rs
@@ -12,7 +12,7 @@ use rg_ir_model::{TraitApplicability, TraitImplRef, TraitRef};
 use rg_ir_storage::{DefMapSource, ItemLookupIndex, ItemStoreSource, TargetItemQuery};
 use rg_std::ExpectedUnique;
 
-use self::header::SupportedImplHeader;
+pub use self::header::TraitSelectionOptions;
 use self::matcher::CandidateMatcher;
 use crate::ItemPathQuery;
 use crate::inference::{InferGenericArg, InferTy, InferTypeSubst, InferenceTable};
@@ -43,6 +43,7 @@ pub struct TraitSelectionQuery<'query, D, I> {
     item_paths: ItemPathQuery<'query, D, I>,
     target_items: TargetItemQuery<'query, D, I>,
     lookup_index: &'query ItemLookupIndex,
+    options: TraitSelectionOptions,
 }
 
 impl<'query, D, I> TraitSelectionQuery<'query, D, I>
@@ -59,7 +60,14 @@ where
             item_paths,
             target_items,
             lookup_index,
+            options: TraitSelectionOptions::new(),
         }
+    }
+
+    /// Use a non-default selection policy for all probes made through this query.
+    pub fn with_options(mut self, options: TraitSelectionOptions) -> Self {
+        self.options = options;
+        self
     }
 
     /// Return the unique visible impl whose simple header is compatible with the goal.
@@ -94,28 +102,31 @@ where
         table: &InferenceTable,
         trait_impl: TraitImplRef,
     ) -> Result<Option<TraitSelection>, I::Error> {
-        Self::probe_visible_trait_impl(
+        Self::probe_impl(
             &self.item_paths,
             &self.target_items,
             goal,
             table,
             trait_impl,
+            self.options,
         )
     }
 
-    /// Probe one already-visible impl without constructing an owning query wrapper.
+    /// Probe one already-visible impl using borrowed query state and an explicit policy.
     ///
     /// Some callers, such as method lookup, already own borrowed query state and want to reuse the
-    /// same candidate matcher for a single impl. This keeps that integration read-only and avoids
-    /// adding clone requirements to callers that only need a local proof.
-    pub fn probe_visible_trait_impl(
+    /// same candidate matcher for a single impl. Keeping the options as a parameter is intentional:
+    /// this helper is not a query-object method, so it must not smuggle in a different default
+    /// policy than `probe` / `probe_trait_impl`.
+    pub(crate) fn probe_visible_trait_impl(
         item_paths: &ItemPathQuery<'query, D, I>,
         target_items: &TargetItemQuery<'query, D, I>,
         goal: &TraitGoal,
         table: &InferenceTable,
         trait_impl: TraitImplRef,
+        options: TraitSelectionOptions,
     ) -> Result<Option<TraitSelection>, I::Error> {
-        Self::probe_impl(item_paths, target_items, goal, table, trait_impl)
+        Self::probe_impl(item_paths, target_items, goal, table, trait_impl, options)
     }
 
     fn trait_impl_candidates(&self, trait_ref: TraitRef) -> Result<Vec<TraitImplRef>, I::Error> {
@@ -132,12 +143,13 @@ where
         goal: &TraitGoal,
         table: &InferenceTable,
         trait_impl: TraitImplRef,
+        options: TraitSelectionOptions,
     ) -> Result<Option<TraitSelection>, I::Error> {
         let Some(impl_data) = target_items.items().impl_data(trait_impl.impl_ref)? else {
             return Ok(None);
         };
         if !impl_data.resolved_trait_ref.is(&goal.trait_ref)
-            || !SupportedImplHeader::accepts(impl_data)
+            || !options.accepts_impl_header(impl_data)
         {
             return Ok(None);
         }

--- a/crates/engine/ty/src/trait_selection/tests.rs
+++ b/crates/engine/ty/src/trait_selection/tests.rs
@@ -4,7 +4,7 @@ use rg_ir_model::hir::items::ImplData;
 use rg_ir_model::hir::source::{GeneratedItemRef, GeneratedSourceId, ItemSource, ItemSourceKind};
 use rg_ir_model::items::{
     GenericArg as ItemGenericArg, GenericParams, ItemTreeId, TypeBound, TypeParamData, TypePath,
-    TypePathSegment, TypeRef,
+    TypePathSegment, TypeRef, WherePredicate,
 };
 use rg_ir_model::{
     DefMapRef, FileId, ImplId, LocalImplId, LocalImplRef, ModuleId, ModuleRef, PackageSlot, Span,
@@ -18,9 +18,9 @@ use rg_ir_storage::{
 use rg_std::ExpectedUnique;
 use rg_text::Name;
 
-use super::{TraitGoal, TraitSelectionQuery};
+use super::{TraitGoal, TraitSelectionOptions, TraitSelectionQuery};
 use crate::inference::{InferGenericArg, InferNominalTy, InferTy, InferenceTable};
-use crate::{GenericArg, ItemPathQuery, NominalTy, Ty};
+use crate::{ClosureTyId, GenericArg, ItemPathQuery, NominalTy, Ty};
 
 struct TraitSelectionFixture {
     store: ItemStore,
@@ -171,6 +171,17 @@ fn bounded_type_param(name: &str) -> TypeParamData {
 fn generics(types: Vec<TypeParamData>) -> GenericParams {
     GenericParams {
         types,
+        ..GenericParams::default()
+    }
+}
+
+fn generics_with_where(
+    types: Vec<TypeParamData>,
+    where_predicates: Vec<WherePredicate>,
+) -> GenericParams {
+    GenericParams {
+        types,
+        where_predicates,
         ..GenericParams::default()
     }
 }
@@ -405,4 +416,47 @@ fn probe_skips_impls_that_need_bound_solving() {
     let selection = query(&fixture).probe(&goal, &table).unwrap();
 
     assert!(selection.is_empty());
+}
+
+#[test]
+fn probe_header_can_return_impl_that_still_needs_where_predicate_solving() {
+    let adapter_def = type_def(0);
+    let produces = trait_ref(0);
+    let impl_data = impl_data(
+        0,
+        generics_with_where(
+            vec![type_param("F"), type_param("R")],
+            vec![WherePredicate::Type {
+                ty: path_ty("F", Vec::new()),
+                bounds: vec![TypeBound::Trait(path_ty("FnOnce", Vec::new()))],
+            }],
+        ),
+        produces,
+        path_ty("Produces", Vec::new()),
+        adapter_def,
+        path_ty("Adapter", vec![type_arg(path_ty("F", Vec::new()))]),
+    );
+    let fixture = fixture(vec![impl_data]);
+
+    let goal = TraitGoal {
+        self_ty: nominal_infer_ty(
+            adapter_def,
+            vec![infer_type_arg(InferTy::Closure(ClosureTyId::new(0)))],
+        ),
+        trait_ref: produces,
+        args: Vec::new(),
+    };
+    let table = InferenceTable::new();
+
+    assert!(query(&fixture).probe(&goal, &table).unwrap().is_empty());
+    assert!(
+        matches!(
+            query(&fixture)
+                .with_options(TraitSelectionOptions::new().ignore_where_predicates())
+                .probe(&goal, &table)
+                .unwrap(),
+            ExpectedUnique::One(_)
+        ),
+        "header-only probe should leave the where predicate to a higher layer"
+    );
 }

--- a/crates/engine/ty/src/trait_selection/tests.rs
+++ b/crates/engine/ty/src/trait_selection/tests.rs
@@ -7,8 +7,8 @@ use rg_ir_model::items::{
     TypePathSegment, TypeRef, WherePredicate,
 };
 use rg_ir_model::{
-    DefMapRef, FileId, ImplId, LocalImplId, LocalImplRef, ModuleId, ModuleRef, PackageSlot, Span,
-    StructId, TargetId, TargetRef, TextSpan, TraitId, TraitImplRef, TraitRef, TypeDefId,
+    DefMapRef, ExprId, FileId, ImplId, LocalImplId, LocalImplRef, ModuleId, ModuleRef, PackageSlot,
+    Span, StructId, TargetId, TargetRef, TextSpan, TraitId, TraitImplRef, TraitRef, TypeDefId,
     TypeDefRef,
 };
 use rg_ir_storage::{
@@ -441,7 +441,9 @@ fn probe_header_can_return_impl_that_still_needs_where_predicate_solving() {
     let goal = TraitGoal {
         self_ty: nominal_infer_ty(
             adapter_def,
-            vec![infer_type_arg(InferTy::Closure(ClosureTyId::new(0)))],
+            vec![infer_type_arg(InferTy::Closure(ClosureTyId::new(ExprId(
+                0,
+            ))))],
         ),
         trait_ref: produces,
         args: Vec::new(),

--- a/crates/engine/ty/src/ty.rs
+++ b/crates/engine/ty/src/ty.rs
@@ -66,6 +66,23 @@ impl FromIterator<(Name, Ty)> for TypeSubst {
     }
 }
 
+/// Body-local identity of an anonymous closure type.
+///
+/// Rust gives every closure expression its own anonymous type. This id preserves that identity
+/// inside one body without pretending that it is a stable cross-body item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SchemaRead, SchemaWrite, MemorySize, Shrink)]
+pub struct ClosureTyId(u32);
+
+impl ClosureTyId {
+    pub fn new(index: u32) -> Self {
+        Self(index)
+    }
+
+    pub fn index(self) -> u32 {
+        self.0
+    }
+}
+
 /// Small type vocabulary shared by IR layers.
 #[derive(Debug, Clone, PartialEq, Eq, SchemaRead, SchemaWrite, MemorySize)]
 pub enum Ty {
@@ -88,6 +105,7 @@ pub enum Ty {
         #[wincode(with = "rg_wincode_utils::WincodeDynamic<UniqueVec<OpaqueTraitBound>>")]
         bounds: UniqueVec<OpaqueTraitBound>,
     },
+    Closure(ClosureTyId),
     Syntax(TypeRef),
     Nominal(NominalTy),
     SelfTy(NominalTy),
@@ -162,6 +180,10 @@ impl Ty {
         Self::Opaque { bounds }
     }
 
+    pub fn closure(id: ClosureTyId) -> Self {
+        Self::Closure(id)
+    }
+
     pub fn nominal(ty: NominalTy) -> Self {
         Self::Nominal(ty)
     }
@@ -198,6 +220,7 @@ impl Ty {
             | Self::Slice(_)
             | Self::Reference { .. }
             | Self::Opaque { .. }
+            | Self::Closure(_)
             | Self::Syntax(_)
             | Self::Unknown => &[],
         }
@@ -213,6 +236,7 @@ impl Ty {
             | Self::Array { .. }
             | Self::Slice(_)
             | Self::Opaque { .. }
+            | Self::Closure(_)
             | Self::Syntax(_)
             | Self::Nominal(_)
             | Self::SelfTy(_)
@@ -232,7 +256,9 @@ impl Ty {
                 .any(|bound| bound.args.iter().any(GenericArg::has_unknown)),
             Self::Nominal(ty) | Self::SelfTy(ty) => ty.args.iter().any(GenericArg::has_unknown),
             Self::Unknown => true,
-            Self::Unit | Self::Never | Self::Primitive(_) | Self::Syntax(_) => false,
+            Self::Unit | Self::Never | Self::Primitive(_) | Self::Closure(_) | Self::Syntax(_) => {
+                false
+            }
         }
     }
 
@@ -245,9 +271,12 @@ impl Ty {
             Self::Opaque { bounds } => bounds
                 .iter()
                 .all(|bound| bound.args.iter().all(GenericArg::is_projectable)),
-            Self::Unit | Self::Never | Self::Primitive(_) | Self::Nominal(_) | Self::SelfTy(_) => {
-                true
-            }
+            Self::Unit
+            | Self::Never
+            | Self::Primitive(_)
+            | Self::Closure(_)
+            | Self::Nominal(_)
+            | Self::SelfTy(_) => true,
         }
     }
 }
@@ -302,7 +331,7 @@ impl Shrink for Ty {
             Self::Nominal(ty) | Self::SelfTy(ty) => {
                 Shrink::shrink_to_fit(ty);
             }
-            Self::Unit | Self::Never | Self::Primitive(_) | Self::Unknown => {}
+            Self::Unit | Self::Never | Self::Primitive(_) | Self::Closure(_) | Self::Unknown => {}
         }
     }
 }

--- a/crates/engine/ty/src/ty.rs
+++ b/crates/engine/ty/src/ty.rs
@@ -1,5 +1,7 @@
+use std::fmt;
+
 use rg_ir_model::items::{GenericParams, TypeRef};
-use rg_ir_model::{TraitRef, TypeDefRef, TypePathResolution};
+use rg_ir_model::{ExprId, TraitRef, TypeDefRef, TypePathResolution};
 use rg_std::{ExpectedUnique, MemorySize, Shrink, UniqueVec};
 use rg_text::Name;
 
@@ -70,16 +72,26 @@ impl FromIterator<(Name, Ty)> for TypeSubst {
 ///
 /// Rust gives every closure expression its own anonymous type. This id preserves that identity
 /// inside one body without pretending that it is a stable cross-body item.
+///
+/// Example: the closure at `ExprId(12)` can become `ClosureTyId::new(ExprId(12))`, so body
+/// inference can later find that closure's params and body result. The id does not encode
+/// captures or which callable trait the closure implements.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SchemaRead, SchemaWrite, MemorySize, Shrink)]
-pub struct ClosureTyId(u32);
+pub struct ClosureTyId(ExprId);
 
 impl ClosureTyId {
-    pub fn new(index: u32) -> Self {
-        Self(index)
+    pub fn new(expr: ExprId) -> Self {
+        Self(expr)
     }
 
-    pub fn index(self) -> u32 {
+    pub fn into_expr_id(self) -> ExprId {
         self.0
+    }
+}
+
+impl fmt::Display for ClosureTyId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.0.fmt(f)
     }
 }
 

--- a/crates/engine/ty/src/ty.rs
+++ b/crates/engine/ty/src/ty.rs
@@ -274,6 +274,24 @@ impl Ty {
         }
     }
 
+    /// Returns true when this type shape contains `Ty::Unknown` or unresolved source syntax.
+    pub fn has_unknown_or_syntax(&self) -> bool {
+        match self {
+            Self::Tuple(fields) => fields.iter().any(Self::has_unknown_or_syntax),
+            Self::Array { inner, .. } | Self::Slice(inner) | Self::Reference { inner, .. } => {
+                inner.has_unknown_or_syntax()
+            }
+            Self::Opaque { bounds } => bounds
+                .iter()
+                .any(|bound| bound.args.iter().any(GenericArg::has_unknown_or_syntax)),
+            Self::Nominal(ty) | Self::SelfTy(ty) => {
+                ty.args.iter().any(GenericArg::has_unknown_or_syntax)
+            }
+            Self::Unknown | Self::Syntax(_) => true,
+            Self::Unit | Self::Never | Self::Primitive(_) | Self::Closure(_) => false,
+        }
+    }
+
     pub(crate) fn is_projectable(&self) -> bool {
         match self {
             Self::Unknown | Self::Syntax(_) => false,


### PR DESCRIPTION
Separate chunk; e.g. closure evidence, selected call / associated type projections / stuff like this

Conclusion of this chunk -- the idea to have "our own small trait solver" does not pay off, there is just _too_ much stuff there. Probably the next thing to do is to actually start integrating real solver, since it feels like a better idea than continuing the current path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved closure handling across type inference and trait selection, including better support for `Fn`, `FnMut`, and `FnOnce`-style arguments.
  * Added more accurate inference for iterator adapters, callable bounds, and associated types in chained expressions.

* **Bug Fixes**
  * Closure types now display consistently in rendered output and snapshots.
  * Fixed several inference cases where method calls, receiver types, or closure parameters could previously resolve to unknown or incorrect types.
  * Improved handling of `Self::Assoc` and type-parameter-associated paths in selected trait contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->