### PR TITLE
ci: Fix renovate config, attempt N

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -49,24 +49,6 @@
     // a little more CI, but stale dependency PRs are much harder to trust.
     "rebaseWhen": "behind-base-branch",
 
-    // Some CI tools are installed from workflow strings rather than native
-    // package manifests. Teach Renovate about the important ones so they stay
-    // in the same dependency PRs as the libraries that require them.
-    "customManagers": [
-        {
-            "customType": "regex",
-            "description": "Update Rust CLI tools installed by CI",
-            "managerFilePatterns": [
-                "/^\\.github/workflows/.+\\.ya?ml$/"
-            ],
-            "matchStrings": [
-                "tool: (?<depName>gungraun-runner)@(?<currentValue>[^\\s]+)"
-            ],
-            "datasourceTemplate": "crate",
-            "versioningTemplate": "cargo"
-        }
-    ],
-
     // Refresh lockfiles weekly as a separate maintenance PR rather than mixing
     // transitive-only churn into direct dependency updates.
     "lockFileMaintenance": {
@@ -110,6 +92,18 @@
             "enabled": false
         },
         {
+            // Gungraun is only used by CI benchmarks, and its crate plus runner
+            // must stay protocol-compatible. Renovate can pick a stable manifest
+            // version while Cargo resolves a newer pending runner into Cargo.lock,
+            // so automated updates create more work than they save here.
+            "description": "Do not update Gungraun benchmark tooling automatically",
+            "matchDepNames": [
+                "gungraun",
+                "gungraun-runner"
+            ],
+            "enabled": false
+        },
+        {
             "description": "Group non-major Rust dependencies",
             "matchManagers": [
                 "cargo"
@@ -117,16 +111,6 @@
             "matchUpdateTypes": [
                 "minor",
                 "patch"
-            ],
-            "groupName": "rust dependencies"
-        },
-        {
-            "description": "Group CI Rust tools with Rust dependencies",
-            "matchManagers": [
-                "custom.regex"
-            ],
-            "matchDepNames": [
-                "gungraun-runner"
             ],
             "groupName": "rust dependencies"
         },
@@ -200,6 +184,7 @@
                 "digest"
             ],
             "groupName": "github-action digests",
+            "minimumReleaseAge": "0 days",
             "automerge": true
         }
     ]

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -175,7 +175,8 @@
         {
             // Digest refreshes keep already-pinned GitHub Actions pointing at the
             // current commit behind their version tags. They are intentionally kept
-            // separate from version bumps so this narrow update type can automerge.
+            // separate from version bumps so this narrow update type can automerge
+            // after the repository-wide release-age window has passed.
             "description": "Automerge only GitHub Action digest pin refreshes",
             "matchManagers": [
                 "github-actions"
@@ -184,7 +185,6 @@
                 "digest"
             ],
             "groupName": "github-action digests",
-            "minimumReleaseAge": "0 days",
             "automerge": true
         }
     ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ drop_bomb = "0.1.5"
 either = "1.15.0"
 expect-test = "1.5.1"
 futures = "0.3.32"
-gungraun = "0.18.2"
+gungraun = "=0.18.2"
 ignore = "0.4.26"
 itertools = "0.14.0"
 ls_types = { package = "ls-types", version = "0.0.6" }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to better control how CI-related crate updates are detected and refreshed.
  * Disabled automatic update runs for the `gungraun` and `gungraun-runner` crates to improve release consistency.
  * Adjusted refresh behavior for GitHub Actions digest pin updates to align with automerge timing after the repository-wide window.
  * Pinned the `gungraun` Rust dependency to a single exact version for more predictable builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->