### PR TITLE
ci: Fix report downloading for memory-gungraun-lsp-compare

### DIFF
--- a/.github/actions/download-performance-baseline/action.yml
+++ b/.github/actions/download-performance-baseline/action.yml
@@ -1,0 +1,133 @@
+name: Download Performance baseline
+description: Find and download a retained baseline artifact from a successful main Performance run.
+
+inputs:
+  artifact-name:
+    description: Baseline artifact name to download.
+    required: true
+  path:
+    description: Directory where the artifact should be extracted.
+    required: true
+  base-sha:
+    description: Pull request base commit SHA to compare against.
+    required: true
+  github-token:
+    description: Token with actions:read access for listing runs and downloading artifacts.
+    required: true
+  workflow:
+    description: Workflow name that publishes the baseline artifacts.
+    required: false
+    default: Performance
+
+runs:
+  using: composite
+  steps:
+    - name: Find baseline artifact
+      id: find-baseline
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        BASE_SHA: ${{ inputs.base-sha }}
+        WORKFLOW_NAME: ${{ inputs.workflow }}
+      run: |
+        set -euo pipefail
+
+        artifact_available() {
+          local candidate_run_id="$1"
+          local artifact_count
+
+          artifact_count="$(
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate_run_id}/artifacts" \
+              --jq '[.artifacts[] | select(.name == env.ARTIFACT_NAME and (.expired | not))] | length'
+          )"
+
+          [[ "${artifact_count:-0}" != "0" ]]
+        }
+
+        ancestor_or_same() {
+          local candidate_sha="$1"
+          local status
+
+          status="$(
+            gh api "repos/${GITHUB_REPOSITORY}/compare/${candidate_sha}...${BASE_SHA}" \
+              --jq '.status' 2>/dev/null || true
+          )"
+
+          [[ "$status" == "identical" || "$status" == "ahead" ]]
+        }
+
+        run_id=""
+        head_sha=""
+
+        exact_run_id="$(
+          gh run list \
+            --workflow "$WORKFLOW_NAME" \
+            --branch main \
+            --commit "$BASE_SHA" \
+            --event push \
+            --status success \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId // ""'
+        )"
+
+        if [[ -n "$exact_run_id" ]] && artifact_available "$exact_run_id"; then
+          run_id="$exact_run_id"
+          head_sha="$BASE_SHA"
+        fi
+
+        if [[ -z "$run_id" ]]; then
+          mapfile -t candidate_runs < <(
+            gh run list \
+              --workflow "$WORKFLOW_NAME" \
+              --branch main \
+              --event push \
+              --status success \
+              --limit 50 \
+              --json databaseId,headSha \
+              --jq '.[] | [.databaseId, .headSha] | @tsv'
+          )
+
+          for candidate_run in "${candidate_runs[@]}"; do
+            IFS=$'\t' read -r candidate_run_id candidate_sha <<< "$candidate_run"
+            if [[ -z "$candidate_run_id" || -z "$candidate_sha" ]]; then
+              continue
+            fi
+
+            if ancestor_or_same "$candidate_sha" && artifact_available "$candidate_run_id"; then
+              run_id="$candidate_run_id"
+              head_sha="$candidate_sha"
+              break
+            fi
+          done
+        fi
+
+        if [[ -n "$run_id" ]]; then
+          {
+            echo "baseline-found=true"
+            echo "run-id=$run_id"
+            echo "head-sha=$head_sha"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "Selected \`$ARTIFACT_NAME\` from Performance run \`$run_id\` at \`$head_sha\`."
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "baseline-found=false" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "No retained \`$ARTIFACT_NAME\` artifact was found for base SHA \`$BASE_SHA\`."
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+    - name: Download baseline artifact
+      if: steps.find-baseline.outputs.baseline-found == 'true'
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.path }}
+        github-token: ${{ inputs.github-token }}
+        run-id: ${{ steps.find-baseline.outputs.run-id }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -11,6 +11,8 @@ on:
       - ".github/scripts/render_lsp_compatibility_comment.py"
       - ".github/scripts/render_memory_profile_comment.py"
       - ".github/scripts/render_performance_comment.py"
+      - ".github/actions/cargo-cache/**"
+      - ".github/actions/download-performance-baseline/**"
       - ".github/workflows/performance.yml"
       - "test_targets/bench_fixtures/fetch-rust-analyzer.sh"
       - "test_targets/moderate_workspace/**"
@@ -26,12 +28,15 @@ on:
       - ".github/scripts/render_lsp_compatibility_comment.py"
       - ".github/scripts/render_memory_profile_comment.py"
       - ".github/scripts/render_performance_comment.py"
+      - ".github/actions/cargo-cache/**"
+      - ".github/actions/download-performance-baseline/**"
       - ".github/workflows/performance.yml"
       - "test_targets/bench_fixtures/fetch-rust-analyzer.sh"
       - "test_targets/moderate_workspace/**"
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   pull-requests: write
 
@@ -48,12 +53,14 @@ jobs:
           target-dir: target
           dependency-key: ${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml', 'rust-toolchain.toml') }}
 
-      - name: Restore base memory profile
+      - name: Download base memory profile
         if: github.event_name == 'pull_request'
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/download-performance-baseline
         with:
+          artifact-name: memory-profile-baseline
+          base-sha: ${{ github.event.pull_request.base.sha }}
           path: .ci/memory/base
-          key: memory-profile-${{ github.event.pull_request.base.sha }}
+          github-token: ${{ github.token }}
 
       - name: Fetch rust-analyzer fixture
         run: ./test_targets/bench_fixtures/fetch-rust-analyzer.sh
@@ -85,19 +92,14 @@ jobs:
           name: memory-profile-comment
           path: .ci/memory/comment.md
 
-      - name: Prepare main-branch memory profile cache
+      - name: Upload main-branch memory profile baseline
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          mkdir -p .ci/memory/base
-          cp .ci/memory/current/result.json .ci/memory/base/result.json
-
-      - name: Save main-branch memory profile cache
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          path: .ci/memory/base
-          key: memory-profile-${{ github.sha }}
+          name: memory-profile-baseline
+          path: .ci/memory/current/result.json
+          if-no-files-found: error
+          retention-days: 30
 
   benchmark:
     name: benchmark
@@ -125,12 +127,14 @@ jobs:
           tool: gungraun-runner@0.18.2
           fallback: none
 
-      - name: Restore base Gungraun baseline
+      - name: Download base Gungraun baseline
         if: github.event_name == 'pull_request'
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/download-performance-baseline
         with:
+          artifact-name: gungraun-baseline
+          base-sha: ${{ github.event.pull_request.base.sha }}
           path: target/gungraun
-          key: gungraun-${{ github.event.pull_request.base.sha }}
+          github-token: ${{ github.token }}
 
       - name: Run pull request benchmark
         if: github.event_name == 'pull_request'
@@ -173,13 +177,14 @@ jobs:
           name: benchmark-comment
           path: .ci/benchmark/comment.md
 
-      - name: Save main-branch Gungraun baseline
+      - name: Upload main-branch Gungraun baseline
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
+          name: gungraun-baseline
           path: target/gungraun
-          key: gungraun-${{ github.sha }}
+          if-no-files-found: error
+          retention-days: 30
 
   lsp-compatibility:
     name: lsp-compatibility
@@ -193,12 +198,14 @@ jobs:
           target-dir: target
           dependency-key: ${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml', 'rust-toolchain.toml') }}
 
-      - name: Restore base LSP compatibility
+      - name: Download base LSP compatibility
         if: github.event_name == 'pull_request'
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: ./.github/actions/download-performance-baseline
         with:
+          artifact-name: lsp-compatibility-baseline
+          base-sha: ${{ github.event.pull_request.base.sha }}
           path: .ci/lsp/base
-          key: lsp-compatibility-${{ github.event.pull_request.base.sha }}
+          github-token: ${{ github.token }}
 
       - name: Fetch rust-analyzer fixture
         run: ./test_targets/bench_fixtures/fetch-rust-analyzer.sh
@@ -233,19 +240,14 @@ jobs:
           name: lsp-compatibility-comment
           path: .ci/lsp/comment.md
 
-      - name: Prepare main-branch LSP compatibility cache
+      - name: Upload main-branch LSP compatibility baseline
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          mkdir -p .ci/lsp/base
-          cp .ci/lsp/current/result.json .ci/lsp/base/result.json
-
-      - name: Save main-branch LSP compatibility cache
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          path: .ci/lsp/base
-          key: lsp-compatibility-${{ github.sha }}
+          name: lsp-compatibility-baseline
+          path: .ci/lsp/current/result.json
+          if-no-files-found: error
+          retention-days: 30
 
   performance-comment:
     name: performance-comment


### PR DESCRIPTION
Storing such data in cache is a bad idea since cache is transient and gets removed due to rust cache etc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Performance-related data is now stored and retrieved as downloadable artifacts, making baseline reuse more reliable across runs.
  * PR checks now automatically locate the most relevant prior baseline from an earlier successful run.

* **Bug Fixes**
  * Improved baseline selection when an exact match is unavailable, helping performance jobs continue with the best available reference data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->