### PR TITLE
refactor: Rework TypeRef to use anchor for qualified associated paths

### DIFF
--- a/crates/engine/analysis/src/tests/inference.rs
+++ b/crates/engine/analysis/src/tests/inference.rs
@@ -810,7 +810,7 @@ impl<I> iter::Iterator for iter::Enumerate<I>
 where
     I: iter::Iterator,
 {
-    type Item = (usize, I::Item);
+    type Item = (usize, <I>::Item);
 }
 
 pub fn missing<T>() -> T {}

--- a/crates/engine/body-ir/src/cursor/scan/path_completion_site.rs
+++ b/crates/engine/body-ir/src/cursor/scan/path_completion_site.rs
@@ -125,6 +125,10 @@ impl<'txn, 'db> PathCompletionSiteScanner<'txn, 'db> {
         scope: ScopeId,
         path: &TypePath,
     ) -> Option<PathCompletionSite> {
+        if path.anchor.is_some() {
+            return None;
+        }
+
         for (idx, segment) in path.segments.iter().enumerate().skip(1) {
             if !segment.span.touches(self.offset) {
                 continue;
@@ -133,7 +137,7 @@ impl<'txn, 'db> PathCompletionSiteScanner<'txn, 'db> {
             return Some(PathCompletionSite {
                 body,
                 scope,
-                qualifier: Path::from_type_path_prefix(path, idx - 1),
+                qualifier: Path::from_type_path_prefix(path, idx - 1)?,
                 member_prefix_span: segment.span,
                 namespace: PathCompletionNamespace::Types,
             });
@@ -152,7 +156,7 @@ impl<'txn, 'db> PathCompletionSiteScanner<'txn, 'db> {
         Some(PathCompletionSite {
             body,
             scope,
-            qualifier: Path::from_type_path(path),
+            qualifier: Path::from_type_path(path)?,
             member_prefix_span: span,
             namespace: PathCompletionNamespace::Types,
         })

--- a/crates/engine/body-ir/src/cursor/scan/paths.rs
+++ b/crates/engine/body-ir/src/cursor/scan/paths.rs
@@ -36,12 +36,19 @@ impl TypePathCursorScanner<'_> {
 
     /// Adds one candidate per path segment so each prefix can resolve independently.
     fn scan_type_path(&mut self, scope: ScopeId, path: &TypePath, file_id: FileId) {
+        if path.anchor.is_some() {
+            return;
+        }
+
         for (idx, segment) in path.segments.iter().enumerate() {
             if self.offset_matches(segment.span) {
+                let Some(path) = Path::from_type_path_prefix(path, idx) else {
+                    continue;
+                };
                 self.candidates.push(BodyCursorCandidate::TypePath {
                     body: self.body_ref,
                     scope,
-                    path: Path::from_type_path_prefix(path, idx),
+                    path,
                     file_id,
                     span: segment.span,
                 });

--- a/crates/engine/body-ir/src/resolution/pass/builtin_macro.rs
+++ b/crates/engine/body-ir/src/resolution/pass/builtin_macro.rs
@@ -73,6 +73,7 @@ where
             inner: Box::new(TypeRef::Path(TypePath {
                 source_span: synthetic_span,
                 absolute: false,
+                anchor: None,
                 segments: vec![TypePathSegment {
                     name: Name::new("str"),
                     args: Vec::new(),
@@ -123,6 +124,7 @@ where
         TypeRef::Path(TypePath {
             source_span: synthetic_span,
             absolute: false,
+            anchor: None,
             segments: segments
                 .iter()
                 .enumerate()

--- a/crates/engine/body-ir/src/resolution/query/traits.rs
+++ b/crates/engine/body-ir/src/resolution/query/traits.rs
@@ -114,7 +114,9 @@ where
         let TypeRef::Path(type_path) = trait_ty_ref else {
             return Ok(None);
         };
-        let path = Path::from_type_path(type_path);
+        let Some(path) = Path::from_type_path(type_path) else {
+            return Ok(None);
+        };
         let TypePathResolution::Trait(trait_ref) = self
             .context
             .type_path_query()

--- a/crates/engine/body-ir/src/resolution/query/type_ref.rs
+++ b/crates/engine/body-ir/src/resolution/query/type_ref.rs
@@ -126,7 +126,9 @@ where
         type_path: &TypePath,
         anchor: TypeRefAnchor,
     ) -> Result<Ty, PackageStoreError> {
-        let path = Path::from_type_path(type_path);
+        let Some(path) = Path::from_type_path(type_path) else {
+            return Ok(Ty::syntax(original_ty.clone()));
+        };
         if let Some(ty) = self.subst_for_single_segment(&path) {
             return Ok(ty);
         }
@@ -325,7 +327,9 @@ where
         };
 
         let anchor = self.anchor_for_use_site(self.use_site)?;
-        let path = Path::from_type_path(type_path);
+        let Some(path) = Path::from_type_path(type_path) else {
+            return Ok(None);
+        };
         let args = self.generic_args_from_type_path(type_path, anchor)?;
         let TypePathResolution::Trait(trait_ref) = self.resolve_type_path(anchor, &path)? else {
             return Ok(None);
@@ -381,6 +385,7 @@ fn prefix_type_ref(path: &TypePath) -> Option<TypeRef> {
     Some(TypeRef::Path(TypePath {
         source_span: path.source_span,
         absolute: path.absolute,
+        anchor: path.anchor.clone(),
         segments: path.segments[..prefix_len].to_vec(),
     }))
 }

--- a/crates/engine/body-ir/src/resolution/support/type_ref_projector.rs
+++ b/crates/engine/body-ir/src/resolution/support/type_ref_projector.rs
@@ -6,7 +6,7 @@
 
 use rg_ir_model::{
     TraitRef,
-    items::{GenericArg as ItemGenericArg, TypeRef},
+    items::{GenericArg as ItemGenericArg, TypePathAnchor, TypeRef},
 };
 use rg_ir_storage::{DefMapSource, ItemStoreSource};
 use rg_package_store::PackageStoreError;
@@ -200,14 +200,24 @@ where
             )?));
         }
 
-        // Check `<T as Trait>::Assoc`.
-        if let TypeRef::QualifiedAssociatedType {
-            self_ty,
-            trait_ty,
-            assoc_name,
-        } = ty
+        // Check `<T>::Assoc` and `<T as Trait>::Assoc`.
+        if let TypeRef::Path(path) = ty
+            && let Some(anchor) = &path.anchor
         {
-            return self.project_qualified_associated_ty(self_ty, trait_ty.as_deref(), assoc_name);
+            let Some(assoc_segment) = path.segments.first() else {
+                return Ok(LocalProjection::Unsupported);
+            };
+            if path.segments.len() != 1 || !assoc_segment.args.is_empty() {
+                return Ok(LocalProjection::Unsupported);
+            }
+            return match anchor {
+                TypePathAnchor::Type(self_ty) => {
+                    self.project_type_anchor_associated_ty(self_ty, &assoc_segment.name)
+                }
+                TypePathAnchor::QualifiedTrait { self_ty, trait_ty } => {
+                    self.project_qualified_associated_ty(self_ty, trait_ty, &assoc_segment.name)
+                }
+            };
         }
 
         // Check tuple.
@@ -248,10 +258,9 @@ where
         Ok(LocalProjection::NotBodyLocal)
     }
 
-    fn project_qualified_associated_ty(
+    fn project_type_anchor_associated_ty(
         &mut self,
         self_ty: &TypeRef,
-        trait_ty: Option<&TypeRef>,
         assoc_name: &Name,
     ) -> Result<LocalProjection, PackageStoreError> {
         if self.type_param_associated_ty.is_none() {
@@ -263,9 +272,32 @@ where
         if self.subst.type_param(param_name.as_str()).is_none() {
             return Ok(LocalProjection::Unsupported);
         }
-        let Some(trait_ty) = trait_ty else {
+        let Some(projector) = self.type_param_associated_ty.as_mut() else {
+            return Ok(LocalProjection::NotBodyLocal);
+        };
+
+        Ok(LocalProjection::from_attempted_projection(projector(
+            &param_name,
+            None,
+            assoc_name,
+        )?))
+    }
+
+    fn project_qualified_associated_ty(
+        &mut self,
+        self_ty: &TypeRef,
+        trait_ty: &TypeRef,
+        assoc_name: &Name,
+    ) -> Result<LocalProjection, PackageStoreError> {
+        if self.type_param_associated_ty.is_none() {
+            return Ok(LocalProjection::NotBodyLocal);
+        }
+        let Some(param_name) = self_ty.type_param_name() else {
             return Ok(LocalProjection::Unsupported);
         };
+        if self.subst.type_param(param_name.as_str()).is_none() {
+            return Ok(LocalProjection::Unsupported);
+        }
         let Some((trait_ref, resolved_args)) = self.resolver.resolve_trait_bound(trait_ty)? else {
             return Ok(LocalProjection::Unsupported);
         };

--- a/crates/engine/body-ir/src/resolution/support/type_ref_projector.rs
+++ b/crates/engine/body-ir/src/resolution/support/type_ref_projector.rs
@@ -263,18 +263,11 @@ where
         self_ty: &TypeRef,
         assoc_name: &Name,
     ) -> Result<LocalProjection, PackageStoreError> {
-        if self.type_param_associated_ty.is_none() {
-            return Ok(LocalProjection::NotBodyLocal);
-        }
-        let Some(param_name) = self_ty.type_param_name() else {
-            return Ok(LocalProjection::Unsupported);
+        let param_name = match self.type_param_assoc_name(self_ty) {
+            Ok(param_name) => param_name,
+            Err(projection) => return Ok(projection),
         };
-        if self.subst.type_param(param_name.as_str()).is_none() {
-            return Ok(LocalProjection::Unsupported);
-        }
-        let Some(projector) = self.type_param_associated_ty.as_mut() else {
-            return Ok(LocalProjection::NotBodyLocal);
-        };
+        let projector = self.type_param_assoc_projector_unchecked();
 
         Ok(LocalProjection::from_attempted_projection(projector(
             &param_name,
@@ -289,30 +282,43 @@ where
         trait_ty: &TypeRef,
         assoc_name: &Name,
     ) -> Result<LocalProjection, PackageStoreError> {
-        if self.type_param_associated_ty.is_none() {
-            return Ok(LocalProjection::NotBodyLocal);
-        }
-        let Some(param_name) = self_ty.type_param_name() else {
-            return Ok(LocalProjection::Unsupported);
+        let param_name = match self.type_param_assoc_name(self_ty) {
+            Ok(param_name) => param_name,
+            Err(projection) => return Ok(projection),
         };
-        if self.subst.type_param(param_name.as_str()).is_none() {
-            return Ok(LocalProjection::Unsupported);
-        }
         let Some((trait_ref, resolved_args)) = self.resolver.resolve_trait_bound(trait_ty)? else {
             return Ok(LocalProjection::Unsupported);
         };
         let Some(args) = self.project_qualified_trait_args(trait_ty, &resolved_args) else {
             return Ok(LocalProjection::Unsupported);
         };
-        let Some(projector) = self.type_param_associated_ty.as_mut() else {
-            return Ok(LocalProjection::NotBodyLocal);
-        };
+        let projector = self.type_param_assoc_projector_unchecked();
 
         Ok(LocalProjection::from_attempted_projection(projector(
             &param_name,
             Some((trait_ref, args)),
             assoc_name,
         )?))
+    }
+
+    fn type_param_assoc_name(&self, self_ty: &TypeRef) -> Result<Name, LocalProjection> {
+        if self.type_param_associated_ty.is_none() {
+            return Err(LocalProjection::NotBodyLocal);
+        }
+        let Some(param_name) = self_ty.type_param_name() else {
+            return Err(LocalProjection::Unsupported);
+        };
+        if self.subst.type_param(param_name.as_str()).is_none() {
+            return Err(LocalProjection::Unsupported);
+        }
+
+        Ok(param_name)
+    }
+
+    fn type_param_assoc_projector_unchecked(&mut self) -> &mut AssociatedTypeProjector<'a> {
+        self.type_param_associated_ty
+            .as_mut()
+            .expect("type-param associated projector must be checked")
     }
 
     fn project_qualified_trait_args(

--- a/crates/engine/body-ir/src/walk/ty.rs
+++ b/crates/engine/body-ir/src/walk/ty.rs
@@ -1,4 +1,4 @@
-use rg_ir_model::items::{GenericArg, TypeBound, TypePath, TypeRef};
+use rg_ir_model::items::{GenericArg, TypeBound, TypePath, TypePathAnchor, TypeRef};
 
 /// Walks every path node nested inside a type reference.
 ///
@@ -8,6 +8,10 @@ pub(crate) fn walk_type_ref_paths<'ty>(ty: &'ty TypeRef, visit: &mut impl FnMut(
     match ty {
         TypeRef::Path(path) => {
             visit(path);
+
+            if let Some(anchor) = &path.anchor {
+                walk_type_path_anchor(anchor, visit);
+            }
 
             for segment in &path.segments {
                 for arg in &segment.args {
@@ -28,14 +32,6 @@ pub(crate) fn walk_type_ref_paths<'ty>(ty: &'ty TypeRef, visit: &mut impl FnMut(
                         | GenericArg::Unsupported(_) => {}
                     }
                 }
-            }
-        }
-        TypeRef::QualifiedAssociatedType {
-            self_ty, trait_ty, ..
-        } => {
-            walk_type_ref_paths(self_ty, visit);
-            if let Some(trait_ty) = trait_ty {
-                walk_type_ref_paths(trait_ty, visit);
             }
         }
         TypeRef::Tuple(types) => {
@@ -61,5 +57,15 @@ pub(crate) fn walk_type_ref_paths<'ty>(ty: &'ty TypeRef, visit: &mut impl FnMut(
             }
         }
         TypeRef::Unknown(_) | TypeRef::Never | TypeRef::Unit | TypeRef::Infer => {}
+    }
+}
+
+fn walk_type_path_anchor<'ty>(anchor: &'ty TypePathAnchor, visit: &mut impl FnMut(&'ty TypePath)) {
+    match anchor {
+        TypePathAnchor::Type(ty) => walk_type_ref_paths(ty, visit),
+        TypePathAnchor::QualifiedTrait { self_ty, trait_ty } => {
+            walk_type_ref_paths(self_ty, visit);
+            walk_type_ref_paths(trait_ty, visit);
+        }
     }
 }

--- a/crates/engine/ir-model/src/hir/body/path.rs
+++ b/crates/engine/ir-model/src/hir/body/path.rs
@@ -6,7 +6,7 @@ use wincode::{SchemaRead, SchemaWrite};
 
 use crate::{
     Path, PathSegment, TargetRef,
-    items::{GenericArg, TypePath, TypePathSegment, TypeRef},
+    items::{GenericArg, TypePath, TypePathAnchor, TypePathSegment, TypeRef},
 };
 use rg_std::{MemorySize, Shrink};
 
@@ -76,6 +76,18 @@ pub enum BodyAssociatedPathPrefix {
     },
 }
 
+impl BodyAssociatedPathPrefix {
+    fn from_type_anchor(self_ty: &TypeRef, trait_ref: Option<&TypeRef>) -> Self {
+        match TypePathAnchor::from_parts(self_ty.clone(), trait_ref.cloned()) {
+            TypePathAnchor::Type(ty) => Self::Type(*ty),
+            TypePathAnchor::QualifiedTrait { self_ty, trait_ty } => Self::QualifiedTrait {
+                self_ty: *self_ty,
+                trait_ref: *trait_ty,
+            },
+        }
+    }
+}
+
 impl BodyPath {
     pub fn new(source_span: Span, absolute: bool, segments: Vec<BodyPathSegment>) -> Self {
         Self {
@@ -114,6 +126,7 @@ impl BodyPath {
             TypeRef::Path(TypePath {
                 source_span: self.source_span,
                 absolute: self.absolute,
+                anchor: None,
                 segments: prefix_segments,
             }),
             last_segment.as_str(),
@@ -141,13 +154,7 @@ impl BodyPath {
             _,
         ] = self.segments.as_slice()
         {
-            let prefix = match trait_ref {
-                Some(trait_ref) => BodyAssociatedPathPrefix::QualifiedTrait {
-                    self_ty: self_ty.clone(),
-                    trait_ref: trait_ref.clone(),
-                },
-                None => BodyAssociatedPathPrefix::Type(self_ty.clone()),
-            };
+            let prefix = BodyAssociatedPathPrefix::from_type_anchor(self_ty, trait_ref.as_ref());
             return Some((prefix, last_segment.as_str()));
         }
 
@@ -464,6 +471,7 @@ mod tests {
         TypeRef::Path(TypePath {
             source_span: span(),
             absolute: false,
+            anchor: None,
             segments: vec![TypePathSegment {
                 name: Name::new(name),
                 args: Vec::new(),

--- a/crates/engine/ir-model/src/hir/body/path.rs
+++ b/crates/engine/ir-model/src/hir/body/path.rs
@@ -6,7 +6,7 @@ use wincode::{SchemaRead, SchemaWrite};
 
 use crate::{
     Path, PathSegment, TargetRef,
-    items::{GenericArg, TypePath, TypePathAnchor, TypePathSegment, TypeRef},
+    items::{GenericArg, TypePath, TypePathSegment, TypeRef},
 };
 use rg_std::{MemorySize, Shrink};
 
@@ -78,12 +78,12 @@ pub enum BodyAssociatedPathPrefix {
 
 impl BodyAssociatedPathPrefix {
     fn from_type_anchor(self_ty: &TypeRef, trait_ref: Option<&TypeRef>) -> Self {
-        match TypePathAnchor::from_parts(self_ty.clone(), trait_ref.cloned()) {
-            TypePathAnchor::Type(ty) => Self::Type(*ty),
-            TypePathAnchor::QualifiedTrait { self_ty, trait_ty } => Self::QualifiedTrait {
-                self_ty: *self_ty,
-                trait_ref: *trait_ty,
+        match trait_ref {
+            Some(trait_ref) => Self::QualifiedTrait {
+                self_ty: self_ty.clone(),
+                trait_ref: trait_ref.clone(),
             },
+            None => Self::Type(self_ty.clone()),
         }
     }
 }

--- a/crates/engine/ir-model/src/items/mod.rs
+++ b/crates/engine/ir-model/src/items/mod.rs
@@ -23,7 +23,7 @@ pub use self::{
     },
     module::{ModuleItem, ModuleSource},
     primitive::{FloatTy, PrimitiveTy, SignedIntTy, UnsignedIntTy},
-    type_ref::{GenericArg, TypeBound, TypePath, TypePathSegment, TypeRef},
+    type_ref::{GenericArg, TypeBound, TypePath, TypePathAnchor, TypePathSegment, TypeRef},
     visibility::VisibilityLevel,
 };
 

--- a/crates/engine/ir-model/src/items/type_ref.rs
+++ b/crates/engine/ir-model/src/items/type_ref.rs
@@ -6,7 +6,7 @@ use rg_parse::Span;
 use rg_std::{MemorySize, Shrink};
 use rg_text::Name;
 
-use crate::Mutability;
+use crate::{Mutability, Path, PathSegment};
 
 /// Unresolved type syntax lowered into the item tree.
 ///
@@ -19,13 +19,6 @@ pub enum TypeRef {
     Unit,
     Infer,
     Path(#[wincode(with = "rg_wincode_utils::WincodeDynamic<TypePath>")] TypePath),
-    QualifiedAssociatedType {
-        #[wincode(with = "rg_wincode_utils::WincodeDynamic<Box<TypeRef>>")]
-        self_ty: Box<TypeRef>,
-        #[wincode(with = "rg_wincode_utils::WincodeDynamic<Option<Box<TypeRef>>>")]
-        trait_ty: Option<Box<TypeRef>>,
-        assoc_name: Name,
-    },
     Tuple(#[wincode(with = "rg_wincode_utils::WincodeDynamic<Vec<TypeRef>>")] Vec<TypeRef>),
     Reference {
         lifetime: Option<String>,
@@ -78,6 +71,7 @@ impl TypeRef {
     /// to decide whether `S` is actually one of the relevant type parameters.
     pub fn as_type_param_assoc_path(&self) -> Option<(&Name, &Name)> {
         if let Self::Path(path) = self
+            && path.anchor.is_none()
             && !path.absolute
             && let [param_segment, assoc_segment] = path.segments.as_slice()
             && param_segment.args.is_empty()
@@ -92,13 +86,7 @@ impl TypeRef {
     /// Returns true when this type syntax contains explicit generic arguments anywhere inside it.
     pub fn has_generic_args(&self) -> bool {
         match self {
-            Self::Path(path) => path.segments.iter().any(|segment| !segment.args.is_empty()),
-            Self::QualifiedAssociatedType {
-                self_ty, trait_ty, ..
-            } => {
-                self_ty.has_generic_args()
-                    || trait_ty.as_deref().is_some_and(Self::has_generic_args)
-            }
+            Self::Path(path) => path.has_generic_args(),
             Self::Tuple(types) => types.iter().any(Self::has_generic_args),
             Self::Reference { inner, .. }
             | Self::RawPointer { inner, .. }
@@ -117,21 +105,7 @@ impl TypeRef {
     /// Returns true when this type syntax mentions one of the provided type parameter names.
     pub fn mentions_type_param(&self, params: &[&str]) -> bool {
         match self {
-            Self::Path(path) => path.segments.iter().any(|segment| {
-                params.contains(&segment.name.as_str())
-                    || segment
-                        .args
-                        .iter()
-                        .any(|arg| arg.mentions_type_param(params))
-            }),
-            Self::QualifiedAssociatedType {
-                self_ty, trait_ty, ..
-            } => {
-                self_ty.mentions_type_param(params)
-                    || trait_ty
-                        .as_deref()
-                        .is_some_and(|trait_ty| trait_ty.mentions_type_param(params))
-            }
+            Self::Path(path) => path.mentions_type_param(params),
             Self::Tuple(types) => types.iter().any(|ty| ty.mentions_type_param(params)),
             Self::Reference { inner, .. }
             | Self::RawPointer { inner, .. }
@@ -161,14 +135,6 @@ impl fmt::Display for TypeRef {
             Self::Unit => write!(f, "()"),
             Self::Infer => write!(f, "_"),
             Self::Path(path) => write!(f, "{path}"),
-            Self::QualifiedAssociatedType {
-                self_ty,
-                trait_ty,
-                assoc_name,
-            } => match trait_ty {
-                Some(trait_ty) => write!(f, "<{self_ty} as {trait_ty}>::{assoc_name}"),
-                None => write!(f, "<{self_ty}>::{assoc_name}"),
-            },
             Self::Tuple(types) => {
                 write!(f, "(")?;
                 for (idx, ty) in types.iter().enumerate() {
@@ -235,14 +201,57 @@ pub struct TypePath {
     #[shrink(skip)]
     pub source_span: Span,
     pub absolute: bool,
+    #[wincode(with = "rg_wincode_utils::WincodeDynamic<Option<TypePathAnchor>>")]
+    pub anchor: Option<TypePathAnchor>,
     #[wincode(with = "rg_wincode_utils::WincodeDynamic<Vec<TypePathSegment>>")]
     pub segments: Vec<TypePathSegment>,
 }
 
 impl TypePath {
+    /// Returns the compact path shape used by DefMap resolution.
+    ///
+    /// Type anchors such as `<T>::Assoc` and `<T as Trait>::Assoc` are real path syntax, but
+    /// there is no honest way to represent the anchor as plain DefMap segments. Callers that need
+    /// associated type semantics should handle the anchored shape directly instead of resolving an
+    /// empty fallback path.
+    pub fn as_def_map_path(&self) -> Option<Path> {
+        if self.anchor.is_some() {
+            return None;
+        }
+
+        Some(Path {
+            absolute: self.absolute,
+            segments: self
+                .segments
+                .iter()
+                .map(|segment| PathSegment::from_type_segment_name(&segment.name))
+                .collect(),
+        })
+    }
+
+    /// Returns the DefMap path prefix ending at `end_idx`.
+    ///
+    /// Like [`Self::as_def_map_path`], anchored paths return `None` because their prefix carries
+    /// type syntax that DefMap paths cannot preserve.
+    pub fn as_def_map_path_prefix(&self, end_idx: usize) -> Option<Path> {
+        if self.anchor.is_some() {
+            return None;
+        }
+
+        Some(Path {
+            absolute: self.absolute,
+            segments: self
+                .segments
+                .iter()
+                .take(end_idx.saturating_add(1))
+                .map(|segment| PathSegment::from_type_segment_name(&segment.name))
+                .collect(),
+        })
+    }
+
     /// Returns the name of a single-segment relative path.
     pub fn single_name(&self) -> Option<&Name> {
-        if self.absolute || self.segments.len() != 1 {
+        if self.anchor.is_some() || self.absolute || self.segments.len() != 1 {
             return None;
         }
 
@@ -253,11 +262,38 @@ impl TypePath {
         self.single_name()
             .is_some_and(|name| name.as_str() == "Self")
     }
+
+    /// Returns true when any path segment or anchor contains explicit generic arguments.
+    pub fn has_generic_args(&self) -> bool {
+        self.anchor
+            .as_ref()
+            .is_some_and(TypePathAnchor::has_generic_args)
+            || self.segments.iter().any(|segment| !segment.args.is_empty())
+    }
+
+    /// Returns true when this path or anchor mentions one of the provided type parameter names.
+    pub fn mentions_type_param(&self, params: &[&str]) -> bool {
+        self.anchor
+            .as_ref()
+            .is_some_and(|anchor| anchor.mentions_type_param(params))
+            || self.segments.iter().any(|segment| {
+                params.contains(&segment.name.as_str())
+                    || segment
+                        .args
+                        .iter()
+                        .any(|arg| arg.mentions_type_param(params))
+            })
+    }
 }
 
 impl fmt::Display for TypePath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.absolute {
+        if let Some(anchor) = &self.anchor {
+            write!(f, "{anchor}")?;
+            if !self.segments.is_empty() {
+                write!(f, "::")?;
+            }
+        } else if self.absolute {
             write!(f, "::")?;
         }
 
@@ -269,6 +305,60 @@ impl fmt::Display for TypePath {
         }
 
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, SchemaRead, SchemaWrite, MemorySize, Shrink)]
+pub enum TypePathAnchor {
+    /// `<T>::Assoc`.
+    Type(#[wincode(with = "rg_wincode_utils::WincodeDynamic<Box<TypeRef>>")] Box<TypeRef>),
+    /// `<T as Trait>::Assoc`.
+    QualifiedTrait {
+        #[wincode(with = "rg_wincode_utils::WincodeDynamic<Box<TypeRef>>")]
+        self_ty: Box<TypeRef>,
+        #[wincode(with = "rg_wincode_utils::WincodeDynamic<Box<TypeRef>>")]
+        trait_ty: Box<TypeRef>,
+    },
+}
+
+impl TypePathAnchor {
+    pub fn from_parts(self_ty: TypeRef, trait_ty: Option<TypeRef>) -> Self {
+        match trait_ty {
+            Some(trait_ty) => Self::QualifiedTrait {
+                self_ty: Box::new(self_ty),
+                trait_ty: Box::new(trait_ty),
+            },
+            None => Self::Type(Box::new(self_ty)),
+        }
+    }
+
+    pub fn has_generic_args(&self) -> bool {
+        match self {
+            Self::Type(ty) => ty.has_generic_args(),
+            Self::QualifiedTrait { self_ty, trait_ty } => {
+                self_ty.has_generic_args() || trait_ty.has_generic_args()
+            }
+        }
+    }
+
+    pub fn mentions_type_param(&self, params: &[&str]) -> bool {
+        match self {
+            Self::Type(ty) => ty.mentions_type_param(params),
+            Self::QualifiedTrait { self_ty, trait_ty } => {
+                self_ty.mentions_type_param(params) || trait_ty.mentions_type_param(params)
+            }
+        }
+    }
+}
+
+impl fmt::Display for TypePathAnchor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Type(ty) => write!(f, "<{ty}>"),
+            Self::QualifiedTrait { self_ty, trait_ty } => {
+                write!(f, "<{self_ty} as {trait_ty}>")
+            }
+        }
     }
 }
 

--- a/crates/engine/ir-model/src/path.rs
+++ b/crates/engine/ir-model/src/path.rs
@@ -31,30 +31,15 @@ impl Path {
             return None;
         };
 
-        Some(Self::from_type_path(path))
+        Self::from_type_path(path)
     }
 
-    pub fn from_type_path(path: &TypePath) -> Self {
-        Self {
-            absolute: path.absolute,
-            segments: path
-                .segments
-                .iter()
-                .map(|segment| PathSegment::from_type_segment_name(&segment.name))
-                .collect(),
-        }
+    pub fn from_type_path(path: &TypePath) -> Option<Self> {
+        path.as_def_map_path()
     }
 
-    pub fn from_type_path_prefix(path: &TypePath, end_idx: usize) -> Self {
-        Self {
-            absolute: path.absolute,
-            segments: path
-                .segments
-                .iter()
-                .take(end_idx.saturating_add(1))
-                .map(|segment| PathSegment::from_type_segment_name(&segment.name))
-                .collect(),
-        }
+    pub fn from_type_path_prefix(path: &TypePath, end_idx: usize) -> Option<Self> {
+        path.as_def_map_path_prefix(end_idx)
     }
 
     pub fn from_use_path(path: &UsePath) -> Self {
@@ -167,7 +152,7 @@ pub enum PathSegment {
 }
 
 impl PathSegment {
-    fn from_type_segment_name(name: &Name) -> Self {
+    pub(crate) fn from_type_segment_name(name: &Name) -> Self {
         match name.as_str() {
             "self" => Self::SelfKw,
             "super" => Self::SuperKw,
@@ -222,7 +207,8 @@ mod tests {
         ];
 
         for (label, path, expected) in cases {
-            assert_eq!(Path::from_type_path(&path).to_string(), expected, "{label}");
+            let actual = Path::from_type_path(&path).map(|path| path.to_string());
+            assert_eq!(actual.as_deref(), Some(expected), "{label}");
         }
     }
 
@@ -290,13 +276,34 @@ mod tests {
         );
 
         assert_eq!(
-            Path::from_type_path_prefix(&type_path, 1).to_string(),
-            "api::User"
+            Path::from_type_path_prefix(&type_path, 1)
+                .map(|path| path.to_string())
+                .as_deref(),
+            Some("api::User")
         );
         assert_eq!(
             Path::from_use_path_prefix(&use_path, 1).to_string(),
             "::api::User"
         );
+    }
+
+    #[test]
+    fn anchored_type_paths_have_no_def_map_path_projection() {
+        let path = TypePath {
+            source_span: span(),
+            absolute: false,
+            anchor: Some(crate::items::TypePathAnchor::Type(Box::new(TypeRef::Path(
+                type_path(false, &["T"]),
+            )))),
+            segments: vec![TypePathSegment {
+                name: Name::new("Assoc"),
+                args: Vec::new(),
+                span: span(),
+            }],
+        };
+
+        assert_eq!(Path::from_type_path(&path), None);
+        assert_eq!(Path::from_type_path_prefix(&path, 0), None);
     }
 
     #[test]
@@ -455,6 +462,7 @@ mod tests {
         TypePath {
             source_span: span(),
             absolute,
+            anchor: None,
             segments: names
                 .iter()
                 .map(|name| TypePathSegment {

--- a/crates/engine/item-tree/src/item/type_ref.rs
+++ b/crates/engine/item-tree/src/item/type_ref.rs
@@ -1,6 +1,6 @@
 use rg_ir_model::{
     Mutability,
-    items::{GenericArg, TypeBound, TypePath, TypePathSegment, TypeRef},
+    items::{GenericArg, TypeBound, TypePath, TypePathAnchor, TypePathSegment, TypeRef},
 };
 use rg_parse::{LineIndex, Span};
 use rg_syntax::{
@@ -67,12 +67,7 @@ impl FromAst for TypeRef {
                 .unwrap_or_else(|| Self::unknown_from_text(normalized_syntax(&ty))),
             ast::Type::PathType(ty) => ty
                 .path()
-                .map(|path| {
-                    qualified_associated_type_from_ast(&path, line_index, &mut *interner)
-                        .unwrap_or_else(|| {
-                            Self::Path(TypePath::from_ast(&path, (line_index, &mut *interner)))
-                        })
-                })
+                .map(|path| Self::Path(TypePath::from_ast(&path, (line_index, &mut *interner))))
                 .unwrap_or_else(|| Self::unknown_from_text(normalized_syntax(&ty))),
             ast::Type::PtrType(ty) => Self::RawPointer {
                 mutability: Mutability::from_mut_token(ty.mut_token().is_some()),
@@ -111,81 +106,82 @@ impl FromAst for TypeRef {
     }
 }
 
-fn qualified_associated_type_from_ast(
-    path: &ast::Path,
-    line_index: &LineIndex,
-    interner: &mut NameInterner,
-) -> Option<TypeRef> {
-    let assoc_segment = path.segment()?;
-    if assoc_segment.generic_arg_list().is_some()
-        || assoc_segment.parenthesized_arg_list().is_some()
-        || assoc_segment.ret_type().is_some()
-    {
-        return None;
-    }
-    let assoc_name = assoc_segment
-        .name_ref()
-        .map(|name| interner.intern(name.syntax().text().to_string().trim()))?;
-
-    let qualifier = path.qualifier()?;
-    if qualifier.qualifier().is_some() {
-        return None;
-    }
-    let anchor_segment = qualifier.segment()?;
-    let ast::PathSegmentKind::Type {
-        type_ref,
-        trait_ref,
-    } = anchor_segment.kind()?
-    else {
-        return None;
-    };
-    let self_ty = type_ref
-        .as_ref()
-        .map(|ty| TypeRef::from_ast(ty, (line_index, &mut *interner)))?;
-    let trait_ty = trait_ref
-        .and_then(|trait_ref| trait_ref.path())
-        .map(|path| TypeRef::Path(TypePath::from_ast(&path, (line_index, interner))));
-
-    Some(TypeRef::QualifiedAssociatedType {
-        self_ty: Box::new(self_ty),
-        trait_ty: trait_ty.map(Box::new),
-        assoc_name,
-    })
-}
-
 impl FromAst for TypePath {
     type AstNode = ast::Path;
     type Context<'a> = (&'a LineIndex, &'a mut NameInterner);
 
     fn from_ast(path: &Self::AstNode, (line_index, interner): Self::Context<'_>) -> Self {
         let source_span = Span::from_text_range(path.syntax().text_range());
-        let absolute = path
-            .first_segment()
+        let mut ast_segments = Vec::new();
+        collect_ast_path_segments(path, &mut ast_segments);
+        let mut anchor = None;
+        let mut segment_start = 0;
+        let mut absolute = ast_segments
+            .first()
             .is_some_and(|segment| segment.coloncolon_token().is_some());
-        let mut segments = Vec::new();
-        collect_segments(path, line_index, interner, &mut segments);
+
+        // Rust stores `<T>::Assoc` and `<T as Trait>::Assoc` as a leading type path segment.
+        // Keep that as a path anchor and let the rest of the path use ordinary named segments.
+        if let Some(first_segment) = ast_segments.first()
+            && let Some(anchor_from_segment) =
+                type_path_anchor_from_ast(first_segment, line_index, &mut *interner)
+        {
+            anchor = Some(anchor_from_segment);
+            segment_start = 1;
+            absolute = false;
+        }
+        let segments = ast_segments
+            .iter()
+            .skip(segment_start)
+            .map(|segment| type_path_segment_from_ast(segment, line_index, &mut *interner))
+            .collect();
 
         Self {
             source_span,
             absolute,
+            anchor,
             segments,
         }
     }
 }
 
-fn collect_segments(
-    path: &ast::Path,
-    line_index: &LineIndex,
-    interner: &mut NameInterner,
-    segments: &mut Vec<TypePathSegment>,
-) {
+fn collect_ast_path_segments(path: &ast::Path, segments: &mut Vec<ast::PathSegment>) {
     if let Some(qualifier) = path.qualifier() {
-        collect_segments(&qualifier, line_index, interner, segments);
+        collect_ast_path_segments(&qualifier, segments);
     }
 
     if let Some(segment) = path.segment() {
-        segments.push(type_path_segment_from_ast(&segment, line_index, interner));
+        segments.push(segment);
     }
+}
+
+fn type_path_anchor_from_ast(
+    segment: &ast::PathSegment,
+    line_index: &LineIndex,
+    interner: &mut NameInterner,
+) -> Option<TypePathAnchor> {
+    let ast::PathSegmentKind::Type {
+        type_ref,
+        trait_ref,
+    } = segment.kind()?
+    else {
+        return None;
+    };
+
+    let self_ty = type_ref
+        .as_ref()
+        .map(|ty| TypeRef::from_ast(ty, (line_index, &mut *interner)))?;
+
+    let trait_ty = match trait_ref {
+        Some(trait_ref) => Some(
+            trait_ref
+                .path()
+                .map(|path| TypeRef::Path(TypePath::from_ast(&path, (line_index, interner))))?,
+        ),
+        None => None,
+    };
+
+    Some(TypePathAnchor::from_parts(self_ty, trait_ty))
 }
 
 fn type_path_segment_from_ast(

--- a/crates/engine/item-tree/src/lib.rs
+++ b/crates/engine/item-tree/src/lib.rs
@@ -22,8 +22,8 @@ pub use self::{
         MacroDefinitionAttrs, MacroDefinitionItem, MacroRulesAst, MacroRulesContext, MacroUseAttr,
         MacroUseSelector, MaybeFromAst, ModuleItem, ModuleSource, OuterDocs, ParamItem, ParamKind,
         StaticItem, StructItem, TraitItem, TraitItemContext, TypeAliasItem, TypeBound, TypePath,
-        TypePathSegment, TypeRef, UnionItem, UseImport, UseImportKind, UseItem, UsePath,
-        UsePathSegment, UsePathSegmentKind, VisibilityLevel, WherePredicate,
+        TypePathAnchor, TypePathSegment, TypeRef, UnionItem, UseImport, UseImportKind, UseItem,
+        UsePath, UsePathSegment, UsePathSegmentKind, VisibilityLevel, WherePredicate,
     },
     package::{FileTree, Package, TargetRoot},
 };

--- a/crates/engine/item-tree/src/tests/mod.rs
+++ b/crates/engine/item-tree/src/tests/mod.rs
@@ -1,6 +1,96 @@
 mod utils;
 
+use crate::{FromAst, GenericArg, TypePathAnchor, TypeRef};
 use expect_test::expect;
+use rg_parse::LineIndex;
+use rg_syntax::{AstNode as _, Edition, SourceFile, ast};
+use rg_text::NameInterner;
+
+#[test]
+fn lowers_qualified_associated_type_as_anchored_path() {
+    let TypeRef::Path(path) = lower_alias_ty("type Alias<I> = <I as Iterator>::Item;") else {
+        panic!("aliased type should lower to a path");
+    };
+    assert_eq!(path.to_string(), "<I as Iterator>::Item");
+    assert_eq!(path.segments.len(), 1);
+    assert_eq!(path.segments[0].name.as_str(), "Item");
+
+    let Some(TypePathAnchor::QualifiedTrait { self_ty, trait_ty }) = &path.anchor else {
+        panic!("qualified associated type should keep a qualified trait anchor");
+    };
+    assert_eq!(
+        self_ty.type_param_name().map(|name| name.to_string()),
+        Some("I".to_string())
+    );
+    let TypeRef::Path(trait_path) = trait_ty.as_ref() else {
+        panic!("qualified trait anchor should keep the trait as a path type");
+    };
+    assert_eq!(
+        trait_path.single_name().map(|name| name.as_str()),
+        Some("Iterator")
+    );
+}
+
+#[test]
+fn lowers_type_only_associated_type_as_anchored_path() {
+    let TypeRef::Path(path) = lower_alias_ty("type Alias<T> = <T>::Item;") else {
+        panic!("aliased type should lower to a path");
+    };
+    assert_eq!(path.to_string(), "<T>::Item");
+    assert_eq!(path.segments.len(), 1);
+    assert_eq!(path.segments[0].name.as_str(), "Item");
+
+    let Some(TypePathAnchor::Type(self_ty)) = &path.anchor else {
+        panic!("type-only associated path should keep a type anchor");
+    };
+    assert_eq!(
+        self_ty.type_param_name().map(|name| name.to_string()),
+        Some("T".to_string())
+    );
+}
+
+#[test]
+fn preserves_generic_args_on_associated_path_segment() {
+    let TypeRef::Path(path) = lower_alias_ty("type Alias<I> = <I as Iterator>::Item<'static, I>;")
+    else {
+        panic!("aliased type should lower to a path");
+    };
+    assert_eq!(path.to_string(), "<I as Iterator>::Item<'static, I>");
+    assert!(matches!(
+        &path.anchor,
+        Some(TypePathAnchor::QualifiedTrait { .. })
+    ));
+
+    let [assoc_segment] = path.segments.as_slice() else {
+        panic!("associated path should have one associated segment");
+    };
+    assert_eq!(assoc_segment.name.as_str(), "Item");
+    assert_eq!(assoc_segment.args.len(), 2);
+    assert!(matches!(
+        &assoc_segment.args[0],
+        GenericArg::Lifetime(lifetime) if lifetime == "'static"
+    ));
+    assert!(matches!(
+        &assoc_segment.args[1],
+        GenericArg::Type(ty) if ty.type_param_name().is_some_and(|name| name.as_str() == "I")
+    ));
+}
+
+fn lower_alias_ty(source: &str) -> TypeRef {
+    let file = SourceFile::parse(source, Edition::CURRENT)
+        .ok()
+        .expect("fixture should parse");
+    let alias = file
+        .syntax()
+        .descendants()
+        .find_map(ast::TypeAlias::cast)
+        .expect("fixture should contain a type alias");
+    let ty = alias.ty().expect("fixture type alias should have a value");
+    let line_index = LineIndex::new(source);
+    let mut interner = NameInterner::new();
+
+    TypeRef::from_ast(&ty, (&line_index, &mut interner))
+}
 
 #[test]
 fn dumps_lib_and_bin_item_trees() {

--- a/crates/engine/semantic-ir/src/cursor.rs
+++ b/crates/engine/semantic-ir/src/cursor.rs
@@ -9,7 +9,8 @@ use rg_ir_model::{DefMapRef, TargetRef};
 use rg_ir_model::{EnumVariantRef, FieldRef, FunctionRef, ItemOwner, TypeDefId, TypeDefRef};
 use rg_ir_storage::{ItemStoreQuery, TypePathContext};
 use rg_item_tree::{
-    FieldList, GenericArg, GenericParams, TypeBound, TypePath, TypeRef, WherePredicate,
+    FieldList, GenericArg, GenericParams, TypeBound, TypePath, TypePathAnchor, TypeRef,
+    WherePredicate,
 };
 use rg_package_store::PackageStoreError;
 use rg_parse::{FileId, Span};
@@ -430,14 +431,6 @@ impl SignatureCursorScanner<'_, '_> {
     fn push_type_ref(&mut self, context: TypePathContext, ty: &TypeRef, file_id: FileId) {
         match ty {
             TypeRef::Path(path) => self.push_type_path(context, path, file_id),
-            TypeRef::QualifiedAssociatedType {
-                self_ty, trait_ty, ..
-            } => {
-                self.push_type_ref(context, self_ty, file_id);
-                if let Some(trait_ty) = trait_ty {
-                    self.push_type_ref(context, trait_ty, file_id);
-                }
-            }
             TypeRef::Tuple(types) => {
                 for ty in types {
                     self.push_type_ref(context, ty, file_id);
@@ -461,11 +454,18 @@ impl SignatureCursorScanner<'_, '_> {
     }
 
     fn push_type_path(&mut self, context: TypePathContext, path: &TypePath, file_id: FileId) {
+        if let Some(anchor) = &path.anchor {
+            self.push_type_path_anchor(context, anchor, file_id);
+        }
+
         for (idx, segment) in path.segments.iter().enumerate() {
-            if self.offset_matches(segment.span) {
+            if path.anchor.is_none()
+                && self.offset_matches(segment.span)
+                && let Some(def_map_path) = Path::from_type_path_prefix(path, idx)
+            {
                 self.push_candidate(SemanticCursorCandidate::TypePath {
                     context,
-                    path: Path::from_type_path_prefix(path, idx),
+                    path: def_map_path,
                     file_id,
                     span: segment.span,
                 });
@@ -473,6 +473,21 @@ impl SignatureCursorScanner<'_, '_> {
 
             for arg in &segment.args {
                 self.push_generic_arg(context, arg, file_id);
+            }
+        }
+    }
+
+    fn push_type_path_anchor(
+        &mut self,
+        context: TypePathContext,
+        anchor: &TypePathAnchor,
+        file_id: FileId,
+    ) {
+        match anchor {
+            TypePathAnchor::Type(ty) => self.push_type_ref(context, ty, file_id),
+            TypePathAnchor::QualifiedTrait { self_ty, trait_ty } => {
+                self.push_type_ref(context, self_ty, file_id);
+                self.push_type_ref(context, trait_ty, file_id);
             }
         }
     }

--- a/crates/engine/ty/src/impl_match/projection.rs
+++ b/crates/engine/ty/src/impl_match/projection.rs
@@ -314,9 +314,11 @@ where
             module: impl_data.owner,
             impl_ref: Some(impl_ref),
         };
-        let TypePathResolution::Trait(trait_ref) = self
-            .item_paths
-            .resolve_type_path(context, &Path::from_type_path(bound_path))?
+        let Some(path) = Path::from_type_path(bound_path) else {
+            return Ok(false);
+        };
+        let TypePathResolution::Trait(trait_ref) =
+            self.item_paths.resolve_type_path(context, &path)?
         else {
             return Ok(false);
         };

--- a/crates/engine/ty/src/item_path.rs
+++ b/crates/engine/ty/src/item_path.rs
@@ -52,7 +52,9 @@ where
             TypeRef::Unit => Ok(Ty::Unit),
             TypeRef::Never => Ok(Ty::Never),
             TypeRef::Path(type_path) => {
-                let path = Path::from_type_path(type_path);
+                let Some(path) = Path::from_type_path(type_path) else {
+                    return Ok(unresolved_path_fallback);
+                };
                 if let Some(name) = path.single_name()
                     && let Some(ty) = subst.type_param(name)
                 {
@@ -283,8 +285,11 @@ where
         for bound in bounds {
             match bound {
                 TypeBound::Trait(TypeRef::Path(bound_path)) => {
+                    let Some(path) = Path::from_type_path(bound_path) else {
+                        continue;
+                    };
                     let TypePathResolution::Trait(trait_ref) =
-                        self.resolve_type_path(context, &Path::from_type_path(bound_path))?
+                        self.resolve_type_path(context, &path)?
                     else {
                         continue;
                     };

--- a/crates/engine/ty/src/trait_selection/chalk/lower.rs
+++ b/crates/engine/ty/src/trait_selection/chalk/lower.rs
@@ -15,10 +15,11 @@ use chalk_solve::rust_ir::{
     ImplDatum, ImplDatumBound, ImplType, Polarity, TraitDatum, TraitDatumBound, TraitFlags,
 };
 use rg_ir_model::items::{
-    GenericArg as ItemGenericArg, GenericParams, TypeBound, TypeRef, WherePredicate,
+    GenericArg as ItemGenericArg, GenericParams, TypeBound, TypePath, TypePathAnchor, TypeRef,
+    WherePredicate,
 };
 use rg_ir_model::{
-    ImplRef, Mutability, Path, TraitRef, TypeAliasRef, TypeDefId, TypeDefRef, TypePathResolution,
+    ImplRef, Mutability, TraitRef, TypeAliasRef, TypeDefId, TypeDefRef, TypePathResolution,
     hir::items::TypeAliasData,
 };
 use rg_ir_storage::{DefMapSource, ItemStoreSource, TypePathContext};
@@ -468,7 +469,11 @@ where
             TypeRef::Never => Some(TyKind::Never.intern(INTER)),
             TypeRef::Infer | TypeRef::Unknown(_) => None,
             TypeRef::Path(path) => {
-                let path_key = Path::from_type_path(path);
+                if path.anchor.is_some() {
+                    return self.lower_anchored_type_path(path, subst);
+                }
+
+                let path_key = path.as_def_map_path()?;
                 if let Some(name) = path_key.single_name() {
                     if let Some((subst, table)) = subst
                         && let Some(ty) = subst.type_param(name)
@@ -534,12 +539,31 @@ where
                 Some(TyKind::Array(inner, len).intern(INTER))
             }
             TypeRef::FnPointer { .. } | TypeRef::ImplTrait(_) | TypeRef::DynTrait(_) => None,
-            TypeRef::QualifiedAssociatedType {
-                self_ty,
-                trait_ty: Some(trait_ty),
-                assoc_name,
-            } => self.lower_qualified_associated_type(self_ty, trait_ty, assoc_name, subst),
-            TypeRef::QualifiedAssociatedType { trait_ty: None, .. } => None,
+        }
+    }
+
+    fn lower_anchored_type_path(
+        &self,
+        path: &TypePath,
+        subst: Option<(&InferenceTypeSubst, &InferenceTable)>,
+    ) -> Option<ChalkTy> {
+        let Some(anchor) = &path.anchor else {
+            return None;
+        };
+        let [assoc_segment] = path.segments.as_slice() else {
+            return None;
+        };
+
+        match anchor {
+            TypePathAnchor::Type(_) => None,
+            TypePathAnchor::QualifiedTrait { self_ty, trait_ty } => self
+                .lower_qualified_associated_type(
+                    self_ty,
+                    trait_ty,
+                    &assoc_segment.name,
+                    &assoc_segment.args,
+                    subst,
+                ),
         }
     }
 
@@ -548,8 +572,13 @@ where
         self_ty: &TypeRef,
         trait_ty: &TypeRef,
         assoc_name: &Name,
+        assoc_args: &[ItemGenericArg],
         subst: Option<(&InferenceTypeSubst, &InferenceTable)>,
     ) -> Option<ChalkTy> {
+        if !assoc_args.is_empty() {
+            return None;
+        }
+
         let self_ty = self.lower_type_ref(self_ty, subst)?;
         let TypeRef::Path(trait_path) = trait_ty else {
             return None;
@@ -734,7 +763,7 @@ where
     }
 
     fn resolve_trait_path(&self, path: &rg_ir_model::items::TypePath) -> Option<TraitRef> {
-        let path_key = Path::from_type_path(path);
+        let path_key = path.as_def_map_path()?;
         if let TypePathResolution::Trait(trait_ref) = self
             .item_paths
             .resolve_type_path(self.context, &path_key)

--- a/crates/engine/ty/src/trait_selection/matcher.rs
+++ b/crates/engine/ty/src/trait_selection/matcher.rs
@@ -554,21 +554,12 @@ where
     /// supports that for already-concrete projectable types.
     fn type_ref_mentions_impl_type_param(ty: &TypeRef, generics: &GenericParams) -> bool {
         match ty {
-            TypeRef::Path(path) => path.segments.iter().any(|segment| {
-                Self::is_impl_type_param(generics, &segment.name)
-                    || segment
-                        .args
-                        .iter()
-                        .any(|arg| Self::generic_arg_mentions_impl_type_param(arg, generics))
-            }),
-            TypeRef::QualifiedAssociatedType {
-                self_ty, trait_ty, ..
-            } => {
-                Self::type_ref_mentions_impl_type_param(self_ty, generics)
-                    || trait_ty.as_deref().is_some_and(|trait_ty| {
-                        Self::type_ref_mentions_impl_type_param(trait_ty, generics)
-                    })
-            }
+            TypeRef::Path(path) => path.mentions_type_param(
+                &generics
+                    .type_param_names()
+                    .map(|name| name.as_str())
+                    .collect::<Vec<_>>(),
+            ),
             TypeRef::Tuple(types) => types
                 .iter()
                 .any(|ty| Self::type_ref_mentions_impl_type_param(ty, generics)),
@@ -588,27 +579,6 @@ where
                 .iter()
                 .any(|bound| Self::type_bound_mentions_impl_type_param(bound, generics)),
             TypeRef::Unknown(_) | TypeRef::Never | TypeRef::Unit | TypeRef::Infer => false,
-        }
-    }
-
-    fn generic_arg_mentions_impl_type_param(
-        arg: &ItemGenericArg,
-        generics: &GenericParams,
-    ) -> bool {
-        match arg {
-            ItemGenericArg::Type(ty) => Self::type_ref_mentions_impl_type_param(ty, generics),
-            ItemGenericArg::AssocType { ty, .. } => ty
-                .as_ref()
-                .is_some_and(|ty| Self::type_ref_mentions_impl_type_param(ty, generics)),
-            ItemGenericArg::FnTraitArgs { params, ret } => {
-                params
-                    .iter()
-                    .any(|ty| Self::type_ref_mentions_impl_type_param(ty, generics))
-                    || Self::type_ref_mentions_impl_type_param(ret, generics)
-            }
-            ItemGenericArg::Lifetime(_)
-            | ItemGenericArg::Const(_)
-            | ItemGenericArg::Unsupported(_) => false,
         }
     }
 

--- a/crates/engine/ty/src/trait_selection/predicate.rs
+++ b/crates/engine/ty/src/trait_selection/predicate.rs
@@ -147,9 +147,11 @@ where
         if !segment.args.is_empty() {
             return Ok(None);
         }
-        if let TypePathResolution::Trait(trait_ref) = self
-            .item_paths
-            .resolve_type_path(context, &Path::from_type_path(path))?
+        let Some(path_key) = Path::from_type_path(path) else {
+            return Ok(None);
+        };
+        if let TypePathResolution::Trait(trait_ref) =
+            self.item_paths.resolve_type_path(context, &path_key)?
         {
             return Ok(Some(trait_ref));
         }

--- a/crates/engine/ty/src/trait_selection/projection.rs
+++ b/crates/engine/ty/src/trait_selection/projection.rs
@@ -6,7 +6,9 @@
 
 use rg_ir_model::{
     AssocItemId, Path, TraitApplicability, TraitRef, TypeAliasRef, TypePathResolution,
-    items::{GenericArg as ItemGenericArg, TypeBound, TypeRef, WherePredicate},
+    items::{
+        GenericArg as ItemGenericArg, TypeBound, TypePath, TypePathAnchor, TypeRef, WherePredicate,
+    },
 };
 use rg_ir_storage::{DefMapSource, ItemStoreSource, TypePathContext};
 use rg_std::ExpectedUnique;
@@ -325,25 +327,9 @@ where
         }
 
         match ty {
-            TypeRef::QualifiedAssociatedType {
-                self_ty,
-                trait_ty: Some(trait_ty),
-                assoc_name,
-            } => {
-                if remaining_depth == 0 {
-                    return Ok(None);
-                }
-                self.project_qualified_associated_type_ref(
-                    context,
-                    subst,
-                    table,
-                    self_ty,
-                    trait_ty,
-                    assoc_name.as_str(),
-                    remaining_depth,
-                )
+            TypeRef::Path(path) if path.anchor.is_some() => {
+                self.project_anchored_path_type_ref(context, subst, table, path, remaining_depth)
             }
-            TypeRef::QualifiedAssociatedType { trait_ty: None, .. } => Ok(None),
             TypeRef::Tuple(fields) => {
                 let mut table = table.clone();
                 let mut applicability = TraitApplicability::Yes;
@@ -437,6 +423,54 @@ where
                     table,
                 }))
             }
+        }
+    }
+
+    fn project_anchored_path_type_ref(
+        &self,
+        context: TypePathContext,
+        subst: &InferenceTypeSubst,
+        table: &InferenceTable,
+        path: &TypePath,
+        remaining_depth: usize,
+    ) -> Result<Option<ProjectedTypeRef>, I::Error> {
+        if remaining_depth == 0 {
+            return Ok(None);
+        }
+        let Some(anchor) = &path.anchor else {
+            return Ok(None);
+        };
+        let [assoc_segment] = path.segments.as_slice() else {
+            return Ok(None);
+        };
+        if !assoc_segment.args.is_empty() {
+            return Ok(None);
+        }
+
+        match anchor {
+            TypePathAnchor::Type(self_ty) => {
+                let Some(param_name) = self_ty.type_param_name() else {
+                    return Ok(None);
+                };
+                self.project_type_param_associated_path(
+                    context,
+                    subst,
+                    table,
+                    &param_name,
+                    assoc_segment.name.as_str(),
+                    remaining_depth,
+                )
+            }
+            TypePathAnchor::QualifiedTrait { self_ty, trait_ty } => self
+                .project_qualified_associated_type_ref(
+                    context,
+                    subst,
+                    table,
+                    self_ty,
+                    trait_ty,
+                    assoc_segment.name.as_str(),
+                    remaining_depth,
+                ),
         }
     }
 
@@ -646,9 +680,11 @@ where
         let TypeRef::Path(path) = trait_ty else {
             return Ok(None);
         };
-        let TypePathResolution::Trait(trait_ref) = self
-            .item_paths
-            .resolve_type_path(context, &Path::from_type_path(path))?
+        let Some(path_key) = Path::from_type_path(path) else {
+            return Ok(None);
+        };
+        let TypePathResolution::Trait(trait_ref) =
+            self.item_paths.resolve_type_path(context, &path_key)?
         else {
             return Ok(None);
         };

--- a/crates/engine/ty/src/trait_selection/tests/utils.rs
+++ b/crates/engine/ty/src/trait_selection/tests/utils.rs
@@ -8,8 +8,8 @@ use rg_ir_model::hir::signature::TypeAliasSignature;
 use rg_ir_model::hir::source::{GeneratedItemRef, GeneratedSourceId, ItemSource, ItemSourceKind};
 use rg_ir_model::items::{
     FieldList, FloatTy, GenericArg as ItemGenericArg, GenericParams, ItemTreeId, SignedIntTy,
-    TypeAliasItem, TypeBound, TypeParamData, TypePath, TypePathSegment, TypeRef, UnsignedIntTy,
-    VisibilityLevel, WherePredicate,
+    TypeAliasItem, TypeBound, TypeParamData, TypePath, TypePathAnchor, TypePathSegment, TypeRef,
+    UnsignedIntTy, VisibilityLevel, WherePredicate,
 };
 use rg_ir_model::{
     AssocItemId, DefId, DefMapRef, FileId, ImplId, ItemId, ItemOwner, LocalDefId, LocalDefRef,
@@ -187,16 +187,26 @@ pub(super) fn path_ty(path: &str, args: Vec<ItemGenericArg>) -> TypeRef {
     TypeRef::Path(TypePath {
         source_span: span,
         absolute: false,
+        anchor: None,
         segments,
     })
 }
 
 pub(super) fn qualified_assoc_ty(self_ty: TypeRef, trait_ty: TypeRef, assoc_name: &str) -> TypeRef {
-    TypeRef::QualifiedAssociatedType {
-        self_ty: Box::new(self_ty),
-        trait_ty: Some(Box::new(trait_ty)),
-        assoc_name: Name::new(assoc_name),
-    }
+    let span = fixture_span();
+    TypeRef::Path(TypePath {
+        source_span: span,
+        absolute: false,
+        anchor: Some(TypePathAnchor::QualifiedTrait {
+            self_ty: Box::new(self_ty),
+            trait_ty: Box::new(trait_ty),
+        }),
+        segments: vec![TypePathSegment {
+            name: Name::new(assoc_name),
+            args: Vec::new(),
+            span,
+        }],
+    })
 }
 
 pub(super) fn type_arg(ty: TypeRef) -> ItemGenericArg {
@@ -458,7 +468,6 @@ fn type_ref_path_name(ty: &TypeRef) -> Option<String> {
         | TypeRef::FnPointer { .. }
         | TypeRef::ImplTrait(_)
         | TypeRef::DynTrait(_)
-        | TypeRef::QualifiedAssociatedType { .. }
         | TypeRef::Unknown(_) => None,
     }
 }


### PR DESCRIPTION
The way it was done before was a shortcut, now it's better aligned with what RA does

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for associated types and anchored type paths across type resolution, trait matching, and cursor/completion behavior.
  * Type paths now preserve more information, including generic arguments and qualified associated-type forms.

* **Bug Fixes**
  * Fixed cases where certain type paths were incorrectly treated as resolvable, improving fallback behavior for unsupported paths.
  * Completion and scanning now skip anchored paths when appropriate, reducing spurious suggestions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->