### PR TITLE
feat: Fast start

### DIFF
--- a/.github/scripts/render_memory_profile_comment.py
+++ b/.github/scripts/render_memory_profile_comment.py
@@ -60,12 +60,48 @@ def normalize_optional_report(
 
 
 def normalize_report(report: dict[str, Any]) -> MemoryProfileReport:
+    if not is_current_report(report):
+        return normalize_previous_baseline_report(report)
+
+    return normalize_current_report(report)
+
+
+def is_current_report(report: dict[str, Any]) -> bool:
+    return isinstance(report.get("memory"), list) or isinstance(
+        report.get("profile_snapshot"), dict
+    )
+
+
+def normalize_current_report(report: dict[str, Any]) -> MemoryProfileReport:
     return MemoryProfileReport(
         workspace_root=string_value(report.get("workspace_root")),
         project=dict_value(report.get("project")),
         memory=current_project_memory(report),
         checkpoints=current_build_checkpoints(report),
     )
+
+
+def normalize_previous_baseline_report(report: dict[str, Any]) -> MemoryProfileReport:
+    # Pull-request jobs compare the current report against a baseline artifact produced by `main`.
+    # Keep this one older shape readable until `main` has regenerated baselines with the current
+    # analyze JSON report. This is not a general compatibility layer for older historical reports.
+    memory = dict_value(report.get("memory")).copy()
+    if "by_component" not in memory and "by_phase" in memory:
+        memory["by_component"] = memory["by_phase"]
+
+    return MemoryProfileReport(
+        workspace_root=string_value(report.get("workspace_root")),
+        project=dict_value(report.get("project")),
+        memory=memory,
+        checkpoints=previous_baseline_build_checkpoints(report),
+    )
+
+
+def previous_baseline_build_checkpoints(report: dict[str, Any]) -> list[dict[str, Any]]:
+    checkpoints = dict_value(report.get("build_profile")).get("checkpoints", [])
+    if not isinstance(checkpoints, list):
+        return []
+    return [checkpoint for checkpoint in checkpoints if isinstance(checkpoint, dict)]
 
 
 def current_project_memory(report: dict[str, Any]) -> dict[str, Any]:

--- a/.github/scripts/render_memory_profile_comment.py
+++ b/.github/scripts/render_memory_profile_comment.py
@@ -16,8 +16,6 @@ class MemoryProfileReport:
     project: dict[str, Any]
     memory: dict[str, Any]
     checkpoints: list[dict[str, Any]]
-    allocator_name: Optional[str] = None
-    allocator_resident_bytes: Optional[int] = None
 
 
 def main() -> None:
@@ -62,15 +60,6 @@ def normalize_optional_report(
 
 
 def normalize_report(report: dict[str, Any]) -> MemoryProfileReport:
-    if isinstance(report.get("memory"), list) or isinstance(report.get("profile_snapshot"), dict):
-        return normalize_current_report(report)
-
-    # TODO: remove this legacy branch after this PR lands and the main branch
-    # memory-profile cache has been regenerated from the new analyze JSON schema.
-    return normalize_legacy_report(report)
-
-
-def normalize_current_report(report: dict[str, Any]) -> MemoryProfileReport:
     return MemoryProfileReport(
         workspace_root=string_value(report.get("workspace_root")),
         project=dict_value(report.get("project")),
@@ -149,29 +138,6 @@ def flatten_current_checkpoint(checkpoint: dict[str, Any]) -> dict[str, Any]:
     return row
 
 
-def normalize_legacy_report(report: dict[str, Any]) -> MemoryProfileReport:
-    memory = dict_value(report.get("memory")).copy()
-    if "by_component" not in memory and "by_phase" in memory:
-        memory["by_component"] = memory["by_phase"]
-
-    allocator = dict_value(report.get("allocator"))
-    return MemoryProfileReport(
-        workspace_root=string_value(report.get("workspace_root")),
-        project=dict_value(report.get("project")),
-        memory=memory,
-        checkpoints=legacy_build_checkpoints(report),
-        allocator_name=optional_string(allocator.get("name")),
-        allocator_resident_bytes=nested_int(report, ["allocator", "stats", "resident_bytes"]),
-    )
-
-
-def legacy_build_checkpoints(report: dict[str, Any]) -> list[dict[str, Any]]:
-    checkpoints = dict_value(report.get("build_profile")).get("checkpoints", [])
-    if not isinstance(checkpoints, list):
-        return []
-    return [checkpoint for checkpoint in checkpoints if isinstance(checkpoint, dict)]
-
-
 def render_comment(
     current: MemoryProfileReport,
     base: Optional[MemoryProfileReport],
@@ -210,8 +176,6 @@ def render_context(
         f"- Packages: {packages.get('total_count', '?')} total, {packages.get('workspace_count', '?')} workspace",
         f"- Residency: `{packages.get('residency_policy', '?')}`",
     ]
-    if current.allocator_name is not None:
-        lines.append(f"- Allocator: `{current.allocator_name}`")
     lines.append(f"- Base result: {base_note}")
     return "\n".join(lines)
 
@@ -270,11 +234,7 @@ def render_checkpoint_table(
     if not current_rows:
         return ""
 
-    base_rows = {
-        row.get("label"): row
-        for row in checkpoints_for(base)
-        if isinstance(row.get("label"), str)
-    }
+    base_rows = dict(checkpoint_rows_by_occurrence(checkpoints_for(base)))
 
     rows = [
         "### Build Checkpoints",
@@ -282,9 +242,9 @@ def render_checkpoint_table(
         "| Checkpoint | Phase | Delta | RG sampled | Delta | RG total | Delta | Allocator resident | Delta |",
         "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ]
-    for row in current_rows:
+    for key, row in checkpoint_rows_by_occurrence(current_rows):
         label = row_label(row)
-        base_row = base_rows.get(label)
+        base_row = base_rows.get(key)
         table_row = (
             "| {label} | {phase} | {phase_delta} | "
             "{rg_sampled} | {rg_sampled_delta} | "
@@ -387,7 +347,7 @@ def final_allocator_resident_bytes(report: Optional[MemoryProfileReport]) -> Opt
         return None
     checkpoints = checkpoints_for(report)
     if not checkpoints:
-        return report.allocator_resident_bytes
+        return None
     return row_number(checkpoints[-1], "resident_bytes")
 
 
@@ -404,6 +364,19 @@ def checkpoints_for(report: Optional[MemoryProfileReport]) -> list[dict[str, Any
     return report.checkpoints
 
 
+def checkpoint_rows_by_occurrence(
+    rows: list[dict[str, Any]],
+) -> list[tuple[tuple[str, int], dict[str, Any]]]:
+    occurrences: dict[str, int] = {}
+    keyed_rows = []
+    for row in rows:
+        label = row_label(row)
+        occurrence = occurrences.get(label, 0)
+        occurrences[label] = occurrence + 1
+        keyed_rows.append(((label, occurrence), row))
+    return keyed_rows
+
+
 def row_label(row: dict[str, Any]) -> str:
     label = row.get("label")
     return label if isinstance(label, str) else "?"
@@ -418,25 +391,12 @@ def row_number(row: Optional[dict[str, Any]], key: str) -> Optional[float]:
     return value if isinstance(value, (int, float)) else None
 
 
-def nested_int(report: Optional[dict[str, Any]], path: list[str]) -> Optional[int]:
-    value: Any = report
-    for key in path:
-        if not isinstance(value, dict):
-            return None
-        value = value.get(key)
-    return value if isinstance(value, int) else None
-
-
 def dict_value(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
 def string_value(value: Any, fallback: str = "") -> str:
     return value if isinstance(value, str) else fallback
-
-
-def optional_string(value: Any) -> Optional[str]:
-    return value if isinstance(value, str) else None
 
 
 def number_value(value: Any) -> Optional[float]:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/engine/body-ir/src/build/lower/mod.rs
+++ b/crates/engine/body-ir/src/build/lower/mod.rs
@@ -18,16 +18,16 @@ use rayon::prelude::*;
 use rg_cfg_eval::CfgEvaluator;
 use rg_def_map::{DefMapReadTxn, PackageSlot};
 use rg_ir_model::{ConstRef, StaticRef, TargetRef};
-use rg_parse::{FileId, ParseDb, TargetId};
+use rg_parse::{ParseDb, TargetId};
 use rg_semantic_ir::SemanticIrReadTxn;
 use rg_text::{NameInterner, PackageNameInterners};
 
-use crate::{BodyIrBuildPolicy, BodyIrFile, PackageBodies, TargetBodies};
+use crate::{BodyIrBuildPolicy, PackageBodies, TargetBodies, TargetBodiesCoverage};
 
 pub(super) use self::macro_expansion::BodyMacroExpansion;
 use self::target::TargetLowering;
 pub(super) use self::task::{BodyLoweringTask, BodyTaskLowering};
-use super::local_thread_pool;
+use super::{local_thread_pool, materialization::BodyIrMaterialization};
 
 pub(super) fn build_packages(
     parse: &ParseDb,
@@ -46,7 +46,7 @@ pub(super) fn build_packages(
         parse,
         def_map,
         semantic_ir,
-        BodyIrLoweringScope::PackagePolicy(policy),
+        BodyIrMaterialization::ConfiguredBodies(policy),
         interners,
         &selected,
         &mut packages,
@@ -62,7 +62,7 @@ pub(super) fn build_selected_packages(
     parse: &ParseDb,
     def_map: &DefMapReadTxn<'_>,
     semantic_ir: &SemanticIrReadTxn<'_>,
-    scope: BodyIrLoweringScope<'_>,
+    scope: BodyIrMaterialization<'_>,
     package_slots: &[PackageSlot],
     interners: &mut PackageNameInterners,
 ) -> anyhow::Result<Vec<(PackageSlot, PackageBodies)>> {
@@ -98,7 +98,7 @@ fn build_package_outputs(
     parse: &ParseDb,
     def_map: &DefMapReadTxn<'_>,
     semantic_ir: &SemanticIrReadTxn<'_>,
-    scope: BodyIrLoweringScope<'_>,
+    scope: BodyIrMaterialization<'_>,
     interners: &mut PackageNameInterners,
     selected: &[bool],
     packages: &mut [Option<PackageBodies>],
@@ -147,7 +147,7 @@ fn build_package_with_interner(
     parse_package: &rg_parse::Package,
     def_map: &DefMapReadTxn<'_>,
     semantic_ir: &SemanticIrReadTxn<'_>,
-    scope: BodyIrLoweringScope<'_>,
+    scope: BodyIrMaterialization<'_>,
     package: PackageSlot,
     interner: &mut NameInterner,
 ) -> anyhow::Result<PackageBodies> {
@@ -214,17 +214,24 @@ fn build_package_with_interner(
             })
             .collect::<Vec<_>>();
 
-        // Check if we need lowering in the first place.
+        // Decide both whether this target needs work and how much of its body surface the result
+        // will cover. Selected-file rebuilds are allowed to materialize a target partially, while
+        // package-policy builds keep the historical all-or-nothing behavior.
         let body_files = functions
             .iter()
             .map(|(_, file_id, _)| *file_id)
             .chain(consts.iter().map(|(_, file_id, _)| *file_id))
             .chain(statics.iter().map(|(_, file_id, _)| *file_id))
             .collect::<Vec<_>>();
-        if !scope.should_lower_package(package, parse_package)
-            || !scope.should_lower_target(package, &body_files)
-        {
-            targets.push(TargetBodies::skipped());
+        let coverage = scope.target_coverage(package, parse_package, &body_files);
+        if !coverage.is_materialized() {
+            targets.push(match coverage {
+                TargetBodiesCoverage::Missing => TargetBodies::missing(),
+                TargetBodiesCoverage::SkippedByPolicy => TargetBodies::skipped_by_policy(),
+                TargetBodiesCoverage::Complete | TargetBodiesCoverage::Partial => {
+                    unreachable!("materialized body IR coverage should be lowered")
+                }
+            });
             continue;
         }
 
@@ -239,7 +246,7 @@ fn build_package_with_interner(
                 functions,
                 consts,
                 statics,
-                target_bodies: TargetBodies::new(),
+                target_bodies: TargetBodies::with_coverage(coverage),
                 cfg,
                 interner,
             }
@@ -251,41 +258,6 @@ fn build_package_with_interner(
     }
 
     Ok(PackageBodies::new(targets))
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(super) enum BodyIrLoweringScope<'a> {
-    PackagePolicy(BodyIrBuildPolicy),
-    SelectedFiles(&'a [BodyIrFile]),
-}
-
-impl BodyIrLoweringScope<'_> {
-    fn should_lower_package(self, package: PackageSlot, parse_package: &rg_parse::Package) -> bool {
-        match self {
-            Self::PackagePolicy(policy) => policy.should_lower_package(parse_package),
-            Self::SelectedFiles(files) => files.iter().any(|file| file.package == package),
-        }
-    }
-
-    fn should_lower_target(self, package: PackageSlot, files_with_bodies: &[FileId]) -> bool {
-        match self {
-            Self::PackagePolicy(_) => true,
-            Self::SelectedFiles(files) => files_with_bodies.iter().any(|file_id| {
-                files
-                    .iter()
-                    .any(|file| file.package == package && file.file == *file_id)
-            }),
-        }
-    }
-
-    fn should_lower_body_file(self, package: PackageSlot, file_id: FileId) -> bool {
-        match self {
-            Self::PackagePolicy(_) => true,
-            Self::SelectedFiles(files) => files
-                .iter()
-                .any(|file| file.package == package && file.file == file_id),
-        }
-    }
 }
 
 fn validate_package_inputs(
@@ -329,9 +301,9 @@ fn validate_selected_packages(
 
 fn validate_selected_files(
     package_count: usize,
-    scope: &BodyIrLoweringScope<'_>,
+    scope: &BodyIrMaterialization<'_>,
 ) -> anyhow::Result<()> {
-    let BodyIrLoweringScope::SelectedFiles(files) = scope else {
+    let BodyIrMaterialization::SelectedFiles(files) = scope else {
         return Ok(());
     };
 

--- a/crates/engine/body-ir/src/build/lower/target.rs
+++ b/crates/engine/body-ir/src/build/lower/target.rs
@@ -16,9 +16,8 @@ use rg_text::NameInterner;
 
 use crate::{BodyOwner, TargetBodies};
 
-use super::{
-    BodyIrLoweringScope, BodyMacroExpansion, task::BodyLoweringTask, task::BodyTaskLowering,
-};
+use super::{BodyMacroExpansion, task::BodyLoweringTask, task::BodyTaskLowering};
+use crate::build::materialization::BodyIrMaterialization;
 
 type FunctionLoweringTarget = (FunctionRef, FileId, Span);
 type ConstLoweringTarget = (ConstRef, FileId, Span);
@@ -28,7 +27,7 @@ pub(super) struct TargetLowering<'a> {
     pub(super) parse_package: &'a rg_parse::Package,
     pub(super) def_map: &'a DefMapReadTxn<'a>,
     pub(super) semantic_ir: &'a SemanticIrReadTxn<'a>,
-    pub(super) scope: BodyIrLoweringScope<'a>,
+    pub(super) scope: BodyIrMaterialization<'a>,
     pub(super) package: PackageSlot,
     pub(super) functions: Vec<FunctionLoweringTarget>,
     pub(super) consts: Vec<ConstLoweringTarget>,

--- a/crates/engine/body-ir/src/build/materialization.rs
+++ b/crates/engine/body-ir/src/build/materialization.rs
@@ -1,0 +1,112 @@
+//! Body IR materialization choices for fresh builds and package rebuilds.
+//!
+//! The project layer decides when indexing may start early or when a query needs more analysis
+//! data. Once that decision reaches this crate, the question is narrower: which Body IR payloads
+//! should this rebuild actually lower, and what target coverage should the store report afterward?
+
+use rg_def_map::PackageSlot;
+use rg_parse::FileId;
+
+use crate::{BodyIrBuildPolicy, BodyIrFile, TargetBodiesCoverage};
+
+/// Owned Body IR materialization plan stored by a package rebuilder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum BodyIrMaterializationPlan {
+    /// Lower the full body surface selected by the configured package policy.
+    ConfiguredBodies(BodyIrBuildPolicy),
+    /// Preserve target coverage records, but leave body-bearing targets unlowered for later.
+    CoverageOnly(BodyIrBuildPolicy),
+    /// Lower bodies from selected files while preserving missing/partial target coverage.
+    SelectedFiles(Vec<BodyIrFile>),
+}
+
+impl BodyIrMaterializationPlan {
+    pub(super) fn lowering(&self) -> BodyIrMaterialization<'_> {
+        match self {
+            Self::ConfiguredBodies(policy) => BodyIrMaterialization::ConfiguredBodies(*policy),
+            Self::CoverageOnly(policy) => BodyIrMaterialization::CoverageOnly(*policy),
+            Self::SelectedFiles(files) => BodyIrMaterialization::SelectedFiles(files),
+        }
+    }
+}
+
+/// Borrowed materialization mode used while lowering target bodies.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum BodyIrMaterialization<'a> {
+    /// Lower every body selected by the package policy.
+    ConfiguredBodies(BodyIrBuildPolicy),
+    /// Create the same target slots as a policy build, but mark body-bearing targets as missing.
+    CoverageOnly(BodyIrBuildPolicy),
+    /// Lower only selected source files. Targets can become partial when other body files remain.
+    SelectedFiles(&'a [BodyIrFile]),
+}
+
+impl BodyIrMaterialization<'_> {
+    pub(super) fn target_coverage(
+        self,
+        package: PackageSlot,
+        parse_package: &rg_parse::Package,
+        files_with_bodies: &[FileId],
+    ) -> TargetBodiesCoverage {
+        match self {
+            Self::ConfiguredBodies(policy) => {
+                if policy.should_lower_package(parse_package) {
+                    TargetBodiesCoverage::Complete
+                } else {
+                    TargetBodiesCoverage::SkippedByPolicy
+                }
+            }
+            Self::CoverageOnly(policy) => {
+                if !policy.should_lower_package(parse_package) {
+                    return TargetBodiesCoverage::SkippedByPolicy;
+                }
+
+                if files_with_bodies.is_empty() {
+                    TargetBodiesCoverage::Complete
+                } else {
+                    TargetBodiesCoverage::Missing
+                }
+            }
+            Self::SelectedFiles(files) => {
+                let package_selected = files.iter().any(|file| file.package == package);
+                if !package_selected {
+                    return TargetBodiesCoverage::Missing;
+                }
+
+                if files_with_bodies.is_empty() {
+                    return TargetBodiesCoverage::Complete;
+                }
+
+                let mut selected_body_file_seen = false;
+                let mut unselected_body_file_seen = false;
+                for file_id in files_with_bodies {
+                    let selected = files
+                        .iter()
+                        .any(|file| file.package == package && file.file == *file_id);
+                    if selected {
+                        selected_body_file_seen = true;
+                    } else {
+                        unselected_body_file_seen = true;
+                    }
+                }
+
+                match (selected_body_file_seen, unselected_body_file_seen) {
+                    (true, false) => TargetBodiesCoverage::Complete,
+                    (true, true) => TargetBodiesCoverage::Partial,
+                    (false, true) => TargetBodiesCoverage::Missing,
+                    (false, false) => TargetBodiesCoverage::Complete,
+                }
+            }
+        }
+    }
+
+    pub(super) fn should_lower_body_file(self, package: PackageSlot, file_id: FileId) -> bool {
+        match self {
+            Self::ConfiguredBodies(_) => true,
+            Self::CoverageOnly(_) => false,
+            Self::SelectedFiles(files) => files
+                .iter()
+                .any(|file| file.package == package && file.file == file_id),
+        }
+    }
+}

--- a/crates/engine/body-ir/src/build/mod.rs
+++ b/crates/engine/body-ir/src/build/mod.rs
@@ -3,6 +3,7 @@
 mod body_def_map;
 mod body_item_store;
 mod lower;
+mod materialization;
 mod query_source;
 mod resolve;
 mod state;
@@ -17,6 +18,8 @@ use rg_std::Shrink;
 use rg_text::PackageNameInterners;
 
 use crate::{BodyIrBuildPolicy, BodyIrDb, BodyIrFile, PackageBodies};
+
+use self::materialization::BodyIrMaterializationPlan;
 
 /// Builder for a fresh Body IR snapshot.
 pub struct BodyIrDbBuilder<'db, 'names> {
@@ -115,8 +118,7 @@ pub struct BodyIrDbPackageRebuilder<'db, 'names> {
     parse: &'db rg_parse::ParseDb,
     def_map: &'db rg_def_map::DefMapDb,
     semantic_ir: &'db rg_semantic_ir::SemanticIrDb,
-    policy: BodyIrBuildPolicy,
-    selected_files: Option<Vec<BodyIrFile>>,
+    materialization: BodyIrMaterializationPlan,
     packages: &'db [PackageSlot],
     interners: &'names mut PackageNameInterners,
     def_map_loader: PackageLoader<'db, DefMapPackage>,
@@ -142,8 +144,9 @@ impl<'db, 'names> BodyIrDbPackageRebuilder<'db, 'names> {
             parse,
             def_map,
             semantic_ir,
-            policy: BodyIrBuildPolicy::default(),
-            selected_files: None,
+            materialization: BodyIrMaterializationPlan::ConfiguredBodies(
+                BodyIrBuildPolicy::default(),
+            ),
             packages,
             interners,
             def_map_loader,
@@ -152,23 +155,27 @@ impl<'db, 'names> BodyIrDbPackageRebuilder<'db, 'names> {
         }
     }
 
-    pub fn policy(mut self, policy: BodyIrBuildPolicy) -> Self {
-        self.policy = policy;
+    /// Lowers body contents selected by the package policy.
+    pub fn configured_bodies(mut self, policy: BodyIrBuildPolicy) -> Self {
+        self.materialization = BodyIrMaterializationPlan::ConfiguredBodies(policy);
+        self
+    }
+
+    /// Builds coverage records without lowering body contents selected by the policy.
+    pub fn coverage_only(mut self, policy: BodyIrBuildPolicy) -> Self {
+        self.materialization = BodyIrMaterializationPlan::CoverageOnly(policy);
         self
     }
 
     pub fn selected_files(mut self, files: Vec<BodyIrFile>) -> Self {
-        self.selected_files = Some(files);
+        self.materialization = BodyIrMaterializationPlan::SelectedFiles(files);
         self
     }
 
     pub fn build(self) -> anyhow::Result<BodyIrDb> {
         let mut next = self.old.clone();
         let packages = normalized_package_slots(self.packages);
-        let lowering_scope = match &self.selected_files {
-            Some(files) => lower::BodyIrLoweringScope::SelectedFiles(files),
-            None => lower::BodyIrLoweringScope::PackagePolicy(self.policy),
-        };
+        let materialization = self.materialization.lowering();
         let semantic_ir_txn = self
             .semantic_ir
             .read_txn_for_subset(self.semantic_ir_loader, self.subset);
@@ -179,7 +186,7 @@ impl<'db, 'names> BodyIrDbPackageRebuilder<'db, 'names> {
             self.parse,
             &def_map_txn,
             &semantic_ir_txn,
-            lowering_scope,
+            materialization,
             &packages,
             self.interners,
         )

--- a/crates/engine/body-ir/src/lib.rs
+++ b/crates/engine/body-ir/src/lib.rs
@@ -33,7 +33,8 @@ pub use self::{
     },
     resolution::{BodyMethodQuery, BodyResolutionContext, BodyTypePathQuery, BodyValuePathQuery},
     store::{
-        BodyIrDb, BodyIrReadTxn, BodyIrStats, PackageBodies, TargetBodies, TargetBodiesStatus,
+        BodyIrDb, BodyIrReadTxn, BodyIrStats, PackageBodies, TargetBodies, TargetBodiesCoverage,
+        TargetBodiesStatus,
     },
 };
 

--- a/crates/engine/body-ir/src/store/db.rs
+++ b/crates/engine/body-ir/src/store/db.rs
@@ -6,7 +6,7 @@ use rg_package_store::{PackageLoader, PackageStore, PackageSubset};
 use rg_semantic_ir::PackageIr;
 use rg_text::PackageNameInterners;
 
-use super::{BodyIrReadTxn, PackageBodies, TargetBodiesStatus};
+use super::{BodyIrReadTxn, PackageBodies, TargetBodiesCoverage, TargetBodiesStatus};
 use crate::build::{BodyIrDbBuilder, BodyIrDbPackageRebuilder};
 use rg_std::{MemorySize, Shrink};
 
@@ -16,6 +16,10 @@ pub struct BodyIrStats {
     pub target_count: usize,
     pub built_target_count: usize,
     pub skipped_target_count: usize,
+    pub complete_target_count: usize,
+    pub partial_target_count: usize,
+    pub missing_target_count: usize,
+    pub skipped_by_policy_target_count: usize,
     pub body_count: usize,
     pub scope_count: usize,
     pub binding_count: usize,
@@ -94,6 +98,14 @@ impl BodyIrDb {
                     TargetBodiesStatus::Built => stats.built_target_count += 1,
                     TargetBodiesStatus::Skipped => stats.skipped_target_count += 1,
                 }
+                match target.coverage() {
+                    TargetBodiesCoverage::Complete => stats.complete_target_count += 1,
+                    TargetBodiesCoverage::Partial => stats.partial_target_count += 1,
+                    TargetBodiesCoverage::Missing => stats.missing_target_count += 1,
+                    TargetBodiesCoverage::SkippedByPolicy => {
+                        stats.skipped_by_policy_target_count += 1;
+                    }
+                }
                 stats.body_count += target.bodies().len();
                 for body in target.bodies() {
                     stats.scope_count += body.scopes().len();
@@ -112,6 +124,14 @@ impl BodyIrDb {
         self.packages
             .raw_entry(package)
             .and_then(|entry| entry.as_resident())
+    }
+
+    /// Replaces one package payload while preserving the surrounding package-store shape.
+    ///
+    /// This is used by project-level monotonic Body IR merges, where a background completion
+    /// contributes a package that has strictly better coverage than the current saved project.
+    pub fn replace_package(&mut self, package: PackageSlot, bodies: PackageBodies) -> Option<()> {
+        self.packages.replace(package, bodies)
     }
 
     pub fn read_txn<'db>(

--- a/crates/engine/body-ir/src/store/mod.rs
+++ b/crates/engine/body-ir/src/store/mod.rs
@@ -6,6 +6,6 @@ mod txn;
 
 pub use self::{
     db::{BodyIrDb, BodyIrStats},
-    package::{PackageBodies, TargetBodies, TargetBodiesStatus},
+    package::{PackageBodies, TargetBodies, TargetBodiesCoverage, TargetBodiesStatus},
     txn::BodyIrReadTxn,
 };

--- a/crates/engine/body-ir/src/store/package.rs
+++ b/crates/engine/body-ir/src/store/package.rs
@@ -37,33 +37,36 @@ impl PackageBodies {
 /// Resolved bodies for one target.
 #[derive(Debug, Clone, PartialEq, Eq, SchemaRead, SchemaWrite, MemorySize, Shrink)]
 pub struct TargetBodies {
-    pub(crate) status: TargetBodiesStatus,
+    pub(crate) coverage: TargetBodiesCoverage,
     pub(crate) semantic_index: ItemLookupIndex,
     pub(crate) bodies: Arena<BodyId, ResolvedBodyData>,
     pub(crate) body_local_items: Arena<BodyId, BodyLocalItems>,
 }
 
 impl TargetBodies {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn with_coverage(coverage: TargetBodiesCoverage) -> Self {
         Self {
-            status: TargetBodiesStatus::Built,
+            coverage,
             semantic_index: ItemLookupIndex::default(),
             bodies: Arena::new(),
             body_local_items: Arena::new(),
         }
     }
 
-    pub(crate) fn skipped() -> Self {
-        Self {
-            status: TargetBodiesStatus::Skipped,
-            semantic_index: ItemLookupIndex::default(),
-            bodies: Arena::new(),
-            body_local_items: Arena::new(),
-        }
+    pub(crate) fn missing() -> Self {
+        Self::with_coverage(TargetBodiesCoverage::Missing)
+    }
+
+    pub(crate) fn skipped_by_policy() -> Self {
+        Self::with_coverage(TargetBodiesCoverage::SkippedByPolicy)
+    }
+
+    pub fn coverage(&self) -> TargetBodiesCoverage {
+        self.coverage
     }
 
     pub fn status(&self) -> TargetBodiesStatus {
-        self.status
+        self.coverage.status()
     }
 
     pub fn body(&self, body: BodyId) -> Option<&ResolvedBodyData> {
@@ -109,6 +112,53 @@ impl TargetBodies {
 
     pub(crate) fn bodies_mut(&mut self) -> &mut [ResolvedBodyData] {
         self.bodies.as_mut_slice()
+    }
+}
+
+/// How much of a target's body surface has been materialized.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    derive_more::Display,
+    SchemaRead,
+    SchemaWrite,
+    MemorySize,
+    Shrink,
+)]
+#[memsize(leaf)]
+#[shrink(leaf)]
+pub enum TargetBodiesCoverage {
+    /// Every semantic item body known for the target was considered for lowering.
+    #[display("complete")]
+    Complete,
+    /// At least one, but not every, known body source file was selected for lowering.
+    #[display("partial")]
+    Partial,
+    /// The target has body sources, but none of them were selected for this materialization pass.
+    #[display("missing")]
+    Missing,
+    /// The configured package policy intentionally did not build bodies for this target.
+    #[display("skipped-by-policy")]
+    SkippedByPolicy,
+}
+
+impl TargetBodiesCoverage {
+    pub fn is_complete(self) -> bool {
+        matches!(self, Self::Complete)
+    }
+
+    pub fn is_materialized(self) -> bool {
+        matches!(self, Self::Complete | Self::Partial)
+    }
+
+    pub fn status(self) -> TargetBodiesStatus {
+        match self {
+            Self::Complete | Self::Partial => TargetBodiesStatus::Built,
+            Self::Missing | Self::SkippedByPolicy => TargetBodiesStatus::Skipped,
+        }
     }
 }
 

--- a/crates/engine/project/src/cache/tests/mod.rs
+++ b/crates/engine/project/src/cache/tests/mod.rs
@@ -468,7 +468,7 @@ fn startup_indexing_rejects_artifacts_when_body_ir_policy_needs_more_bodies() {
         misses 1
         body policy mismatches 1
         body IR target statuses
-        - target 0 built
+        - target 0 built complete
     "#]]);
 }
 

--- a/crates/engine/project/src/cache/tests/utils.rs
+++ b/crates/engine/project/src/cache/tests/utils.rs
@@ -991,8 +991,13 @@ fn render_artifact(label: &str, artifact: &PackageCacheArtifact, dump: &mut Stri
 fn render_body_ir_target_statuses(artifact: &PackageCacheArtifact, dump: &mut String) {
     writeln!(dump, "body IR target statuses").expect("string writes should not fail");
     for (target_idx, target) in artifact.payload.body_ir.targets().iter().enumerate() {
-        writeln!(dump, "- target {target_idx} {}", target.status())
-            .expect("string writes should not fail");
+        writeln!(
+            dump,
+            "- target {target_idx} {} {}",
+            target.status(),
+            target.coverage()
+        )
+        .expect("string writes should not fail");
     }
 }
 

--- a/crates/engine/project/src/lib.rs
+++ b/crates/engine/project/src/lib.rs
@@ -12,9 +12,10 @@ pub use self::{
     memory::{ProjectMemoryHooks, ProjectMemoryPurgePoint},
     profile::{BUILD_CHECKPOINTS, BuildProcessMemory, ProcessMemorySampler},
     project::{
-        AnalysisChangeSummary, AnalysisSurface, ChangedFile, DirtyFileChange, FileContext,
-        FinishedSplitIndexing, Project, ProjectBuilder, ProjectSnapshot, ProjectStats,
-        SavedFileChange, SplitIndexing, SplitIndexingMode, StartupCacheLoad,
+        AnalysisChangeSummary, AnalysisSurface, ChangedFile, DetachedSplitIndexing,
+        DirtyFileChange, FileContext, FinishedSplitIndexing, Project, ProjectBuilder,
+        ProjectSnapshot, ProjectStats, SavedFileChange, SplitIndexing, SplitIndexingMode,
+        StartupCacheLoad,
     },
     residency::{PackageResidency, PackageResidencyPlan, PackageResidencyPolicy},
 };

--- a/crates/engine/project/src/lib.rs
+++ b/crates/engine/project/src/lib.rs
@@ -12,8 +12,9 @@ pub use self::{
     memory::{ProjectMemoryHooks, ProjectMemoryPurgePoint},
     profile::{BUILD_CHECKPOINTS, BuildProcessMemory, ProcessMemorySampler},
     project::{
-        AnalysisChangeSummary, ChangedFile, DirtyFileChange, FileContext, Project, ProjectBuilder,
-        ProjectSnapshot, ProjectStats, SavedFileChange, StartupCacheLoad,
+        AnalysisChangeSummary, AnalysisSurface, ChangedFile, DirtyFileChange, FileContext,
+        FinishedSplitIndexing, Project, ProjectBuilder, ProjectSnapshot, ProjectStats,
+        SavedFileChange, SplitIndexing, SplitIndexingMode, StartupCacheLoad,
     },
     residency::{PackageResidency, PackageResidencyPlan, PackageResidencyPolicy},
 };

--- a/crates/engine/project/src/project/build/cache_probe.rs
+++ b/crates/engine/project/src/project/build/cache_probe.rs
@@ -1,6 +1,6 @@
 //! Startup cache probing for fresh project builds.
 
-use rg_body_ir::{BodyIrBuildPolicy, TargetBodiesStatus};
+use rg_body_ir::BodyIrBuildPolicy;
 use rg_def_map::PackageSlot;
 use rg_parse::{PackageParseSnapshot, ParseDb};
 use rg_workspace::WorkspaceMetadata;
@@ -137,7 +137,7 @@ impl<'a> StartupCacheProbe<'a> {
             .body_ir
             .targets()
             .iter()
-            .all(|target| target.status() == TargetBodiesStatus::Built);
+            .all(|target| target.coverage().is_complete());
 
         if !matches_policy {
             metric::CACHE_PROBE_BODY_IR_POLICY_MISMATCHES.inc();

--- a/crates/engine/project/src/project/build/mod.rs
+++ b/crates/engine/project/src/project/build/mod.rs
@@ -34,12 +34,23 @@ impl StartupCacheLoad {
     }
 }
 
+/// Controls how much indexing work a fresh project build completes before returning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SplitIndexingMode {
+    /// Build every configured analysis payload before the project becomes usable.
+    #[default]
+    Full,
+    /// Build structural data now and leave deferred payloads for on-demand/background work.
+    EarlyStart,
+}
+
 /// Fluent construction API for a fresh analysis project.
 pub struct ProjectBuilder {
     workspace: WorkspaceMetadata,
     workspace_lowering_config: WorkspaceLoweringConfig,
     cargo_metadata_config: CargoMetadataConfig,
     body_ir_policy: BodyIrBuildPolicy,
+    split_indexing_mode: SplitIndexingMode,
     indexing_preference: IndexingPerformancePreference,
     package_residency_policy: PackageResidencyPolicy,
     startup_cache_load: StartupCacheLoad,
@@ -54,6 +65,7 @@ impl ProjectBuilder {
             workspace_lowering_config: WorkspaceLoweringConfig::default(),
             cargo_metadata_config: CargoMetadataConfig::default(),
             body_ir_policy: BodyIrBuildPolicy::default(),
+            split_indexing_mode: SplitIndexingMode::default(),
             indexing_preference: IndexingPerformancePreference::default(),
             package_residency_policy: PackageResidencyPolicy::default(),
             startup_cache_load: StartupCacheLoad::default(),
@@ -64,6 +76,11 @@ impl ProjectBuilder {
 
     pub fn body_ir_policy(mut self, policy: BodyIrBuildPolicy) -> Self {
         self.body_ir_policy = policy;
+        self
+    }
+
+    pub fn split_indexing_mode(mut self, mode: SplitIndexingMode) -> Self {
+        self.split_indexing_mode = mode;
         self
     }
 
@@ -124,6 +141,7 @@ impl ProjectBuilder {
             self.cargo_metadata_config,
             cache_instance,
             self.body_ir_policy,
+            self.split_indexing_mode,
             self.indexing_preference,
             self.package_residency_policy,
             self.startup_cache_load,
@@ -156,6 +174,7 @@ pub(crate) fn build_resident_state(
     cargo_metadata_config: CargoMetadataConfig,
     cache_instance: PackageCacheInstance,
     body_ir_policy: BodyIrBuildPolicy,
+    split_indexing_mode: SplitIndexingMode,
     indexing_preference: IndexingPerformancePreference,
     package_residency_policy: PackageResidencyPolicy,
     startup_cache_load: StartupCacheLoad,
@@ -173,6 +192,7 @@ pub(crate) fn build_resident_state(
         &cache_plan,
         &cache_store,
         startup_cache_load,
+        split_indexing_mode,
         memory_hooks.as_ref(),
         memory_sampler,
     )?;

--- a/crates/engine/project/src/project/build/phases.rs
+++ b/crates/engine/project/src/project/build/phases.rs
@@ -17,7 +17,10 @@ use crate::{
     cache::{Fingerprint, PackageCacheStore, WorkspaceCachePlan},
     memory::{ProjectMemoryHooks, ProjectMemoryPurgePoint},
     profile::{BuildMemorySampler, metric},
-    project::{StartupCacheLoad, loading::PackageReadLoaders, package_set::PhasePackageSet},
+    project::{
+        SplitIndexingMode, StartupCacheLoad, loading::PackageReadLoaders,
+        package_set::PhasePackageSet,
+    },
 };
 
 use super::{cache_probe::StartupCacheProbe, checkpoint_memory::CheckpointMemory};
@@ -55,6 +58,7 @@ pub(super) fn build(
     cache_plan: &WorkspaceCachePlan,
     cache_store: &PackageCacheStore,
     startup_cache_load: StartupCacheLoad,
+    split_indexing_mode: SplitIndexingMode,
     memory_hooks: &dyn ProjectMemoryHooks,
     sampler: &mut BuildMemorySampler,
 ) -> anyhow::Result<BuiltPhases> {
@@ -219,18 +223,21 @@ pub(super) fn build(
     // ----------------
     let baseline_body_ir =
         BodyIrDb::from_package_store(offloaded_package_store(parse.package_count()));
-    let body_ir = baseline_body_ir
-        .package_rebuilder(
-            &parse,
-            &def_map,
-            &semantic_ir,
-            build_plan.source_packages.as_slice(),
-            &mut names,
-            loaders.def_map,
-            loaders.semantic_ir,
-            &rebuild_subset,
-        )
-        .policy(body_ir_policy)
+    let mut body_rebuilder = baseline_body_ir.package_rebuilder(
+        &parse,
+        &def_map,
+        &semantic_ir,
+        build_plan.source_packages.as_slice(),
+        &mut names,
+        loaders.def_map,
+        loaders.semantic_ir,
+        &rebuild_subset,
+    );
+    body_rebuilder = match split_indexing_mode {
+        SplitIndexingMode::Full => body_rebuilder.configured_bodies(body_ir_policy),
+        SplitIndexingMode::EarlyStart => body_rebuilder.coverage_only(body_ir_policy),
+    };
+    let body_ir = body_rebuilder
         .build()
         .context("while attempting to build body ir db")?;
     memory_hooks.purge(ProjectMemoryPurgePoint::AfterBodyIrBuild);

--- a/crates/engine/project/src/project/mod.rs
+++ b/crates/engine/project/src/project/mod.rs
@@ -109,6 +109,9 @@ impl Project {
     /// loop, but callers should not receive that clone as a general-purpose `Project`. Returning a
     /// narrow handle keeps the only supported detached operation explicit: finish deferred indexing
     /// and later merge the result back into saved state.
+    //
+    // TODO: Make project snapshots cheap to detach, especially parse state, so background
+    // completion does not have to clone large parse arenas on the caller thread.
     pub fn detach_split_indexing(&self) -> DetachedSplitIndexing {
         DetachedSplitIndexing::new(self.clone())
     }

--- a/crates/engine/project/src/project/mod.rs
+++ b/crates/engine/project/src/project/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod offloading;
 mod package_set;
 mod reference_search;
 mod snapshot;
+mod split_indexing;
 pub(crate) mod state;
 mod stats;
 pub(crate) mod subset;
@@ -27,9 +28,10 @@ use crate::{
 use rg_std::MemorySize;
 
 pub use self::{
-    build::{ProjectBuilder, StartupCacheLoad},
+    build::{ProjectBuilder, SplitIndexingMode, StartupCacheLoad},
     dirty::DirtyFileChange,
     snapshot::ProjectSnapshot,
+    split_indexing::{AnalysisSurface, FinishedSplitIndexing, SplitIndexing},
     stats::ProjectStats,
 };
 
@@ -91,6 +93,11 @@ impl Project {
     /// Rebuilds the whole project from the current workspace graph and saved source files.
     pub fn reindex_workspace(&mut self) -> anyhow::Result<()> {
         update::reindex_workspace(self)
+    }
+
+    /// Returns the split-indexing control surface for deferred analysis work.
+    pub fn split_indexing(&mut self) -> SplitIndexing<'_> {
+        SplitIndexing::new(self)
     }
 
     /// Applies one saved file replacement and refreshes derived analysis state.

--- a/crates/engine/project/src/project/mod.rs
+++ b/crates/engine/project/src/project/mod.rs
@@ -31,7 +31,9 @@ pub use self::{
     build::{ProjectBuilder, SplitIndexingMode, StartupCacheLoad},
     dirty::DirtyFileChange,
     snapshot::ProjectSnapshot,
-    split_indexing::{AnalysisSurface, FinishedSplitIndexing, SplitIndexing},
+    split_indexing::{
+        AnalysisSurface, DetachedSplitIndexing, FinishedSplitIndexing, SplitIndexing,
+    },
     stats::ProjectStats,
 };
 
@@ -98,6 +100,17 @@ impl Project {
     /// Returns the split-indexing control surface for deferred analysis work.
     pub fn split_indexing(&mut self) -> SplitIndexing<'_> {
         SplitIndexing::new(self)
+    }
+
+    /// Clone this project into an owned background-finish handle.
+    ///
+    /// Early-start indexing lets the saved project become queryable while deferred payloads are
+    /// still missing. Background completion must run on a clone so it cannot block the command
+    /// loop, but callers should not receive that clone as a general-purpose `Project`. Returning a
+    /// narrow handle keeps the only supported detached operation explicit: finish deferred indexing
+    /// and later merge the result back into saved state.
+    pub fn detach_split_indexing(&self) -> DetachedSplitIndexing {
+        DetachedSplitIndexing::new(self.clone())
     }
 
     /// Applies one saved file replacement and refreshes derived analysis state.

--- a/crates/engine/project/src/project/offloading.rs
+++ b/crates/engine/project/src/project/offloading.rs
@@ -17,7 +17,7 @@ use crate::{
     profile::{BuildMemorySampler, record_build_checkpoint},
 };
 
-use super::{package_set::PhasePackageSet, state::ProjectState, update};
+use super::{package_set::PhasePackageSet, split_indexing, state::ProjectState, update};
 
 /// Planned residency transition for one mutable project snapshot.
 pub(crate) struct ResidencyApplication<'a> {
@@ -35,7 +35,8 @@ impl<'a> ResidencyApplication<'a> {
     /// offloadable packages whose phase data is actually resident, then offload every package
     /// selected by the residency policy.
     pub(crate) fn fresh(project: &'a mut ProjectState) -> Self {
-        let packages_to_offload = Self::offloadable_packages(project);
+        let packages_to_offload = Self::offloadable_packages(project)
+            .filter(|package| Self::package_can_be_offloaded(project, package));
         // Cache artifacts are the durable backing store for offloadable packages. Resident packages
         // stay in memory and should not pay serialization/write cost until policy asks for it.
         let packages_to_write = packages_to_offload
@@ -58,8 +59,10 @@ impl<'a> ResidencyApplication<'a> {
     pub(crate) fn restore(project: &'a mut ProjectState, rebuilt_packages: &[PackageSlot]) -> Self {
         Self {
             refresh_source_fingerprints_for: PhasePackageSet::from_slice(rebuilt_packages),
-            packages_to_write: Self::rebuilt_offloadable_packages(project, rebuilt_packages),
-            packages_to_offload: Self::offloadable_packages(project),
+            packages_to_write: Self::rebuilt_offloadable_packages(project, rebuilt_packages)
+                .filter(|package| Self::package_artifact_is_resident(project, package)),
+            packages_to_offload: Self::offloadable_packages(project)
+                .filter(|package| Self::package_can_be_offloaded(project, package)),
             project,
         }
     }
@@ -193,11 +196,19 @@ impl<'a> ResidencyApplication<'a> {
         )
     }
 
-    /// Returns whether all artifact-backed phase payloads are resident for this package.
+    /// Returns whether all artifact-backed phase payloads are resident and durable for this package.
     fn package_artifact_is_resident(project: &ProjectState, package: PackageSlot) -> bool {
         project.def_map.resident_package(package).is_some()
             && project.semantic_ir.resident_package(package).is_some()
-            && project.body_ir.resident_package(package).is_some()
+            && split_indexing::package_deferred_payload_is_durable(project, package)
+    }
+
+    fn package_can_be_offloaded(project: &ProjectState, package: PackageSlot) -> bool {
+        let has_resident_payload = project.def_map.resident_package(package).is_some()
+            || project.semantic_ir.resident_package(package).is_some()
+            || project.body_ir.resident_package(package).is_some();
+
+        !has_resident_payload || Self::package_artifact_is_resident(project, package)
     }
 
     /// Writes durable cache artifacts for packages whose resident payloads are about to be dropped.

--- a/crates/engine/project/src/project/package_set.rs
+++ b/crates/engine/project/src/project/package_set.rs
@@ -1,7 +1,8 @@
 use rg_body_ir::BodyIrFile;
 use rg_def_map::PackageSlot;
+use rg_ir_model::TargetRef;
 use rg_package_store::PackageSubset;
-use rg_std::MemorySize;
+use rg_std::{MemorySize, UniqueVec};
 use rg_workspace::WorkspaceMetadata;
 
 use super::subset;
@@ -34,9 +35,22 @@ impl PhasePackageSet {
     }
 
     pub(super) fn from_body_files(files: &[BodyIrFile]) -> Self {
-        let mut packages = files.iter().map(|file| file.package).collect::<Vec<_>>();
+        let mut packages = files
+            .iter()
+            .map(|file| file.package)
+            .collect::<UniqueVec<_>>()
+            .into_vec();
         packages.sort_by_key(|package| package.0);
-        packages.dedup();
+        Self { packages }
+    }
+
+    pub(super) fn from_targets(targets: &[TargetRef]) -> Self {
+        let mut packages = targets
+            .iter()
+            .map(|target| target.package)
+            .collect::<UniqueVec<_>>()
+            .into_vec();
+        packages.sort_by_key(|package| package.0);
         Self { packages }
     }
 

--- a/crates/engine/project/src/project/snapshot.rs
+++ b/crates/engine/project/src/project/snapshot.rs
@@ -1,4 +1,3 @@
-use rg_std::MemorySize;
 use std::path::Path;
 
 use anyhow::Context as _;
@@ -9,6 +8,7 @@ use rg_ir_model::TargetRef;
 #[cfg(test)]
 use rg_parse::ParseDb;
 use rg_parse::{FileId, LineIndex, Span};
+use rg_std::MemorySize;
 use rg_workspace::RustEdition;
 
 use super::{

--- a/crates/engine/project/src/project/split_indexing.rs
+++ b/crates/engine/project/src/project/split_indexing.rs
@@ -11,8 +11,8 @@
 //!   normal package residency.
 //! - `materialize` makes the analysis surface needed by one query available, such as one file for
 //!   hover or a mix of files and targets for reference search.
-//! - `finish_detached` and `merge_finished` let an LSP background clone finish deferred payloads
-//!   and merge package-wise improvements back into the saved project.
+//! - `DetachedSplitIndexing` and `merge_finished` let an LSP background clone finish deferred
+//!   payloads and merge package-wise improvements back into the saved project.
 //!
 //! That last path has to be monotonic. Query-time materialization may finish a package before the
 //! background clone finishes, so a stale background result must not replace better saved coverage
@@ -64,9 +64,10 @@ pub enum AnalysisSurface<'a> {
 /// - `finish` is the background or batch path. It completes the remaining deferred payloads chosen
 ///   by the project's configured indexing policy and then reapplies package residency.
 ///
-/// Detached finishing uses the same policy, but runs on a cloned `Project`. The clone is wrapped in
-/// `FinishedSplitIndexing` until the saved project can merge package-wise improvements without
-/// losing any on-demand work that happened meanwhile.
+/// Detached finishing uses the same policy, but runs through `DetachedSplitIndexing` so callers
+/// cannot accidentally treat a project clone as an ordinary live project. The clone stays hidden
+/// behind that capability until it becomes `FinishedSplitIndexing` and can be merged back into the
+/// saved project.
 pub struct SplitIndexing<'project> {
     project: &'project mut Project,
 }
@@ -99,10 +100,28 @@ impl<'project> SplitIndexing<'project> {
     pub fn merge_finished(&mut self, finished: FinishedSplitIndexing) -> anyhow::Result<bool> {
         merge_finished_project(&mut self.project.state, finished)
     }
+}
 
-    /// Finish deferred indexing inside a detached project clone.
-    pub fn finish_detached(project: Project) -> anyhow::Result<FinishedSplitIndexing> {
-        finish_detached_project(project)
+/// Owned capability for finishing split indexing away from the saved project.
+///
+/// The detached project is deliberately private. Background workers only need to finish deferred
+/// indexing and hand the result back to the saved project; exposing the raw clone would make it too
+/// easy to bypass generation checks or add query shortcuts that do not see live saved-state
+/// mutations.
+#[must_use]
+#[derive(Debug, MemorySize)]
+pub struct DetachedSplitIndexing {
+    project: Project,
+}
+
+impl DetachedSplitIndexing {
+    pub(super) fn new(project: Project) -> Self {
+        Self { project }
+    }
+
+    /// Finish deferred indexing inside the detached project clone.
+    pub fn finish(self) -> anyhow::Result<FinishedSplitIndexing> {
+        finish_detached_project(self.project)
     }
 }
 

--- a/crates/engine/project/src/project/split_indexing.rs
+++ b/crates/engine/project/src/project/split_indexing.rs
@@ -1,0 +1,561 @@
+//! Split indexing policy for a live project.
+//!
+//! Fresh indexing can return after the structural phases are ready, before every expensive
+//! analysis payload has been fully materialized. This module owns the policy after that early-start
+//! point: decide what a query must materialize, finish the deferred work in the background, and
+//! make sure residency only writes durable package artifacts.
+//!
+//! There are three paths through the public `SplitIndexing` entrypoint:
+//!
+//! - `finish` finishes the configured deferred payloads for resident packages and then applies
+//!   normal package residency.
+//! - `materialize` makes the analysis surface needed by one query available, such as one file for
+//!   hover or a mix of files and targets for reference search.
+//! - `finish_detached` and `merge_finished` let an LSP background clone finish deferred payloads
+//!   and merge package-wise improvements back into the saved project.
+//!
+//! That last path has to be monotonic. Query-time materialization may finish a package before the
+//! background clone finishes, so a stale background result must not replace better saved coverage
+//! with an older partial view.
+
+use anyhow::Context as _;
+use rg_body_ir::{BodyIrBuildPolicy, BodyIrFile, PackageBodies, TargetBodiesCoverage};
+use rg_def_map::PackageSlot;
+use rg_ir_model::TargetRef;
+use rg_parse::FileId;
+use rg_std::{MemorySize, Shrink, UniqueVec};
+
+use crate::{
+    ProjectMemoryPurgePoint,
+    profile::{BuildMemorySampler, BuildProcessMemory, record_build_checkpoint},
+    project::{
+        Project, loading::PackageReadLoaders, offloading::ResidencyApplication,
+        package_set::PhasePackageSet, state::ProjectState,
+    },
+};
+
+/// Source surface whose deferred analysis data must be available before a query runs.
+///
+/// File surfaces are used when a query is tied to a concrete source file. Target surfaces are
+/// broader: preparing a target means that all deferred data in its owning package may be needed.
+/// Reference search can need both shapes when a text prefilter narrows some work to files while
+/// another part of the query still needs whole-target coverage.
+#[derive(Debug, Clone, Copy)]
+pub enum AnalysisSurface<'a> {
+    /// Prepare deferred data needed by analysis rooted in these package-local source files.
+    Files(&'a [(PackageSlot, FileId)]),
+    /// Prepare all deferred data for the packages that own these targets.
+    Targets(&'a [TargetRef]),
+    /// Prepare exact file coverage first, then finish target-owning packages.
+    FilesAndTargets {
+        files: &'a [(PackageSlot, FileId)],
+        targets: &'a [TargetRef],
+    },
+}
+
+/// Split-indexing operations for a live project.
+///
+/// A project built with `SplitIndexingMode::EarlyStart` is already queryable when this handle is
+/// used, but some expensive analysis payloads may still be absent. Callers use this handle to make
+/// those payloads real in one of two ways:
+///
+/// - `materialize` is the on-demand path. It prepares exactly the source surface a query needs
+///   before that query runs, so reference search and rename do not miss body-local uses.
+/// - `finish` is the background or batch path. It completes the remaining deferred payloads chosen
+///   by the project's configured indexing policy and then reapplies package residency.
+///
+/// Detached finishing uses the same policy, but runs on a cloned `Project`. The clone is wrapped in
+/// `FinishedSplitIndexing` until the saved project can merge package-wise improvements without
+/// losing any on-demand work that happened meanwhile.
+pub struct SplitIndexing<'project> {
+    project: &'project mut Project,
+}
+
+impl<'project> SplitIndexing<'project> {
+    pub(super) fn new(project: &'project mut Project) -> Self {
+        Self { project }
+    }
+
+    /// Finish deferred indexing without recording build checkpoints.
+    pub fn finish(&mut self) -> anyhow::Result<()> {
+        finish_unprofiled(&mut self.project.state)
+    }
+
+    /// Finish deferred indexing and record retained/process memory checkpoints.
+    pub fn finish_profiled(
+        &mut self,
+        sampler: impl FnMut() -> Option<BuildProcessMemory> + 'static,
+    ) -> anyhow::Result<()> {
+        let mut memory_sampler = BuildMemorySampler::retained(Some(Box::new(sampler)));
+        finish_with_sampler(&mut self.project.state, &mut memory_sampler)
+    }
+
+    /// Materialize deferred analysis data for the requested query surface.
+    pub fn materialize(&mut self, surface: AnalysisSurface<'_>) -> anyhow::Result<()> {
+        materialize_surface(&mut self.project.state, surface)
+    }
+
+    /// Merge a detached finish result, returning whether it improved the saved project.
+    pub fn merge_finished(&mut self, finished: FinishedSplitIndexing) -> anyhow::Result<bool> {
+        merge_finished_project(&mut self.project.state, finished)
+    }
+
+    /// Finish deferred indexing inside a detached project clone.
+    pub fn finish_detached(project: Project) -> anyhow::Result<FinishedSplitIndexing> {
+        finish_detached_project(project)
+    }
+}
+
+/// Result of finishing split indexing inside a detached project clone.
+///
+/// The project stays owned by this value until merge time. That lets the saved project decide,
+/// package by package, whether the detached result is still an improvement over any on-demand work
+/// that happened while the background clone was running.
+#[derive(Debug, Clone, MemorySize)]
+pub struct FinishedSplitIndexing {
+    project: Project,
+    packages: Vec<PackageSlot>,
+}
+
+/// Finish deferred indexing without recording build checkpoints.
+fn finish_unprofiled(state: &mut ProjectState) -> anyhow::Result<()> {
+    let mut sampler = BuildMemorySampler::disabled();
+    finish_with_sampler(state, &mut sampler)
+}
+
+/// Finish deferred indexing and record the memory checkpoints used by profiled builds.
+fn finish_with_sampler(
+    state: &mut ProjectState,
+    sampler: &mut BuildMemorySampler,
+) -> anyhow::Result<()> {
+    let packages = finish_resident_with_sampler(state, sampler)?;
+    apply_finished_residency_with_sampler(state, &packages, sampler)
+}
+
+/// Make a query-shaped analysis surface available in the saved project before analysis runs.
+fn materialize_surface(
+    state: &mut ProjectState,
+    surface: AnalysisSurface<'_>,
+) -> anyhow::Result<()> {
+    match surface {
+        AnalysisSurface::Files(files) => materialize_files(state, files),
+        AnalysisSurface::Targets(targets) => materialize_targets(state, targets),
+        AnalysisSurface::FilesAndTargets { files, targets } => {
+            materialize_files(state, files)?;
+            materialize_targets(state, targets)
+        }
+    }
+}
+
+/// Complete deferred indexing inside a detached project so it can later be merged into saved state.
+fn finish_detached_project(mut project: Project) -> anyhow::Result<FinishedSplitIndexing> {
+    let mut sampler = BuildMemorySampler::disabled();
+    let packages = finish_resident_with_sampler(&mut project.state, &mut sampler)?;
+    Ok(FinishedSplitIndexing { project, packages })
+}
+
+/// Merge a detached finish result, returning whether it improved the saved project.
+fn merge_finished_project(
+    state: &mut ProjectState,
+    finished: FinishedSplitIndexing,
+) -> anyhow::Result<bool> {
+    let packages = merge_finished_packages(state, &finished.project.state, &finished.packages)
+        .context("while attempting to merge deferred indexing packages")?;
+    if packages.is_empty() {
+        return Ok(false);
+    }
+
+    apply_finished_residency(state, &packages)
+        .context("while attempting to apply residency after merging deferred indexing")?;
+    Ok(true)
+}
+
+/// Returns whether the current deferred-analysis payload can be written to a durable package cache.
+///
+/// For this split-indexing mode the deferred payload is Body IR. Complete target coverage is
+/// durable, and policy-skipped targets are durable when the configured eager policy would skip the
+/// whole package anyway. Partial selected-file coverage is intentionally transient: writing it as a
+/// package artifact would make future startup-cache reads look complete while silently missing
+/// bodies that were never materialized.
+pub(crate) fn package_deferred_payload_is_durable(
+    state: &ProjectState,
+    package: PackageSlot,
+) -> bool {
+    let Some(parse_package) = state.parse.package(package.0) else {
+        return false;
+    };
+    let Some(body_ir) = state.body_ir.resident_package(package) else {
+        return false;
+    };
+
+    body_ir.targets().iter().all(|target| {
+        target.coverage().is_complete()
+            || (!state.body_ir_policy.should_lower_package(parse_package)
+                && matches!(target.coverage(), TargetBodiesCoverage::SkippedByPolicy))
+    })
+}
+
+/// Materialize the deferred payload for a set of source files.
+///
+/// This is the narrow on-demand path used by file-local LSP queries. The deferred payload is stored
+/// as package-shaped Body IR, so the rebuild below keeps any already-materialized files selected as
+/// well as the newly requested files.
+fn materialize_files(
+    state: &mut ProjectState,
+    files: &[(PackageSlot, FileId)],
+) -> anyhow::Result<()> {
+    let mut body_files = files
+        .iter()
+        .map(|&(package, file)| BodyIrFile::new(package, file))
+        .collect::<UniqueVec<_>>();
+    if body_files.is_empty() {
+        return Ok(());
+    }
+
+    // Selected-file rebuilds replace a package payload. Keep already-materialized files selected so
+    // preparing one new file cannot accidentally discard earlier on-demand coverage from the same
+    // package.
+    let requested_packages = PhasePackageSet::from_body_files(body_files.as_slice());
+    for package in requested_packages.iter() {
+        if let Some(body_ir) = state.body_ir.resident_package(package) {
+            extend_with_materialized_body_files(package, body_ir, &mut body_files);
+        }
+    }
+
+    // Lower only the packages touched by the requested files, but give body lowering the visible
+    // dependency subset it needs for type/name facts referenced from those bodies.
+    let body_packages = PhasePackageSet::from_body_files(body_files.as_slice());
+    let rebuild_subset = body_packages.visible_dependency_subset(&state.workspace);
+    let loaders = PackageReadLoaders::new(state);
+    let body_ir = state
+        .body_ir
+        .package_rebuilder(
+            &state.parse,
+            &state.def_map,
+            &state.semantic_ir,
+            body_packages.as_slice(),
+            &mut state.names,
+            loaders.def_map,
+            loaders.semantic_ir,
+            &rebuild_subset,
+        )
+        .selected_files(body_files.into_vec())
+        .build()
+        .context("while attempting to materialize deferred analysis for files")?;
+
+    state.body_ir = body_ir;
+    Shrink::shrink_to_fit(&mut state.names);
+
+    // A selected-file request can finish a small package. Once the package is complete, apply the
+    // ordinary package-cache/offload rules so restart and idle-memory behavior stay consistent with
+    // background finishing.
+    let finished_packages = finished_resident_packages(state, body_packages.as_slice());
+    apply_finished_residency(state, &finished_packages).context(
+        "while attempting to apply residency after preparing deferred analysis for files",
+    )?;
+    Ok(())
+}
+
+/// Treat target readiness as package readiness, because deferred payloads are package-shaped.
+fn materialize_targets(state: &mut ProjectState, targets: &[TargetRef]) -> anyhow::Result<()> {
+    let packages = PhasePackageSet::from_targets(targets);
+    materialize_packages(state, packages.as_slice())
+}
+
+/// Complete requested resident packages for a query that cannot safely work from partial data.
+fn materialize_packages(state: &mut ProjectState, packages: &[PackageSlot]) -> anyhow::Result<()> {
+    let packages = packages_needing_finished_split_indexing(state, packages);
+    if packages.is_empty() {
+        return Ok(());
+    }
+
+    let rebuild_subset =
+        PhasePackageSet::from_slice(&packages).visible_dependency_subset(&state.workspace);
+    let loaders = PackageReadLoaders::new(state);
+    let body_ir = state
+        .body_ir
+        .package_rebuilder(
+            &state.parse,
+            &state.def_map,
+            &state.semantic_ir,
+            &packages,
+            &mut state.names,
+            loaders.def_map,
+            loaders.semantic_ir,
+            &rebuild_subset,
+        )
+        // Query-driven finishing intentionally overrides the eager indexing policy. If a query
+        // needs to scan a package, missing bodies would be false negatives rather than saved work.
+        .configured_bodies(BodyIrBuildPolicy::all_packages())
+        .build()
+        .context("while attempting to materialize complete deferred analysis for packages")?;
+
+    state.body_ir = body_ir;
+    Shrink::shrink_to_fit(&mut state.names);
+    apply_finished_residency(state, &packages).context(
+        "while attempting to apply residency after preparing complete deferred analysis for packages",
+    )?;
+    Ok(())
+}
+
+/// Complete the deferred packages selected by the project's configured payload policy.
+fn finish_resident_with_sampler(
+    state: &mut ProjectState,
+    sampler: &mut BuildMemorySampler,
+) -> anyhow::Result<Vec<PackageSlot>> {
+    let packages = unfinished_split_indexing_packages(state);
+    if packages.is_empty() {
+        return Ok(packages);
+    }
+
+    let finish_subset =
+        PhasePackageSet::from_slice(&packages).visible_dependency_subset(&state.workspace);
+    let loaders = PackageReadLoaders::new(state);
+    let body_ir = state
+        .body_ir
+        .package_rebuilder(
+            &state.parse,
+            &state.def_map,
+            &state.semantic_ir,
+            &packages,
+            &mut state.names,
+            loaders.def_map,
+            loaders.semantic_ir,
+            &finish_subset,
+        )
+        .configured_bodies(state.body_ir_policy)
+        .build()
+        .context("while attempting to finish deferred indexing packages")?;
+
+    state.body_ir = body_ir;
+    Shrink::shrink_to_fit(&mut state.names);
+    state
+        .memory_hooks
+        .purge(ProjectMemoryPurgePoint::AfterBodyIrBuild);
+    record_project_checkpoint(state, sampler, "after deferred indexing");
+
+    Ok(packages)
+}
+
+/// Apply package residency without adding profiler checkpoints.
+fn apply_finished_residency(
+    state: &mut ProjectState,
+    packages: &[PackageSlot],
+) -> anyhow::Result<()> {
+    let mut sampler = BuildMemorySampler::disabled();
+    apply_finished_residency_with_sampler(state, packages, &mut sampler)
+}
+
+/// Turn finished resident packages into their normal cache/offload state.
+fn apply_finished_residency_with_sampler(
+    state: &mut ProjectState,
+    packages: &[PackageSlot],
+    sampler: &mut BuildMemorySampler,
+) -> anyhow::Result<()> {
+    if packages.is_empty() {
+        return Ok(());
+    }
+
+    ResidencyApplication::restore(state, packages)
+        .apply_profiled(sampler)
+        .context("while attempting to apply package cache residency after deferred indexing")?;
+    state
+        .memory_hooks
+        .purge(ProjectMemoryPurgePoint::AfterBodyIrBuild);
+    record_project_checkpoint(state, sampler, "after deferred indexing cleanup");
+
+    Ok(())
+}
+
+fn record_project_checkpoint(
+    state: &ProjectState,
+    sampler: &mut BuildMemorySampler,
+    label: &'static str,
+) {
+    let process_memory = sampler.sample_process_memory();
+    let project_bytes = sampler.measure_retained(state);
+    record_build_checkpoint(label, project_bytes, project_bytes, process_memory);
+}
+
+/// Merge only package-wise coverage improvements from a detached background finish.
+fn merge_finished_packages(
+    state: &mut ProjectState,
+    finished: &ProjectState,
+    packages: &[PackageSlot],
+) -> anyhow::Result<Vec<PackageSlot>> {
+    let mut replacements = Vec::new();
+
+    // Decide every replacement before mutating the saved project. If the finished payload is
+    // missing a promised package, fail without leaving a half-merged saved state behind.
+    for &package in packages {
+        let finished_bodies = finished
+            .body_ir
+            .resident_package(package)
+            .with_context(|| {
+                format!(
+                    "while attempting to read finished deferred payload package {}",
+                    package.0,
+                )
+            })?;
+        let should_replace = state
+            .body_ir
+            .resident_package(package)
+            .map(|current_bodies| {
+                body_payload_is_coverage_improvement(current_bodies, finished_bodies)
+            })
+            .unwrap_or(true);
+
+        // The background clone can lag behind query-time preparation. Keep the saved package when
+        // the detached version would only be equal or worse.
+        if should_replace {
+            replacements.push((package, finished_bodies.clone()));
+        }
+    }
+
+    if replacements.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut merged_packages = Vec::with_capacity(replacements.len());
+    for (package, bodies) in replacements {
+        state
+            .body_ir
+            .replace_package(package, bodies)
+            .with_context(|| {
+                format!(
+                    "while attempting to merge finished deferred payload package {}",
+                    package.0
+                )
+            })?;
+        merged_packages.push(package);
+    }
+    Shrink::shrink_to_fit(&mut state.names);
+
+    Ok(merged_packages)
+}
+
+/// Return resident packages whose configured deferred payload is still incomplete.
+fn unfinished_split_indexing_packages(state: &ProjectState) -> Vec<PackageSlot> {
+    let mut packages = Vec::new();
+
+    for package_idx in 0..state.parse.package_count() {
+        let package = PackageSlot(package_idx);
+        let Some(parse_package) = state.parse.package(package_idx) else {
+            continue;
+        };
+        if !state.body_ir_policy.should_lower_package(parse_package) {
+            continue;
+        }
+
+        let Some(body_ir) = state.body_ir.resident_package(package) else {
+            continue;
+        };
+        if body_ir
+            .targets()
+            .iter()
+            .all(|target| target.coverage().is_complete())
+        {
+            continue;
+        }
+
+        packages.push(package);
+    }
+
+    packages
+}
+
+/// Keep only requested resident packages that still need complete deferred payloads.
+fn packages_needing_finished_split_indexing(
+    state: &ProjectState,
+    packages: &[PackageSlot],
+) -> Vec<PackageSlot> {
+    let mut needed = UniqueVec::new();
+
+    for &package in packages {
+        let Some(body_ir) = state.body_ir.resident_package(package) else {
+            continue;
+        };
+        if body_ir
+            .targets()
+            .iter()
+            .all(|target| target.coverage().is_complete())
+        {
+            continue;
+        }
+
+        needed.push(package);
+    }
+
+    needed.into_vec()
+}
+
+/// Return packages from this set that have become complete after a partial rebuild.
+fn finished_resident_packages(state: &ProjectState, packages: &[PackageSlot]) -> Vec<PackageSlot> {
+    let mut finished = Vec::new();
+
+    for &package in packages {
+        let Some(body_ir) = state.body_ir.resident_package(package) else {
+            continue;
+        };
+        if body_ir
+            .targets()
+            .iter()
+            .all(|target| target.coverage().is_complete())
+        {
+            finished.push(package);
+        }
+    }
+
+    finished
+}
+
+/// Preserve already-materialized file bodies when a selected-file rebuild replaces a package.
+fn extend_with_materialized_body_files(
+    package: PackageSlot,
+    body_ir: &PackageBodies,
+    files: &mut UniqueVec<BodyIrFile>,
+) {
+    for target in body_ir.targets() {
+        if !target.coverage().is_materialized() {
+            continue;
+        }
+        for body in target.bodies() {
+            let source = body.source();
+            if source.is_written() {
+                files.push(BodyIrFile::new(package, source.file_id));
+            }
+        }
+    }
+}
+
+/// Return whether `finished` can replace `current` without losing target coverage.
+///
+/// Equal coverage is not treated as an improvement: replacing identical packages would create extra
+/// churn and can still disturb residency/cache state.
+fn body_payload_is_coverage_improvement(current: &PackageBodies, finished: &PackageBodies) -> bool {
+    if current.targets().len() != finished.targets().len() {
+        return false;
+    }
+
+    let mut improved = false;
+    for (current, finished) in current.targets().iter().zip(finished.targets()) {
+        let current_rank = body_coverage_rank(current.coverage());
+        let finished_rank = body_coverage_rank(finished.coverage());
+        if finished_rank < current_rank {
+            return false;
+        }
+        if finished_rank > current_rank {
+            improved = true;
+        }
+    }
+
+    improved
+}
+
+fn body_coverage_rank(coverage: TargetBodiesCoverage) -> u8 {
+    match coverage {
+        TargetBodiesCoverage::Missing | TargetBodiesCoverage::SkippedByPolicy => 0,
+        TargetBodiesCoverage::Partial => 1,
+        TargetBodiesCoverage::Complete => 2,
+    }
+}

--- a/crates/engine/project/src/project/split_indexing.rs
+++ b/crates/engine/project/src/project/split_indexing.rs
@@ -206,6 +206,7 @@ fn materialize_files(
 ) -> anyhow::Result<()> {
     let mut body_files = files
         .iter()
+        .filter(|&&(package, file)| body_file_needs_materialization(state, package, file))
         .map(|&(package, file)| BodyIrFile::new(package, file))
         .collect::<UniqueVec<_>>();
     if body_files.is_empty() {
@@ -254,6 +255,37 @@ fn materialize_files(
         "while attempting to apply residency after preparing deferred analysis for files",
     )?;
     Ok(())
+}
+
+/// Return whether a file-local query still needs source rebuilding before it can run.
+///
+/// Non-resident Body IR packages are already backed by durable cache artifacts. Query transactions
+/// can lazy-load them much more cheaply than rebuilding the package from source, so they are ready
+/// for this on-demand path. Resident complete packages are also ready. Partial packages only need a
+/// rebuild when the requested file's bodies are not among the already-materialized bodies.
+fn body_file_needs_materialization(
+    state: &ProjectState,
+    package: PackageSlot,
+    file: FileId,
+) -> bool {
+    let Some(body_ir) = state.body_ir.resident_package(package) else {
+        return false;
+    };
+
+    if body_ir
+        .targets()
+        .iter()
+        .all(|target| target.coverage().is_complete())
+    {
+        return false;
+    }
+
+    !body_ir.targets().iter().any(|target| {
+        target
+            .bodies()
+            .iter()
+            .any(|body| body.source().is_written() && body.source().file_id == file)
+    })
 }
 
 /// Treat target readiness as package readiness, because deferred payloads are package-shaped.

--- a/crates/engine/project/src/project/update/package.rs
+++ b/crates/engine/project/src/project/update/package.rs
@@ -131,7 +131,9 @@ fn try_rebuild_packages(
         &rebuild_subset,
     );
     body_rebuilder = match plan.body_scope {
-        BodyRebuildScope::Policy => body_rebuilder.policy(state.body_ir_policy),
+        BodyRebuildScope::ConfiguredBodies => {
+            body_rebuilder.configured_bodies(state.body_ir_policy)
+        }
         BodyRebuildScope::DirtyFiles(files) => body_rebuilder.selected_files(files.to_vec()),
     };
     let body_ir = body_rebuilder
@@ -167,7 +169,7 @@ impl<'a> PackageRebuildPlan<'a> {
         Self {
             source_packages: PhasePackageSet::from_slice(packages),
             body_packages: PhasePackageSet::from_slice(packages),
-            body_scope: BodyRebuildScope::Policy,
+            body_scope: BodyRebuildScope::ConfiguredBodies,
             residency: RebuildResidency::RestoreSavedState,
         }
     }
@@ -184,7 +186,7 @@ impl<'a> PackageRebuildPlan<'a> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BodyRebuildScope<'a> {
-    Policy,
+    ConfiguredBodies,
     DirtyFiles(&'a [BodyIrFile]),
 }
 
@@ -213,6 +215,7 @@ pub(crate) fn rebuild_resident_from_source(state: &mut ProjectState) -> anyhow::
         cargo_metadata_config,
         cache_instance,
         body_ir_policy,
+        build::SplitIndexingMode::Full,
         indexing_preference,
         package_residency_policy,
         StartupCacheLoad::Disabled,

--- a/crates/engine/project/src/tests/mod.rs
+++ b/crates/engine/project/src/tests/mod.rs
@@ -590,6 +590,81 @@ pub fn helper() -> usize {
 }
 
 #[test]
+fn file_prepare_keeps_finished_offloaded_payload_lazy() {
+    let fixture = ProjectSourceFixture::build(
+        r#"
+//- /Cargo.toml
+[package]
+name = "finished_offload_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub fn value() -> usize {
+    let value = 1usize;
+    val$ref$ue
+}
+"#,
+    );
+    let workspace = fixture.workspace_metadata();
+
+    let mut project = Project::builder(workspace)
+        .split_indexing_mode(SplitIndexingMode::EarlyStart)
+        .package_residency_policy(PackageResidencyPolicy::AllOffloadable)
+        .build()
+        .expect("early-start project build should succeed");
+    let reference = fixture.markers().position("ref");
+    let context = project
+        .snapshot()
+        .file_contexts_for_path(fixture.path(&reference.path))
+        .expect("fixture file contexts should resolve")
+        .pop()
+        .expect("fixture file should have one context");
+    let target = context
+        .targets
+        .first()
+        .copied()
+        .expect("fixture file should belong to one target");
+
+    project
+        .split_indexing()
+        .finish()
+        .expect("deferred indexing should finish and restore residency");
+    assert!(
+        project
+            .state
+            .body_ir
+            .resident_package(context.package)
+            .is_none(),
+        "finished all-offloadable package should return to lazy cache-backed residency",
+    );
+
+    project
+        .split_indexing()
+        .materialize(AnalysisSurface::Files(&[(context.package, context.file)]))
+        .expect("file-local preparation should treat finished offloaded payload as ready");
+    assert!(
+        project
+            .state
+            .body_ir
+            .resident_package(context.package)
+            .is_none(),
+        "file-local preparation should not rebuild a finished offloaded package from source",
+    );
+
+    assert!(
+        project
+            .snapshot()
+            .full_analysis()
+            .expect("analysis should lazy-load the finished offloaded package")
+            .type_at(target, context.file, reference.offset)
+            .expect("body-local type query should resolve from lazy package data")
+            .is_some(),
+        "finished offloaded body data should still be queryable through lazy loading",
+    );
+}
+
+#[test]
 fn process_memory_sampler_enables_retained_build_memory() {
     let fixture = ProjectSourceFixture::build(
         r#"

--- a/crates/engine/project/src/tests/mod.rs
+++ b/crates/engine/project/src/tests/mod.rs
@@ -12,7 +12,7 @@ use test_fixture::testonly::MarkedText;
 use self::utils::{HostFixture, HostObservation};
 use crate::{
     AnalysisSurface, BuildProcessMemory, PackageResidencyPolicy, Project, ProjectMemoryHooks,
-    ProjectMemoryPurgePoint, SplitIndexing, SplitIndexingMode,
+    ProjectMemoryPurgePoint, SplitIndexingMode,
     testonly::{ProjectFixture, ProjectSourceFixture},
 };
 
@@ -441,7 +441,9 @@ pub fn dep_value() -> usize {
         .split_indexing_mode(SplitIndexingMode::EarlyStart)
         .build()
         .expect("early-start project build should succeed");
-    let finished = SplitIndexing::finish_detached(project.clone())
+    let finished = project
+        .detach_split_indexing()
+        .finish()
         .expect("background deferred indexing should succeed");
     let dep_ref = fixture.markers().position("dep_ref");
     let dep_context = project

--- a/crates/engine/project/src/tests/mod.rs
+++ b/crates/engine/project/src/tests/mod.rs
@@ -6,12 +6,13 @@ use std::{
 };
 
 use expect_test::expect;
+use rg_analysis::ReferenceQuery;
 use test_fixture::testonly::MarkedText;
 
 use self::utils::{HostFixture, HostObservation};
 use crate::{
-    BuildProcessMemory, PackageResidencyPolicy, Project, ProjectMemoryHooks,
-    ProjectMemoryPurgePoint,
+    AnalysisSurface, BuildProcessMemory, PackageResidencyPolicy, Project, ProjectMemoryHooks,
+    ProjectMemoryPurgePoint, SplitIndexing, SplitIndexingMode,
     testonly::{ProjectFixture, ProjectSourceFixture},
 };
 
@@ -169,6 +170,426 @@ pub struct User;
 }
 
 #[test]
+fn early_start_build_can_finish_split_indexing_later() {
+    let fixture = ProjectSourceFixture::build(
+        r#"
+//- /Cargo.toml
+[package]
+name = "early_start_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub fn value() -> usize {
+    1
+}
+"#,
+    );
+    let workspace = fixture.workspace_metadata();
+
+    let mut project = Project::builder(workspace)
+        .split_indexing_mode(SplitIndexingMode::EarlyStart)
+        .build()
+        .expect("early-start project build should succeed");
+
+    let stats = project.stats().body_ir;
+    assert_eq!(stats.target_count, 1);
+    assert_eq!(stats.complete_target_count, 0);
+    assert_eq!(stats.missing_target_count, 1);
+    assert_eq!(stats.body_count, 0);
+
+    project
+        .split_indexing()
+        .finish()
+        .expect("deferred indexing should succeed");
+
+    let stats = project.stats().body_ir;
+    assert_eq!(stats.target_count, 1);
+    assert_eq!(stats.complete_target_count, 1);
+    assert_eq!(stats.missing_target_count, 0);
+    assert_eq!(stats.body_count, 1);
+}
+
+#[test]
+fn file_prepare_materializes_deferred_analysis_incrementally() {
+    let fixture = ProjectSourceFixture::build(
+        r#"
+//- /Cargo.toml
+[package]
+name = "file_ensure_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+mod other;
+
+pub fn first() -> usize {
+    1
+}
+
+//- /src/other.rs
+pub fn second() -> usize {
+    2
+}
+"#,
+    );
+    let workspace = fixture.workspace_metadata();
+
+    let mut project = Project::builder(workspace)
+        .split_indexing_mode(SplitIndexingMode::EarlyStart)
+        .build()
+        .expect("early-start project build should succeed");
+
+    let stats = project.stats().body_ir;
+    assert_eq!(stats.missing_target_count, 1);
+    assert_eq!(stats.body_count, 0);
+
+    let lib_context = project
+        .snapshot()
+        .file_contexts_for_path(fixture.path("src/lib.rs"))
+        .expect("lib file contexts should resolve")
+        .pop()
+        .expect("lib file should have one context");
+    project
+        .split_indexing()
+        .materialize(AnalysisSurface::Files(&[(
+            lib_context.package,
+            lib_context.file,
+        )]))
+        .expect("lib file deferred analysis should materialize");
+
+    let stats = project.stats().body_ir;
+    assert_eq!(stats.complete_target_count, 0);
+    assert_eq!(stats.partial_target_count, 1);
+    assert_eq!(stats.body_count, 1);
+
+    let other_context = project
+        .snapshot()
+        .file_contexts_for_path(fixture.path("src/other.rs"))
+        .expect("other file contexts should resolve")
+        .pop()
+        .expect("other file should have one context");
+    project
+        .split_indexing()
+        .materialize(AnalysisSurface::Files(&[(
+            other_context.package,
+            other_context.file,
+        )]))
+        .expect("other file deferred analysis should materialize");
+
+    let stats = project.stats().body_ir;
+    assert_eq!(stats.complete_target_count, 1);
+    assert_eq!(stats.partial_target_count, 0);
+    assert_eq!(stats.body_count, 2);
+}
+
+#[test]
+fn split_indexing_prevents_reference_and_rename_false_negatives() {
+    let fixture = ProjectSourceFixture::build(
+        r#"
+//- /Cargo.toml
+[package]
+name = "reference_surface_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+mod other;
+
+pub struct User {
+    pub na$subject$me: usize,
+}
+
+//- /src/other.rs
+use crate::User;
+
+pub fn demo(user: User) -> usize {
+    user.name
+}
+"#,
+    );
+    let workspace = fixture.workspace_metadata();
+
+    let mut project = Project::builder(workspace)
+        .split_indexing_mode(SplitIndexingMode::EarlyStart)
+        .build()
+        .expect("early-start project build should succeed");
+
+    let subject = fixture.markers().position("subject");
+    let lib_context = project
+        .snapshot()
+        .file_contexts_for_path(fixture.path(&subject.path))
+        .expect("subject file contexts should resolve")
+        .pop()
+        .expect("subject file should have one context");
+    let other_context = project
+        .snapshot()
+        .file_contexts_for_path(fixture.path("src/other.rs"))
+        .expect("other file contexts should resolve")
+        .pop()
+        .expect("other file should have one context");
+    let target = lib_context
+        .targets
+        .first()
+        .copied()
+        .expect("subject file should belong to one target");
+
+    let search_files = {
+        let snapshot = project.snapshot();
+        let analysis = snapshot
+            .full_analysis()
+            .expect("early-start analysis should materialize");
+        let declaration_targets = analysis
+            .goto_definition(target, lib_context.file, subject.offset)
+            .expect("definition lookup should resolve")
+            .into_iter()
+            .map(|target| target.target)
+            .collect::<Vec<_>>();
+        let search_targets =
+            snapshot.reference_search_targets(lib_context.package, &declaration_targets);
+        let labels = analysis
+            .reference_search_labels(target, lib_context.file, subject.offset)
+            .expect("reference labels should resolve");
+        let files = snapshot
+            .reference_search_files_matching_labels(&search_targets, &labels)
+            .expect("reference text prefilter should resolve")
+            .expect("reference text prefilter should find label-bearing files");
+
+        assert!(
+            files
+                .iter()
+                .any(|file| file.target == target && file.file_id == other_context.file),
+            "reference scan surface should include the file with body references",
+        );
+
+        files
+    };
+
+    let search_body_files = search_files
+        .iter()
+        .map(|file| (file.target.package, file.file_id))
+        .collect::<Vec<_>>();
+    project
+        .split_indexing()
+        .materialize(AnalysisSurface::Files(&search_body_files))
+        .expect("reference scan files should materialize on demand");
+
+    let snapshot = project.snapshot();
+    let analysis = snapshot
+        .full_analysis()
+        .expect("completed analysis should materialize");
+    let query = ReferenceQuery::find_references_in_files(&search_files, true);
+    let references = analysis
+        .references(target, lib_context.file, subject.offset, query)
+        .expect("references should resolve after on-demand materialization");
+    assert!(
+        references
+            .iter()
+            .any(|reference| reference.file_id == other_context.file),
+        "references should include body occurrences from the on-demand scan surface",
+    );
+
+    let query = ReferenceQuery::find_references_in_files(&search_files, true);
+    let rename = analysis
+        .rename(target, lib_context.file, subject.offset, "label", query)
+        .expect("rename should resolve after on-demand materialization")
+        .expect("rename should be available for the selected field");
+    assert!(
+        rename.edits.iter().any(|edit| {
+            edit.file_id == other_context.file
+                && edit.old_text == "name"
+                && edit.new_text == "label"
+        }),
+        "rename should edit body occurrences from the on-demand scan surface",
+    );
+}
+
+#[test]
+fn merging_finished_split_indexing_does_not_downgrade_on_demand_package() {
+    let fixture = ProjectSourceFixture::build(
+        r#"
+//- /Cargo.toml
+[package]
+name = "background_merge_app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+dep = { path = "dep", package = "background_merge_dep" }
+
+//- /src/lib.rs
+pub fn app_value() -> usize {
+    dep::dep_value()
+}
+
+//- /dep/Cargo.toml
+[package]
+name = "background_merge_dep"
+version = "0.1.0"
+edition = "2024"
+
+//- /dep/src/lib.rs
+pub fn dep_value() -> usize {
+    let value = 1usize;
+    val$dep_ref$ue
+}
+"#,
+    );
+    let workspace = fixture.workspace_metadata();
+
+    let mut project = Project::builder(workspace)
+        .split_indexing_mode(SplitIndexingMode::EarlyStart)
+        .build()
+        .expect("early-start project build should succeed");
+    let finished = SplitIndexing::finish_detached(project.clone())
+        .expect("background deferred indexing should succeed");
+    let dep_ref = fixture.markers().position("dep_ref");
+    let dep_context = project
+        .snapshot()
+        .file_contexts_for_path(fixture.path(&dep_ref.path))
+        .expect("dependency file contexts should resolve")
+        .pop()
+        .expect("dependency file should have one context");
+    let dep_target = dep_context
+        .targets
+        .first()
+        .copied()
+        .expect("dependency file should belong to one target");
+
+    project
+        .split_indexing()
+        .materialize(AnalysisSurface::Targets(&dep_context.targets))
+        .expect("on-demand dependency deferred indexing should succeed");
+    assert!(
+        project
+            .snapshot()
+            .full_analysis()
+            .expect("analysis should materialize after on-demand dependency finish")
+            .type_at(dep_target, dep_context.file, dep_ref.offset)
+            .expect("dependency body-local type query should resolve")
+            .is_some(),
+        "dependency body should be queryable after on-demand finish",
+    );
+
+    assert!(
+        project
+            .split_indexing()
+            .merge_finished(finished)
+            .expect("background deferred indexing should merge"),
+        "workspace package finish should still merge",
+    );
+    assert!(
+        project
+            .snapshot()
+            .full_analysis()
+            .expect("analysis should materialize after background merge")
+            .type_at(dep_target, dep_context.file, dep_ref.offset)
+            .expect("dependency body-local type query should resolve after merge")
+            .is_some(),
+        "background finish must not reinstall the clone's skipped dependency bodies",
+    );
+}
+
+#[test]
+fn residency_keeps_partial_deferred_payload_transient_and_resident() {
+    let fixture = ProjectSourceFixture::build(
+        r#"
+//- /Cargo.toml
+[workspace]
+members = ["app", "helper"]
+
+//- /app/Cargo.toml
+[package]
+name = "partial_residency_app"
+version = "0.1.0"
+edition = "2024"
+
+//- /app/src/lib.rs
+mod other;
+
+pub fn first() -> usize {
+    let value = 1usize;
+    val$app_ref$ue
+}
+
+//- /app/src/other.rs
+pub fn second() -> usize {
+    2
+}
+
+//- /helper/Cargo.toml
+[package]
+name = "partial_residency_helper"
+version = "0.1.0"
+edition = "2024"
+
+//- /helper/src/lib.rs
+pub fn helper() -> usize {
+    1
+}
+"#,
+    );
+    let workspace = fixture.workspace_metadata();
+
+    let mut project = Project::builder(workspace)
+        .split_indexing_mode(SplitIndexingMode::EarlyStart)
+        .package_residency_policy(PackageResidencyPolicy::AllOffloadable)
+        .build()
+        .expect("early-start project build should succeed");
+    let app_ref = fixture.markers().position("app_ref");
+    let lib_context = project
+        .snapshot()
+        .file_contexts_for_path(fixture.path(&app_ref.path))
+        .expect("lib file contexts should resolve")
+        .pop()
+        .expect("lib file should have one context");
+    let helper_context = project
+        .snapshot()
+        .file_contexts_for_path(fixture.path("helper/src/lib.rs"))
+        .expect("helper file contexts should resolve")
+        .pop()
+        .expect("helper file should have one context");
+    let app_target = lib_context
+        .targets
+        .first()
+        .copied()
+        .expect("app file should belong to one target");
+
+    project
+        .split_indexing()
+        .materialize(AnalysisSurface::Files(&[(
+            lib_context.package,
+            lib_context.file,
+        )]))
+        .expect("lib file deferred analysis should materialize");
+    let stats = project.stats().body_ir;
+    assert_eq!(stats.partial_target_count, 1);
+    assert_eq!(stats.body_count, 1);
+
+    project
+        .split_indexing()
+        .materialize(AnalysisSurface::Files(&[(
+            helper_context.package,
+            helper_context.file,
+        )]))
+        .expect("helper deferred indexing should apply residency");
+    let stats = project.stats().body_ir;
+    assert_eq!(stats.partial_target_count, 1);
+    assert_eq!(stats.body_count, 1);
+
+    assert!(
+        project
+            .snapshot()
+            .full_analysis()
+            .expect("analysis should materialize after helper residency")
+            .type_at(app_target, lib_context.file, app_ref.offset)
+            .expect("app body-local type query should resolve")
+            .is_some(),
+        "partial on-demand app body should remain resident after another package applies residency",
+    );
+}
+
+#[test]
 fn process_memory_sampler_enables_retained_build_memory() {
     let fixture = ProjectSourceFixture::build(
         r#"
@@ -211,6 +632,81 @@ pub struct User;
         checkpoint_optional_bytes(after_parse, "allocated_bytes"),
         Some(11),
         "process memory sampling should still record allocator counters"
+    );
+}
+
+#[test]
+fn profiled_split_indexing_reports_finish_and_residency_memory() {
+    let fixture = ProjectSourceFixture::build(
+        r#"
+//- /Cargo.toml
+[package]
+name = "profiled_split_finish_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub fn answer() -> i32 {
+    42
+}
+"#,
+    );
+    let workspace = fixture.workspace_metadata();
+    let run =
+        rg_profile::test_support::ProfileTest::start(crate::profile_descriptors(), "project.build");
+
+    let mut project = Project::builder(workspace)
+        .split_indexing_mode(SplitIndexingMode::EarlyStart)
+        .package_residency_policy(PackageResidencyPolicy::AllOffloadable)
+        .process_memory_sampler(|| {
+            Some(BuildProcessMemory {
+                allocated_bytes: 11,
+                active_bytes: 13,
+                resident_bytes: 17,
+                mapped_bytes: 19,
+            })
+        })
+        .build()
+        .expect("early-start project build should succeed");
+    project
+        .split_indexing()
+        .finish_profiled(|| {
+            Some(BuildProcessMemory {
+                allocated_bytes: 31,
+                active_bytes: 37,
+                resident_bytes: 41,
+                mapped_bytes: 43,
+            })
+        })
+        .expect("profiled deferred indexing should succeed");
+
+    let snapshot = run.finish();
+    let checkpoints = project_build_checkpoints(&snapshot);
+    let finish_labels = checkpoints
+        .iter()
+        .filter(|checkpoint| checkpoint_optional_bytes(checkpoint, "allocated_bytes") == Some(31))
+        .map(|checkpoint| checkpoint.label.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        finish_labels,
+        [
+            "after deferred indexing",
+            "before package cache write",
+            "after package cache write",
+            "after package payload offload",
+            "after package offload cleanup",
+            "after deferred indexing cleanup",
+        ],
+        "deferred indexing should profile both lowering and the follow-up residency pass",
+    );
+
+    let deferred_finish = checkpoints
+        .iter()
+        .find(|checkpoint| checkpoint.label == "after deferred indexing")
+        .expect("profile should contain the deferred indexing checkpoint");
+    assert!(
+        checkpoint_optional_bytes(deferred_finish, "retained_bytes").is_some_and(|bytes| bytes > 0),
+        "profiled deferred indexing should record retained project memory",
     );
 }
 
@@ -669,6 +1165,10 @@ pub fn dirty_body(value: Dirty) {
 
         body ir stats `dirty overlay`
         - targets 1
+        - complete targets 0
+        - partial targets 1
+        - missing targets 0
+        - targets skipped by policy 0
         - bodies 1
 
         workspace symbols `Dirty`

--- a/crates/engine/project/src/tests/utils.rs
+++ b/crates/engine/project/src/tests/utils.rs
@@ -428,6 +428,30 @@ impl HostFixture {
         writeln!(dump, "body ir stats `{label}`").expect("string writes should not fail");
         writeln!(dump, "- targets {}", stats.body_ir.target_count)
             .expect("string writes should not fail");
+        writeln!(
+            dump,
+            "- complete targets {}",
+            stats.body_ir.complete_target_count
+        )
+        .expect("string writes should not fail");
+        writeln!(
+            dump,
+            "- partial targets {}",
+            stats.body_ir.partial_target_count
+        )
+        .expect("string writes should not fail");
+        writeln!(
+            dump,
+            "- missing targets {}",
+            stats.body_ir.missing_target_count
+        )
+        .expect("string writes should not fail");
+        writeln!(
+            dump,
+            "- targets skipped by policy {}",
+            stats.body_ir.skipped_by_policy_target_count
+        )
+        .expect("string writes should not fail");
         writeln!(dump, "- bodies {}", stats.body_ir.body_count)
             .expect("string writes should not fail");
     }

--- a/crates/lib/std/src/unique.rs
+++ b/crates/lib/std/src/unique.rs
@@ -48,6 +48,10 @@ impl<T> UniqueVec<T> {
         self.items.iter()
     }
 
+    pub fn as_slice(&self) -> &[T] {
+        &self.items
+    }
+
     pub fn into_vec(self) -> Vec<T> {
         self.items
     }

--- a/crates/lsp/engine/src/engine/command.rs
+++ b/crates/lsp/engine/src/engine/command.rs
@@ -98,5 +98,9 @@ pub(crate) enum EngineCommand {
     ReindexWorkspace {
         respond_to: EngineResponse<()>,
     },
+    DeferredIndexingFinished {
+        generation: u64,
+        result: anyhow::Result<rg_project::FinishedSplitIndexing>,
+    },
     Shutdown(EngineResponse<()>),
 }

--- a/crates/lsp/engine/src/engine/command.rs
+++ b/crates/lsp/engine/src/engine/command.rs
@@ -6,6 +6,7 @@ use tokio::sync::oneshot;
 use crate::documents::DirtyDocumentSnapshot;
 
 pub(crate) type EngineResponse<T> = oneshot::Sender<anyhow::Result<T>>;
+pub(crate) type DeferredIndexingResult = anyhow::Result<Box<rg_project::FinishedSplitIndexing>>;
 
 #[derive(Debug)]
 pub(crate) enum EngineCommand {
@@ -100,7 +101,7 @@ pub(crate) enum EngineCommand {
     },
     DeferredIndexingFinished {
         generation: u64,
-        result: anyhow::Result<rg_project::FinishedSplitIndexing>,
+        result: DeferredIndexingResult,
     },
     Shutdown(EngineResponse<()>),
 }

--- a/crates/lsp/engine/src/engine/early_start.rs
+++ b/crates/lsp/engine/src/engine/early_start.rs
@@ -95,6 +95,10 @@ impl EarlyStart {
     }
 
     /// Merge the initial background finish if it still matches the saved-project generation.
+    ///
+    /// Returning `true` means that the background finish belongs to the current saved project, even
+    /// if there was nothing left to merge. The client-side status indicator cares about that
+    /// lifecycle fact: deferred indexing is no longer pending once this command has been handled.
     pub(super) fn apply_initial_finish(
         project_proxy: &mut ProjectProxy,
         generation: u64,
@@ -109,7 +113,7 @@ impl EarlyStart {
             return false;
         }
 
-        match result {
+        let updated = match result {
             // The merge itself is monotonic: packages finished by query-time materialization win
             // over an equal or older package from the background clone.
             Ok(finished) => project_proxy
@@ -132,7 +136,15 @@ impl EarlyStart {
                 );
                 false
             }
+        };
+
+        if !updated {
+            tracing::trace!(
+                generation,
+                "initial deferred indexing finish completed without saved project changes"
+            );
         }
+        true
     }
 
     /// Materialize the saved analysis surface needed by one path-local query.

--- a/crates/lsp/engine/src/engine/early_start.rs
+++ b/crates/lsp/engine/src/engine/early_start.rs
@@ -10,7 +10,7 @@ use std::{path::Path, sync::mpsc::Sender, thread, time::Instant};
 use anyhow::Context as _;
 use rg_analysis::{ReferenceQuery, ReferenceSearchFile};
 use rg_ir_model::TargetRef;
-use rg_project::{AnalysisSurface, FileContext, FinishedSplitIndexing, Project, SplitIndexing};
+use rg_project::{AnalysisSurface, DetachedSplitIndexing, FileContext, FinishedSplitIndexing};
 use rg_std::UniqueVec;
 
 use super::{QueuedEngineCommand, command::EngineCommand, project_proxy::ProjectProxy};
@@ -34,18 +34,106 @@ impl ReferenceSearchPlan {
     }
 }
 
-pub(super) struct EarlyStart;
+#[derive(Debug, Default)]
+pub(super) struct DeferredIndexingFinish {
+    in_flight_generation: Option<u64>,
+    restart_after_in_flight: bool,
+}
 
-impl EarlyStart {
-    /// Finish the deferred part of initial indexing on a detached project clone.
+impl DeferredIndexingFinish {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Start deferred indexing for the freshly saved project.
+    ///
+    /// This is called after the worker replaces the saved project during initialization. At that
+    /// point there cannot be an older finish for the same engine, so the clone built by the initial
+    /// index can be handed directly to the background thread.
+    pub(super) fn start_initial(
+        &mut self,
+        sender: &Sender<QueuedEngineCommand>,
+        generation: u64,
+        detached: DetachedSplitIndexing,
+    ) {
+        self.spawn_finish(sender, generation, detached);
+    }
+
+    /// Ensure the current saved project will eventually finish deferred indexing.
+    ///
+    /// Saved-source mutations invalidate any detached clone that is already running. Starting
+    /// another clone immediately would double peak memory, so the worker records that one restart is
+    /// needed and lets the old clone return first.
+    pub(super) fn saved_project_changed(
+        &mut self,
+        sender: &Sender<QueuedEngineCommand>,
+        project_proxy: &ProjectProxy,
+    ) {
+        if self.in_flight_generation.is_some() {
+            self.restart_after_in_flight = true;
+            return;
+        }
+        self.start_current(sender, project_proxy);
+    }
+
+    /// Handle a background result and return whether the editor should see this root as finished.
+    pub(super) fn finish_returned(
+        &mut self,
+        sender: &Sender<QueuedEngineCommand>,
+        project_proxy: &mut ProjectProxy,
+        generation: u64,
+        result: anyhow::Result<FinishedSplitIndexing>,
+    ) -> bool {
+        if self.in_flight_generation != Some(generation) {
+            tracing::info!(
+                generation,
+                current_in_flight_generation = ?self.in_flight_generation,
+                "discarding unknown deferred indexing finish"
+            );
+            return false;
+        }
+        self.in_flight_generation = None;
+
+        let is_current_generation =
+            Self::apply_finish_if_current(project_proxy, generation, result);
+        let should_restart = self.restart_after_in_flight || !is_current_generation;
+        self.restart_after_in_flight = false;
+        if should_restart {
+            self.start_current(sender, project_proxy);
+        }
+
+        is_current_generation
+    }
+
+    fn start_current(
+        &mut self,
+        sender: &Sender<QueuedEngineCommand>,
+        project_proxy: &ProjectProxy,
+    ) {
+        let (generation, detached) = match project_proxy.detach_saved_split_indexing() {
+            Ok(detached) => detached,
+            Err(error) => {
+                tracing::warn!(
+                    error = %format!("{error:#}"),
+                    "failed to detach saved project for deferred indexing finish"
+                );
+                return;
+            }
+        };
+
+        self.spawn_finish(sender, generation, detached);
+    }
+
+    /// Finish deferred indexing on a detached project clone.
     ///
     /// The saved project is already usable when this runs. The background result is sent back to
     /// the command loop instead of mutating saved state directly, so the command loop can keep all
     /// project generation checks in one place.
-    pub(super) fn spawn_initial_finish(
+    fn spawn_finish(
+        &mut self,
         sender: &Sender<QueuedEngineCommand>,
         generation: u64,
-        project: Project,
+        detached: DetachedSplitIndexing,
     ) {
         let sender = sender.clone();
 
@@ -53,21 +141,18 @@ impl EarlyStart {
             .name("rg-deferred-indexing".to_string())
             .spawn(move || {
                 let started = Instant::now();
-                tracing::info!(
-                    generation,
-                    "initial deferred indexing background finish started"
-                );
+                tracing::info!(generation, "deferred indexing background finish started");
 
                 // Finish against the clone. The result still owns that clone, which lets the saved
                 // project later merge only package-wise improvements.
-                let result = SplitIndexing::finish_detached(project);
+                let result = detached.finish();
                 let elapsed_ms = started.elapsed().as_millis();
                 match &result {
                     Ok(_) => {
                         tracing::info!(
                             generation,
                             elapsed_ms,
-                            "initial deferred indexing background finish completed"
+                            "deferred indexing background finish completed"
                         );
                     }
                     Err(error) => {
@@ -75,7 +160,7 @@ impl EarlyStart {
                             generation,
                             elapsed_ms,
                             error = %format!("{error:#}"),
-                            "initial deferred indexing background finish failed"
+                            "deferred indexing background finish failed"
                         );
                     }
                 }
@@ -85,12 +170,17 @@ impl EarlyStart {
                 ));
             });
 
-        if let Err(error) = spawn_result {
-            tracing::warn!(
-                generation,
-                error = %error,
-                "failed to spawn initial deferred indexing background finish"
-            );
+        match spawn_result {
+            Ok(_) => {
+                self.in_flight_generation = Some(generation);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    generation,
+                    error = %error,
+                    "failed to spawn deferred indexing background finish"
+                );
+            }
         }
     }
 
@@ -99,7 +189,7 @@ impl EarlyStart {
     /// Returning `true` means that the background finish belongs to the current saved project, even
     /// if there was nothing left to merge. The client-side status indicator cares about that
     /// lifecycle fact: deferred indexing is no longer pending once this command has been handled.
-    pub(super) fn apply_initial_finish(
+    fn apply_finish_if_current(
         project_proxy: &mut ProjectProxy,
         generation: u64,
         result: anyhow::Result<FinishedSplitIndexing>,
@@ -141,12 +231,16 @@ impl EarlyStart {
         if !updated {
             tracing::trace!(
                 generation,
-                "initial deferred indexing finish completed without saved project changes"
+                "deferred indexing finish completed without saved project changes"
             );
         }
         true
     }
+}
 
+pub(super) struct EarlyStart;
+
+impl EarlyStart {
     /// Materialize the saved analysis surface needed by one path-local query.
     pub(super) fn ensure_path(
         project_proxy: &mut ProjectProxy,

--- a/crates/lsp/engine/src/engine/early_start.rs
+++ b/crates/lsp/engine/src/engine/early_start.rs
@@ -1,0 +1,238 @@
+//! Early-start orchestration for the LSP engine.
+//!
+//! The command worker decides which LSP query is running. This module owns the split-indexing
+//! lifecycle around that command flow: finish deferred indexing in the background, reconcile it
+//! with the current saved-project generation, and materialize the saved analysis surface a query
+//! needs before semantic analysis can produce false negatives.
+
+use std::{path::Path, sync::mpsc::Sender, thread, time::Instant};
+
+use anyhow::Context as _;
+use rg_analysis::{ReferenceQuery, ReferenceSearchFile};
+use rg_ir_model::TargetRef;
+use rg_project::{AnalysisSurface, FileContext, FinishedSplitIndexing, Project, SplitIndexing};
+use rg_std::UniqueVec;
+
+use super::{QueuedEngineCommand, command::EngineCommand, project_proxy::ProjectProxy};
+
+#[derive(Debug, Clone)]
+pub(super) struct ReferenceSearchPlan {
+    targets: Vec<TargetRef>,
+    files: Option<Vec<ReferenceSearchFile>>,
+}
+
+impl ReferenceSearchPlan {
+    pub(super) fn new(targets: Vec<TargetRef>, files: Option<Vec<ReferenceSearchFile>>) -> Self {
+        Self { targets, files }
+    }
+
+    pub(super) fn query(&self, include_declaration: bool) -> ReferenceQuery<'_> {
+        match self.files.as_deref() {
+            Some(files) => ReferenceQuery::find_references_in_files(files, include_declaration),
+            None => ReferenceQuery::find_references(&self.targets, include_declaration),
+        }
+    }
+}
+
+pub(super) struct EarlyStart;
+
+impl EarlyStart {
+    /// Finish the deferred part of initial indexing on a detached project clone.
+    ///
+    /// The saved project is already usable when this runs. The background result is sent back to
+    /// the command loop instead of mutating saved state directly, so the command loop can keep all
+    /// project generation checks in one place.
+    pub(super) fn spawn_initial_finish(
+        sender: &Sender<QueuedEngineCommand>,
+        generation: u64,
+        project: Project,
+    ) {
+        let sender = sender.clone();
+
+        let spawn_result = thread::Builder::new()
+            .name("rg-deferred-indexing".to_string())
+            .spawn(move || {
+                let started = Instant::now();
+                tracing::info!(
+                    generation,
+                    "initial deferred indexing background finish started"
+                );
+
+                // Finish against the clone. The result still owns that clone, which lets the saved
+                // project later merge only package-wise improvements.
+                let result = SplitIndexing::finish_detached(project);
+                let elapsed_ms = started.elapsed().as_millis();
+                match &result {
+                    Ok(_) => {
+                        tracing::info!(
+                            generation,
+                            elapsed_ms,
+                            "initial deferred indexing background finish completed"
+                        );
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            generation,
+                            elapsed_ms,
+                            error = %format!("{error:#}"),
+                            "initial deferred indexing background finish failed"
+                        );
+                    }
+                }
+
+                let _ = sender.send(QueuedEngineCommand::new(
+                    EngineCommand::DeferredIndexingFinished { generation, result },
+                ));
+            });
+
+        if let Err(error) = spawn_result {
+            tracing::warn!(
+                generation,
+                error = %error,
+                "failed to spawn initial deferred indexing background finish"
+            );
+        }
+    }
+
+    /// Merge the initial background finish if it still matches the saved-project generation.
+    pub(super) fn apply_initial_finish(
+        project_proxy: &mut ProjectProxy,
+        generation: u64,
+        result: anyhow::Result<FinishedSplitIndexing>,
+    ) -> bool {
+        if project_proxy.generation() != generation {
+            tracing::info!(
+                generation,
+                current_generation = project_proxy.generation(),
+                "discarding stale deferred indexing finish"
+            );
+            return false;
+        }
+
+        match result {
+            // The merge itself is monotonic: packages finished by query-time materialization win
+            // over an equal or older package from the background clone.
+            Ok(finished) => project_proxy
+                .mutate_saved_preserving_generation(|saved| {
+                    saved.split_indexing().merge_finished(finished)
+                })
+                .unwrap_or_else(|error| {
+                    tracing::warn!(
+                        generation,
+                        error = %format!("{error:#}"),
+                        "deferred indexing finish could not merge into saved project"
+                    );
+                    false
+                }),
+            Err(error) => {
+                tracing::warn!(
+                    generation,
+                    error = %format!("{error:#}"),
+                    "deferred indexing finish did not update project"
+                );
+                false
+            }
+        }
+    }
+
+    /// Materialize the saved analysis surface needed by one path-local query.
+    pub(super) fn ensure_path(
+        project_proxy: &mut ProjectProxy,
+        query: &'static str,
+        path: &Path,
+    ) -> anyhow::Result<()> {
+        let started = Instant::now();
+
+        // Resolve the path before mutating the saved project. A single file can have several target
+        // contexts, but file-shaped materialization only needs the package-local file ids.
+        let files = {
+            let snapshot = project_proxy.saved_snapshot()?;
+            Self::file_contexts(snapshot, path)?
+                .into_iter()
+                .map(|context| (context.package, context.file))
+                .collect::<Vec<_>>()
+        };
+        project_proxy
+            .mutate_saved_preserving_generation(|project| {
+                project
+                    .split_indexing()
+                    .materialize(AnalysisSurface::Files(&files))
+            })
+            .with_context(|| {
+                format!("while attempting to prepare analysis for {query} query path")
+            })?;
+        tracing::trace!(
+            query,
+            file_count = files.len(),
+            elapsed_ms = started.elapsed().as_millis(),
+            "saved analysis surface prepared for query path"
+        );
+        Ok(())
+    }
+
+    /// Materialize the saved analysis surface needed by reference-like scans.
+    ///
+    /// Text prefiltering can narrow some work to exact files, while other plans still need whole
+    /// target/package coverage. Preserve both shapes so split indexing only does the work the query
+    /// planner proved necessary.
+    pub(super) fn ensure_reference_plans(
+        project_proxy: &mut ProjectProxy,
+        query: &'static str,
+        plans: &[ReferenceSearchPlan],
+    ) -> anyhow::Result<()> {
+        let started = Instant::now();
+        let mut files = UniqueVec::<(rg_def_map::PackageSlot, rg_parse::FileId)>::new();
+        let mut targets = UniqueVec::<TargetRef>::new();
+
+        // `ReferenceSearchPlan::files == None` means "scan the targets normally". `Some(files)`
+        // means the text prefilter already selected the exact source files worth materializing.
+        for plan in plans {
+            match &plan.files {
+                Some(plan_files) => {
+                    files.extend(
+                        plan_files
+                            .iter()
+                            .map(|file| (file.target.package, file.file_id)),
+                    );
+                }
+                None => targets.extend(plan.targets.iter().copied()),
+            }
+        }
+
+        let files = files.into_vec();
+        let targets = targets.into_vec();
+        project_proxy
+            .mutate_saved_preserving_generation(|project| {
+                project
+                    .split_indexing()
+                    .materialize(AnalysisSurface::FilesAndTargets {
+                        files: &files,
+                        targets: &targets,
+                    })
+            })
+            .with_context(|| {
+                format!("while attempting to prepare analysis for {query} reference scan")
+            })?;
+        tracing::trace!(
+            query,
+            file_count = files.len(),
+            target_count = targets.len(),
+            elapsed_ms = started.elapsed().as_millis(),
+            "saved analysis surface prepared for reference scan"
+        );
+        Ok(())
+    }
+
+    /// Return saved file contexts for an existing query path.
+    fn file_contexts(
+        snapshot: rg_project::ProjectSnapshot<'_>,
+        path: &Path,
+    ) -> anyhow::Result<Vec<FileContext>> {
+        if !path.exists() {
+            tracing::debug!(path = %path.display(), "query path does not exist");
+            return Ok(Vec::new());
+        }
+
+        snapshot.file_contexts_for_path(path)
+    }
+}

--- a/crates/lsp/engine/src/engine/early_start.rs
+++ b/crates/lsp/engine/src/engine/early_start.rs
@@ -10,10 +10,14 @@ use std::{path::Path, sync::mpsc::Sender, thread, time::Instant};
 use anyhow::Context as _;
 use rg_analysis::{ReferenceQuery, ReferenceSearchFile};
 use rg_ir_model::TargetRef;
-use rg_project::{AnalysisSurface, DetachedSplitIndexing, FileContext, FinishedSplitIndexing};
+use rg_project::{AnalysisSurface, DetachedSplitIndexing, FileContext};
 use rg_std::UniqueVec;
 
-use super::{QueuedEngineCommand, command::EngineCommand, project_proxy::ProjectProxy};
+use super::{
+    QueuedEngineCommand,
+    command::{DeferredIndexingResult, EngineCommand},
+    project_proxy::ProjectProxy,
+};
 
 #[derive(Debug, Clone)]
 pub(super) struct ReferenceSearchPlan {
@@ -82,7 +86,7 @@ impl DeferredIndexingFinish {
         sender: &Sender<QueuedEngineCommand>,
         project_proxy: &mut ProjectProxy,
         generation: u64,
-        result: anyhow::Result<FinishedSplitIndexing>,
+        result: DeferredIndexingResult,
     ) -> bool {
         if self.in_flight_generation != Some(generation) {
             tracing::info!(
@@ -145,7 +149,7 @@ impl DeferredIndexingFinish {
 
                 // Finish against the clone. The result still owns that clone, which lets the saved
                 // project later merge only package-wise improvements.
-                let result = detached.finish();
+                let result = detached.finish().map(Box::new);
                 let elapsed_ms = started.elapsed().as_millis();
                 match &result {
                     Ok(_) => {
@@ -192,7 +196,7 @@ impl DeferredIndexingFinish {
     fn apply_finish_if_current(
         project_proxy: &mut ProjectProxy,
         generation: u64,
-        result: anyhow::Result<FinishedSplitIndexing>,
+        result: DeferredIndexingResult,
     ) -> bool {
         if project_proxy.generation() != generation {
             tracing::info!(
@@ -208,7 +212,7 @@ impl DeferredIndexingFinish {
             // over an equal or older package from the background clone.
             Ok(finished) => project_proxy
                 .mutate_saved_preserving_generation(|saved| {
-                    saved.split_indexing().merge_finished(finished)
+                    saved.split_indexing().merge_finished(*finished)
                 })
                 .unwrap_or_else(|error| {
                     tracing::warn!(

--- a/crates/lsp/engine/src/engine/mod.rs
+++ b/crates/lsp/engine/src/engine/mod.rs
@@ -72,7 +72,10 @@ impl EngineHandle {
         thread::spawn({
             let dirty_state = dirty_state.clone();
             let sender = sender.clone();
-            move || EngineWorker::new(sender, memory_control, dirty_state).run(receiver)
+            let notifications = notifications.clone();
+            move || {
+                EngineWorker::new(sender, memory_control, dirty_state, notifications).run(receiver)
+            }
         });
 
         Self {

--- a/crates/lsp/engine/src/engine/mod.rs
+++ b/crates/lsp/engine/src/engine/mod.rs
@@ -1,4 +1,5 @@
 mod command;
+mod early_start;
 mod project_proxy;
 mod worker;
 
@@ -70,7 +71,8 @@ impl EngineHandle {
 
         thread::spawn({
             let dirty_state = dirty_state.clone();
-            move || EngineWorker::new(memory_control, dirty_state).run(receiver)
+            let sender = sender.clone();
+            move || EngineWorker::new(sender, memory_control, dirty_state).run(receiver)
         });
 
         Self {

--- a/crates/lsp/engine/src/engine/project_proxy.rs
+++ b/crates/lsp/engine/src/engine/project_proxy.rs
@@ -8,9 +8,17 @@ use crate::{
 };
 
 /// Owns the saved project and the disposable dirty overlay used by read-only queries.
+///
+/// `generation` is the saved-project identity seen by asynchronous work. It changes when saved
+/// source state is replaced or rebuilt, so background results produced from an older `Project`
+/// clone can be discarded instead of merged into a newer workspace. Split-indexing materialization
+/// intentionally keeps the same generation: it enriches analysis data for the same saved source
+/// snapshot, but it still clears dirty overlays because those overlays borrow from the old project
+/// internals.
 #[derive(Debug)]
 pub(super) struct ProjectProxy {
     saved: Option<Project>,
+    generation: u64,
     dirty_overlay: DirtyOverlayCache,
 }
 
@@ -18,6 +26,7 @@ impl ProjectProxy {
     pub(super) fn new(memory_control: Arc<dyn MemoryControl>) -> Self {
         Self {
             saved: None,
+            generation: 0,
             dirty_overlay: DirtyOverlayCache::new(memory_control),
         }
     }
@@ -26,9 +35,15 @@ impl ProjectProxy {
         self.saved.is_some()
     }
 
-    pub(super) fn replace_saved(&mut self, project: Project) {
+    pub(super) fn replace_saved(&mut self, project: Project) -> u64 {
+        self.generation = self.generation.saturating_add(1);
         self.saved = Some(project);
         self.dirty_overlay.clear();
+        self.generation
+    }
+
+    pub(super) fn generation(&self) -> u64 {
+        self.generation
     }
 
     pub(super) fn mutate_saved<T>(
@@ -42,6 +57,22 @@ impl ProjectProxy {
 
         // Any saved-project mutation attempt may leave the project in a different state even if it
         // returns an error, so discard overlays derived from the previous saved state up front.
+        self.generation = self.generation.saturating_add(1);
+        self.dirty_overlay.clear();
+        mutation(saved)
+    }
+
+    pub(super) fn mutate_saved_preserving_generation<T>(
+        &mut self,
+        mutation: impl FnOnce(&mut Project) -> anyhow::Result<T>,
+    ) -> anyhow::Result<T> {
+        let saved = self
+            .saved
+            .as_mut()
+            .context("LSP engine is not initialized")?;
+
+        // Body-only materialization keeps the same saved-source snapshot, but dirty overlays still
+        // need to be rebuilt because they borrow analysis state from the previous saved project.
         self.dirty_overlay.clear();
         mutation(saved)
     }

--- a/crates/lsp/engine/src/engine/project_proxy.rs
+++ b/crates/lsp/engine/src/engine/project_proxy.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Context as _;
-use rg_project::{Project, ProjectSnapshot};
+use rg_project::{DetachedSplitIndexing, Project, ProjectSnapshot};
 
 use crate::{
     dirty_state::DirtyOverlayCache, documents::DirtyDocumentSnapshot, memory::MemoryControl,
@@ -44,6 +44,21 @@ impl ProjectProxy {
 
     pub(super) fn generation(&self) -> u64 {
         self.generation
+    }
+
+    /// Clone saved analysis into a generation-paired deferred-finish handle.
+    ///
+    /// The proxy keeps raw `Project` ownership private. Background split-indexing only needs a
+    /// detached finish capability, and the paired generation lets the worker reject results that
+    /// were produced from an older saved-source snapshot.
+    pub(super) fn detach_saved_split_indexing(
+        &self,
+    ) -> anyhow::Result<(u64, DetachedSplitIndexing)> {
+        let saved = self
+            .saved
+            .as_ref()
+            .context("LSP engine is not initialized")?;
+        Ok((self.generation, saved.detach_split_indexing()))
     }
 
     pub(super) fn mutate_saved<T>(

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -16,7 +16,7 @@ use rg_ir_model::TargetRef;
 use rg_lsp_proto::{
     AnalysisConfig, CargoMetadataTarget as ProtoCargoMetadataTarget, CompletionClientCapabilities,
     IndexingPerformancePreference as ProtoIndexingPerformancePreference,
-    PackageResidencyPolicy as ProtoPackageResidencyPolicy,
+    PackageResidencyPolicy as ProtoPackageResidencyPolicy, ServiceNotification,
     SysrootDiscovery as ProtoSysrootDiscovery,
 };
 use rg_parse::TextSpan;
@@ -43,6 +43,7 @@ use crate::{
         completion, formatting as formatting_proto, hover, inlay_hint, navigation, position,
         references, rename, symbols,
     },
+    service::ServiceNotificationsSink,
 };
 
 #[derive(Debug)]
@@ -50,6 +51,7 @@ pub(super) struct EngineWorker {
     sender: Sender<QueuedEngineCommand>,
     project: ProjectProxy,
     dirty_state: DirtyState,
+    notifications: ServiceNotificationsSink,
     memory_control: Arc<dyn MemoryControl>,
     memory_hooks: Arc<dyn ProjectMemoryHooks>,
 }
@@ -94,12 +96,14 @@ impl EngineWorker {
         sender: Sender<QueuedEngineCommand>,
         memory_control: Arc<dyn MemoryControl>,
         dirty_state: DirtyState,
+        notifications: ServiceNotificationsSink,
     ) -> Self {
         let memory_hooks = Arc::new(ProjectMemoryReporter::new(Arc::clone(&memory_control)));
         Self {
             sender,
             project: ProjectProxy::new(Arc::clone(&memory_control)),
             dirty_state,
+            notifications,
             memory_control,
             memory_hooks,
         }
@@ -366,6 +370,8 @@ impl EngineWorker {
                     let applied =
                         EarlyStart::apply_initial_finish(&mut self.project, generation, result);
                     if applied {
+                        self.notifications
+                            .send(ServiceNotification::DeferredIndexingFinished);
                         if let Ok(snapshot) = self.project.saved_snapshot() {
                             Self::log_project_snapshot(
                                 snapshot,
@@ -1500,7 +1506,17 @@ mod tests {
     use tokio::sync::oneshot;
 
     use super::*;
-    use crate::documents::{DirtyDocumentSnapshotState, DocumentStore};
+    use crate::{
+        documents::{DirtyDocumentSnapshotState, DocumentStore},
+        service::ServiceNotificationPublisher,
+    };
+
+    #[derive(Debug)]
+    struct NoopNotifications;
+
+    impl ServiceNotificationPublisher for NoopNotifications {
+        fn send(&self, _notification: ServiceNotification) {}
+    }
 
     #[test]
     fn stale_dirty_query_responds_without_running_analysis() {
@@ -1518,7 +1534,9 @@ mod tests {
         };
 
         let (sender, _receiver) = std::sync::mpsc::channel();
-        let mut worker = EngineWorker::new(sender, Arc::new(()), DirtyState::default());
+        let notifications = ServiceNotificationsSink::from_publisher(NoopNotifications);
+        let mut worker =
+            EngineWorker::new(sender, Arc::new(()), DirtyState::default(), notifications);
         let (respond_to, response) = oneshot::channel();
         let context = QueryContext::document("hover", Duration::ZERO, Some(&snapshot));
 

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -367,9 +367,9 @@ impl EngineWorker {
                         generation,
                         "engine command started: deferred_indexing_finished"
                     );
-                    let applied =
+                    let current_generation_finished =
                         EarlyStart::apply_initial_finish(&mut self.project, generation, result);
-                    if applied {
+                    if current_generation_finished {
                         self.notifications
                             .send(ServiceNotification::DeferredIndexingFinished);
                         if let Ok(snapshot) = self.project.saved_snapshot() {

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -34,7 +34,7 @@ use crate::{
     engine::{
         QueuedEngineCommand,
         command::{EngineCommand, EngineResponse},
-        early_start::{EarlyStart, ReferenceSearchPlan},
+        early_start::{DeferredIndexingFinish, EarlyStart, ReferenceSearchPlan},
         project_proxy::ProjectProxy,
     },
     memory::{MemoryControl, MemoryReporter, ProjectMemoryReporter},
@@ -50,6 +50,8 @@ use crate::{
 pub(super) struct EngineWorker {
     sender: Sender<QueuedEngineCommand>,
     project: ProjectProxy,
+    deferred_indexing_finish: DeferredIndexingFinish,
+    workspace_root: Option<PathBuf>,
     dirty_state: DirtyState,
     notifications: ServiceNotificationsSink,
     memory_control: Arc<dyn MemoryControl>,
@@ -102,6 +104,8 @@ impl EngineWorker {
         Self {
             sender,
             project: ProjectProxy::new(Arc::clone(&memory_control)),
+            deferred_indexing_finish: DeferredIndexingFinish::new(),
+            workspace_root: None,
             dirty_state,
             notifications,
             memory_control,
@@ -367,16 +371,13 @@ impl EngineWorker {
                         generation,
                         "engine command started: deferred_indexing_finished"
                     );
-                    let current_generation_finished =
-                        EarlyStart::apply_initial_finish(&mut self.project, generation, result);
+                    let current_generation_finished = self
+                        .deferred_indexing_finish
+                        .finish_returned(&self.sender, &mut self.project, generation, result);
                     if current_generation_finished {
-                        self.notifications
-                            .send(ServiceNotification::DeferredIndexingFinished);
+                        self.send_deferred_indexing_finished();
                         if let Ok(snapshot) = self.project.saved_snapshot() {
-                            Self::log_project_snapshot(
-                                snapshot,
-                                "initial deferred indexing finish",
-                            );
+                            Self::log_project_snapshot(snapshot, "deferred indexing finish");
                         }
                     }
                 }
@@ -496,14 +497,17 @@ impl EngineWorker {
             .memory_hooks(Arc::clone(&self.memory_hooks))
             .build()
             .context("while attempting to build LSP analysis project")?;
-        let generation = self.project.replace_saved(project.clone());
+        self.workspace_root = Some(workspace_root.clone());
+        let detached = project.detach_split_indexing();
+        let generation = self.project.replace_saved(project);
         Self::log_project_snapshot(self.project.saved_snapshot()?, "initial early-start index");
         tracing::info!(
             workspace_root = %workspace_root.display(),
             elapsed_ms = started.elapsed().as_millis(),
             "workspace early-start indexing finished"
         );
-        EarlyStart::spawn_initial_finish(&self.sender, generation, project);
+        self.deferred_indexing_finish
+            .start_initial(&self.sender, generation, detached);
 
         Ok(())
     }
@@ -512,7 +516,7 @@ impl EngineWorker {
         let started = Instant::now();
 
         tracing::info!("manual workspace reindex started");
-        self.project.mutate_saved(|project| {
+        self.mutate_saved_and_schedule_deferred_finish(|project| {
             project
                 .reindex_workspace()
                 .context("while attempting to manually reindex workspace")
@@ -536,7 +540,7 @@ impl EngineWorker {
         tracing::info!(path_count = paths.len(), "processing project path changes");
 
         for path in paths {
-            let summary = self.project.mutate_saved(|project| {
+            let summary = self.mutate_saved_and_schedule_deferred_finish(|project| {
                 project
                     .apply_change(SavedFileChange::new(&path))
                     .context("while attempting to apply project path change")
@@ -563,6 +567,28 @@ impl EngineWorker {
         }
 
         Ok(())
+    }
+
+    fn mutate_saved_and_schedule_deferred_finish<T>(
+        &mut self,
+        mutation: impl FnOnce(&mut Project) -> anyhow::Result<T>,
+    ) -> anyhow::Result<T> {
+        let result = self.project.mutate_saved(mutation);
+        if self.project.is_initialized() {
+            self.deferred_indexing_finish
+                .saved_project_changed(&self.sender, &self.project);
+        }
+        result
+    }
+
+    fn send_deferred_indexing_finished(&self) {
+        let Some(root) = &self.workspace_root else {
+            tracing::warn!("deferred indexing finished before workspace root was recorded");
+            return;
+        };
+
+        self.notifications
+            .send(ServiceNotification::DeferredIndexingFinished { root: root.clone() });
     }
 
     fn reference_search_plans_for_position(
@@ -1448,10 +1474,9 @@ impl EngineWorker {
             "analysis query hit invalid package cache; rebuilding cache before next command"
         );
 
-        match self
-            .project
-            .mutate_saved(|project| project.recover_after_cache_load_failure())
-        {
+        match self.mutate_saved_and_schedule_deferred_finish(|project| {
+            project.recover_after_cache_load_failure()
+        }) {
             Ok(()) => {
                 let snapshot = self
                     .project

--- a/crates/lsp/engine/src/engine/worker.rs
+++ b/crates/lsp/engine/src/engine/worker.rs
@@ -1,13 +1,16 @@
 use std::{
     path::{Path, PathBuf},
-    sync::{Arc, mpsc::Receiver},
+    sync::{
+        Arc,
+        mpsc::{Receiver, Sender},
+    },
     time::{Duration, Instant},
 };
 
 use anyhow::Context as _;
 use rg_analysis::{
     Analysis as QueryAnalysis, CompletionQuery, InlayHint as AnalysisInlayHint, ReferenceQuery,
-    ReferenceSearchFile, RenameEdit, RenameTarget,
+    RenameEdit, RenameTarget,
 };
 use rg_ir_model::TargetRef;
 use rg_lsp_proto::{
@@ -19,7 +22,7 @@ use rg_lsp_proto::{
 use rg_parse::TextSpan;
 use rg_project::{
     FileContext, IndexingPerformancePreference, PackageResidencyPolicy, Project,
-    ProjectMemoryHooks, ProjectSnapshot, SavedFileChange,
+    ProjectMemoryHooks, ProjectSnapshot, SavedFileChange, SplitIndexingMode,
 };
 use rg_workspace::{
     CargoMetadataConfig, RustEdition, SysrootSources, WorkspaceLoweringConfig, WorkspaceMetadata,
@@ -31,6 +34,7 @@ use crate::{
     engine::{
         QueuedEngineCommand,
         command::{EngineCommand, EngineResponse},
+        early_start::{EarlyStart, ReferenceSearchPlan},
         project_proxy::ProjectProxy,
     },
     memory::{MemoryControl, MemoryReporter, ProjectMemoryReporter},
@@ -43,6 +47,7 @@ use crate::{
 
 #[derive(Debug)]
 pub(super) struct EngineWorker {
+    sender: Sender<QueuedEngineCommand>,
     project: ProjectProxy,
     dirty_state: DirtyState,
     memory_control: Arc<dyn MemoryControl>,
@@ -54,21 +59,6 @@ struct QueryContext {
     label: &'static str,
     queue_elapsed: Duration,
     dirty_identity: Option<DirtyDocumentIdentity>,
-}
-
-#[derive(Debug)]
-struct ReferenceSearchPlan {
-    targets: Vec<TargetRef>,
-    files: Option<Vec<ReferenceSearchFile>>,
-}
-
-impl ReferenceSearchPlan {
-    fn query(&self, include_declaration: bool) -> ReferenceQuery<'_> {
-        match self.files.as_deref() {
-            Some(files) => ReferenceQuery::find_references_in_files(files, include_declaration),
-            None => ReferenceQuery::find_references(&self.targets, include_declaration),
-        }
-    }
 }
 
 impl QueryContext {
@@ -100,9 +90,14 @@ impl QueryContext {
 }
 
 impl EngineWorker {
-    pub(super) fn new(memory_control: Arc<dyn MemoryControl>, dirty_state: DirtyState) -> Self {
+    pub(super) fn new(
+        sender: Sender<QueuedEngineCommand>,
+        memory_control: Arc<dyn MemoryControl>,
+        dirty_state: DirtyState,
+    ) -> Self {
         let memory_hooks = Arc::new(ProjectMemoryReporter::new(Arc::clone(&memory_control)));
         Self {
+            sender,
             project: ProjectProxy::new(Arc::clone(&memory_control)),
             dirty_state,
             memory_control,
@@ -363,6 +358,22 @@ impl EngineWorker {
                     tracing::trace!("engine command started: reindex_workspace");
                     let _ = respond_to.send(self.reindex_workspace());
                 }
+                EngineCommand::DeferredIndexingFinished { generation, result } => {
+                    tracing::trace!(
+                        generation,
+                        "engine command started: deferred_indexing_finished"
+                    );
+                    let applied =
+                        EarlyStart::apply_initial_finish(&mut self.project, generation, result);
+                    if applied {
+                        if let Ok(snapshot) = self.project.saved_snapshot() {
+                            Self::log_project_snapshot(
+                                snapshot,
+                                "initial deferred indexing finish",
+                            );
+                        }
+                    }
+                }
                 EngineCommand::Shutdown(respond_to) => {
                     tracing::info!("shutting down LSP engine worker");
                     let _ = respond_to.send(Ok(()));
@@ -474,17 +485,19 @@ impl EngineWorker {
             .workspace_lowering_config(workspace_lowering_config)
             .cargo_metadata_config(cargo_metadata_config)
             .indexing_preference(indexing_preference)
+            .split_indexing_mode(SplitIndexingMode::EarlyStart)
             .package_residency_policy(package_residency_policy)
             .memory_hooks(Arc::clone(&self.memory_hooks))
             .build()
             .context("while attempting to build LSP analysis project")?;
-        self.project.replace_saved(project);
-        Self::log_project_snapshot(self.project.saved_snapshot()?, "initial index");
+        let generation = self.project.replace_saved(project.clone());
+        Self::log_project_snapshot(self.project.saved_snapshot()?, "initial early-start index");
         tracing::info!(
             workspace_root = %workspace_root.display(),
             elapsed_ms = started.elapsed().as_millis(),
-            "workspace indexing finished"
+            "workspace early-start indexing finished"
         );
+        EarlyStart::spawn_initial_finish(&self.sender, generation, project);
 
         Ok(())
     }
@@ -546,6 +559,27 @@ impl EngineWorker {
         Ok(())
     }
 
+    fn reference_search_plans_for_position(
+        &mut self,
+        path: &Path,
+        position: ls_types::Position,
+        dirty: Option<&DirtyDocumentSnapshot>,
+    ) -> anyhow::Result<Vec<ReferenceSearchPlan>> {
+        self.project.with_query_snapshot(dirty, |snapshot| {
+            let target_offsets = Self::target_offsets(snapshot, path, position)?;
+            let analysis = snapshot.full_analysis()?;
+            let mut plans = Vec::new();
+
+            for (context, target, offset) in target_offsets {
+                plans.push(Self::reference_search_plan(
+                    snapshot, &analysis, &context, target, offset,
+                )?);
+            }
+
+            Ok(plans)
+        })
+    }
+
     fn goto_definition(
         &mut self,
         path: PathBuf,
@@ -581,6 +615,10 @@ impl EngineWorker {
         dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::Location>> {
         let started = Instant::now();
+        EarlyStart::ensure_path(&mut self.project, "references", &path)?;
+        let search_plans =
+            self.reference_search_plans_for_position(&path, position, dirty.as_ref())?;
+        EarlyStart::ensure_reference_plans(&mut self.project, "references", &search_plans)?;
         // Dirty overlays lower Body IR only for dirty files. Cross-file body references are
         // intentionally best-effort until the buffer is saved and the normal project catches up.
         let locations = self
@@ -632,6 +670,7 @@ impl EngineWorker {
         dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Option<ls_types::PrepareRenameResponse>> {
         let started = Instant::now();
+        EarlyStart::ensure_path(&mut self.project, "prepare_rename", &path)?;
         let response = self
             .project
             .with_query_snapshot(dirty.as_ref(), |snapshot| {
@@ -686,6 +725,10 @@ impl EngineWorker {
         dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Option<ls_types::WorkspaceEdit>> {
         let started = Instant::now();
+        EarlyStart::ensure_path(&mut self.project, "rename", &path)?;
+        let search_plans =
+            self.reference_search_plans_for_position(&path, position, dirty.as_ref())?;
+        EarlyStart::ensure_reference_plans(&mut self.project, "rename", &search_plans)?;
         let edit = self
             .project
             .with_query_snapshot(dirty.as_ref(), |snapshot| {
@@ -754,6 +797,7 @@ impl EngineWorker {
         dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::DocumentHighlight>> {
         let started = Instant::now();
+        EarlyStart::ensure_path(&mut self.project, "document_highlight", &path)?;
         let highlights = self
             .project
             .with_query_snapshot(dirty.as_ref(), |snapshot| {
@@ -814,6 +858,7 @@ impl EngineWorker {
         dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::CompletionItem>> {
         let started = Instant::now();
+        EarlyStart::ensure_path(&mut self.project, "completion", &path)?;
         let source_text = dirty.as_ref().map(DirtyDocumentSnapshot::text);
         let completions = self
             .project
@@ -868,6 +913,7 @@ impl EngineWorker {
         dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Option<ls_types::Hover>> {
         let started = Instant::now();
+        EarlyStart::ensure_path(&mut self.project, "hover", &path)?;
         let hover = self
             .project
             .with_query_snapshot(dirty.as_ref(), |snapshot| {
@@ -987,6 +1033,7 @@ impl EngineWorker {
         dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::InlayHint>> {
         let started = Instant::now();
+        EarlyStart::ensure_path(&mut self.project, "inlay_hint", &path)?;
         let lsp_hints = self
             .project
             .with_query_snapshot(dirty.as_ref(), |snapshot| {
@@ -1069,6 +1116,7 @@ impl EngineWorker {
         dirty: Option<DirtyDocumentSnapshot>,
     ) -> anyhow::Result<Vec<ls_types::Location>> {
         let started = Instant::now();
+        EarlyStart::ensure_path(&mut self.project, query.name(), &path)?;
         let locations = self
             .project
             .with_query_snapshot(dirty.as_ref(), |snapshot| {
@@ -1173,7 +1221,7 @@ impl EngineWorker {
         let labels = analysis.reference_search_labels(target, context.file, offset)?;
         let files = snapshot.reference_search_files_matching_labels(&targets, &labels)?;
 
-        Ok(ReferenceSearchPlan { targets, files })
+        Ok(ReferenceSearchPlan::new(targets, files))
     }
 
     fn file_contexts(
@@ -1469,7 +1517,8 @@ mod tests {
             panic!("dirty full-sync document should expose a snapshot");
         };
 
-        let mut worker = EngineWorker::new(Arc::new(()), DirtyState::default());
+        let (sender, _receiver) = std::sync::mpsc::channel();
+        let mut worker = EngineWorker::new(sender, Arc::new(()), DirtyState::default());
         let (respond_to, response) = oneshot::channel();
         let context = QueryContext::document("hover", Duration::ZERO, Some(&snapshot));
 

--- a/crates/lsp/engine/src/tests/utils.rs
+++ b/crates/lsp/engine/src/tests/utils.rs
@@ -238,7 +238,7 @@ impl LspEngineFixture {
                         rendered_inlay_hint_refresh = true;
                     }
                 }
-                ServiceNotification::DeferredIndexingFinished => {
+                ServiceNotification::DeferredIndexingFinished { .. } => {
                     // Initial deferred indexing finishes on a background thread, so this lifecycle
                     // notification can race with later fixture operations. These snapshots describe
                     // stable editor-facing effects of the operation under test, not the whole event

--- a/crates/lsp/engine/src/tests/utils.rs
+++ b/crates/lsp/engine/src/tests/utils.rs
@@ -180,19 +180,16 @@ impl LspEngineFixture {
         let mut rendered = String::new();
         writeln!(rendered, "notifications").expect("snapshot should be writable");
 
-        let notifications = self.notifications.snapshot();
-        if notifications.is_empty() {
-            writeln!(rendered, "- none").expect("snapshot should be writable");
-        }
-
+        let mut rendered_any_notification = false;
         let mut rendered_inlay_hint_refresh = false;
-        for notification in notifications {
+        for notification in self.notifications.snapshot() {
             match notification {
                 ServiceNotification::PublishDiagnostics {
                     path,
                     diagnostics,
                     version,
                 } => {
+                    rendered_any_notification = true;
                     writeln!(
                         rendered,
                         "- publish diagnostics {} version {:?} count {}",
@@ -207,6 +204,7 @@ impl LspEngineFixture {
                     title,
                     message,
                 } => {
+                    rendered_any_notification = true;
                     writeln!(
                         rendered,
                         "- begin progress {token:?}: {title}{}",
@@ -218,6 +216,7 @@ impl LspEngineFixture {
                     .expect("snapshot should be writable");
                 }
                 ServiceNotification::EndWorkDoneProgress { token, message } => {
+                    rendered_any_notification = true;
                     writeln!(
                         rendered,
                         "- end progress {token:?}{}",
@@ -233,20 +232,27 @@ impl LspEngineFixture {
                     // `didChange` may have a pending debounced refresh while `didSave` sends an
                     // immediate refresh, so duplicate invalidations are intentionally collapsed.
                     if !rendered_inlay_hint_refresh {
+                        rendered_any_notification = true;
                         writeln!(rendered, "- inlay hint refresh")
                             .expect("snapshot should be writable");
                         rendered_inlay_hint_refresh = true;
                     }
                 }
                 ServiceNotification::DeferredIndexingFinished => {
-                    writeln!(rendered, "- deferred indexing finished")
-                        .expect("snapshot should be writable");
+                    // Initial deferred indexing finishes on a background thread, so this lifecycle
+                    // notification can race with later fixture operations. These snapshots describe
+                    // stable editor-facing effects of the operation under test, not the whole event
+                    // stream.
                 }
                 ServiceNotification::LogMessage { level, message } => {
+                    rendered_any_notification = true;
                     writeln!(rendered, "- log {level:?}: {message}")
                         .expect("snapshot should be writable");
                 }
             }
+        }
+        if !rendered_any_notification {
+            writeln!(rendered, "- none").expect("snapshot should be writable");
         }
 
         expect.assert_eq(&rendered);

--- a/crates/lsp/engine/src/tests/utils.rs
+++ b/crates/lsp/engine/src/tests/utils.rs
@@ -238,6 +238,10 @@ impl LspEngineFixture {
                         rendered_inlay_hint_refresh = true;
                     }
                 }
+                ServiceNotification::DeferredIndexingFinished => {
+                    writeln!(rendered, "- deferred indexing finished")
+                        .expect("snapshot should be writable");
+                }
                 ServiceNotification::LogMessage { level, message } => {
                     writeln!(rendered, "- log {level:?}: {message}")
                         .expect("snapshot should be writable");

--- a/crates/lsp/proto/src/notifications.rs
+++ b/crates/lsp/proto/src/notifications.rs
@@ -21,6 +21,7 @@ pub enum ServiceNotification {
         message: Option<String>,
     },
     InlayHintRefresh,
+    DeferredIndexingFinished,
     LogMessage {
         level: ServiceLogLevel,
         message: String,

--- a/crates/lsp/proto/src/notifications.rs
+++ b/crates/lsp/proto/src/notifications.rs
@@ -21,7 +21,9 @@ pub enum ServiceNotification {
         message: Option<String>,
     },
     InlayHintRefresh,
-    DeferredIndexingFinished,
+    DeferredIndexingFinished {
+        root: PathBuf,
+    },
     LogMessage {
         level: ServiceLogLevel,
         message: String,

--- a/crates/lsp/server/src/client_notifications.rs
+++ b/crates/lsp/server/src/client_notifications.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use tower_lsp_server::ls_types::{LSPAny, LSPObject, notification::Notification};
 
@@ -44,9 +44,20 @@ impl ActiveWorkspaceChanged {
 pub(crate) struct DeferredIndexingFinished;
 
 impl Notification for DeferredIndexingFinished {
-    type Params = ();
+    type Params = LSPAny;
 
     const METHOD: &'static str = DEFERRED_INDEXING_FINISHED_METHOD;
+}
+
+impl DeferredIndexingFinished {
+    pub(crate) fn params(root: &Path) -> LSPAny {
+        let mut params = LSPObject::new();
+        params.insert(
+            "root".to_string(),
+            LSPAny::String(root.display().to_string()),
+        );
+        LSPAny::Object(params)
+    }
 }
 
 /// Client-facing snapshot of the workspace currently selected by document routing.
@@ -112,6 +123,14 @@ mod tests {
             let actual = render_params(ActiveWorkspaceChanged::params(&status));
             assert_eq!(actual, expected);
         }
+    }
+
+    #[test]
+    fn deferred_indexing_finished_params_render_root() {
+        let actual = render_params(DeferredIndexingFinished::params(Path::new(
+            "workspace/project_a",
+        )));
+        assert_eq!(actual, "root: workspace/project_a");
     }
 
     fn render_params(params: LSPAny) -> String {

--- a/crates/lsp/server/src/client_notifications.rs
+++ b/crates/lsp/server/src/client_notifications.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use tower_lsp_server::ls_types::{LSPAny, LSPObject, notification::Notification};
 
 const ACTIVE_WORKSPACE_CHANGED_METHOD: &str = "rust-glancer/activeWorkspaceChanged";
+const DEFERRED_INDEXING_FINISHED_METHOD: &str = "rust-glancer/deferredIndexingFinished";
 
 /// Custom notification that lets the VS Code client show which workspace currently owns requests.
 ///
@@ -32,6 +33,20 @@ impl ActiveWorkspaceChanged {
         }
         LSPAny::Object(params)
     }
+}
+
+/// Custom notification used by tooling that wants to distinguish structural readiness from the
+/// background indexing work that completes shortly after it.
+///
+/// Editors can ignore this notification. `compare-lsp` uses it as a precise post-ready barrier so
+/// its measured query latency does not include the first body-sensitive request materializing
+/// deferred indexes on demand.
+pub(crate) struct DeferredIndexingFinished;
+
+impl Notification for DeferredIndexingFinished {
+    type Params = ();
+
+    const METHOD: &'static str = DEFERRED_INDEXING_FINISHED_METHOD;
 }
 
 /// Client-facing snapshot of the workspace currently selected by document routing.

--- a/crates/lsp/server/src/notifications.rs
+++ b/crates/lsp/server/src/notifications.rs
@@ -105,9 +105,11 @@ async fn publish_service_notification(
                 );
             }
         }
-        ServiceNotification::DeferredIndexingFinished => {
+        ServiceNotification::DeferredIndexingFinished { root } => {
             lsp_client
-                .send_notification::<DeferredIndexingFinished>(())
+                .send_notification::<DeferredIndexingFinished>(DeferredIndexingFinished::params(
+                    &root,
+                ))
                 .await;
         }
         ServiceNotification::LogMessage { level, message } => {

--- a/crates/lsp/server/src/notifications.rs
+++ b/crates/lsp/server/src/notifications.rs
@@ -10,6 +10,8 @@ use tower_lsp_server::{
     },
 };
 
+use crate::client_notifications::DeferredIndexingFinished;
+
 /// Publishes service side effects to the real LSP client.
 ///
 /// The worker process deliberately only sends protocol-level notifications. This service is the
@@ -102,6 +104,11 @@ async fn publish_service_notification(
                     "failed to request inlay hint refresh after service notification"
                 );
             }
+        }
+        ServiceNotification::DeferredIndexingFinished => {
+            lsp_client
+                .send_notification::<DeferredIndexingFinished>(())
+                .await;
         }
         ServiceNotification::LogMessage { level, message } => {
             lsp_client.log_message(message_type(level), message).await;

--- a/crates/rust-glancer/src/analyze/data/project.rs
+++ b/crates/rust-glancer/src/analyze/data/project.rs
@@ -44,6 +44,10 @@ impl ProjectReport {
                 target_count: stats.body_ir.target_count,
                 built_target_count: stats.body_ir.built_target_count,
                 skipped_target_count: stats.body_ir.skipped_target_count,
+                complete_target_count: stats.body_ir.complete_target_count,
+                partial_target_count: stats.body_ir.partial_target_count,
+                missing_target_count: stats.body_ir.missing_target_count,
+                skipped_by_policy_target_count: stats.body_ir.skipped_by_policy_target_count,
                 body_count: stats.body_ir.body_count,
                 scope_count: stats.body_ir.scope_count,
                 binding_count: stats.body_ir.binding_count,
@@ -140,6 +144,10 @@ pub(crate) struct BodyIrReport {
     pub(crate) target_count: usize,
     pub(crate) built_target_count: usize,
     pub(crate) skipped_target_count: usize,
+    pub(crate) complete_target_count: usize,
+    pub(crate) partial_target_count: usize,
+    pub(crate) missing_target_count: usize,
+    pub(crate) skipped_by_policy_target_count: usize,
     pub(crate) body_count: usize,
     pub(crate) scope_count: usize,
     pub(crate) binding_count: usize,
@@ -160,6 +168,26 @@ impl BodyIrReport {
                 "skipped_target_count",
                 "skipped targets",
                 self.skipped_target_count,
+            )
+            .count_as(
+                "complete_target_count",
+                "complete targets",
+                self.complete_target_count,
+            )
+            .count_as(
+                "partial_target_count",
+                "partial targets",
+                self.partial_target_count,
+            )
+            .count_as(
+                "missing_target_count",
+                "missing targets",
+                self.missing_target_count,
+            )
+            .count_as(
+                "skipped_by_policy_target_count",
+                "targets skipped by policy",
+                self.skipped_by_policy_target_count,
             )
             .count_as("body_count", "bodies", self.body_count)
             .count_as("scope_count", "scopes", self.scope_count)

--- a/crates/rust-glancer/src/analyze/mod.rs
+++ b/crates/rust-glancer/src/analyze/mod.rs
@@ -4,11 +4,11 @@ use std::{
 };
 
 use anyhow::Context as _;
-use rg_lsp_engine::MemoryControl as _;
+use rg_lsp_engine::MemoryControl;
 use rg_profile::ProfileRun;
 use rg_project::{
     BuildProcessMemory, IndexingPerformancePreference, PackageResidencyPolicy, Project,
-    StartupCacheLoad,
+    SplitIndexingMode, StartupCacheLoad,
 };
 use rg_workspace::{
     CargoMetadataConfig, SysrootSources, WorkspaceLoweringConfig, WorkspaceMetadata,
@@ -79,26 +79,31 @@ pub(crate) fn analyze(
     let builder = Project::builder(workspace)
         .cargo_metadata_config(cargo_metadata_config)
         .indexing_preference(indexing_preference)
+        .split_indexing_mode(SplitIndexingMode::EarlyStart)
         .package_residency_policy(package_residency_policy)
         .startup_cache_load(startup_cache_load)
         .memory_hooks(crate::memory::project_memory_hooks());
     let builder = if include_memory {
-        builder.process_memory_sampler(move || {
-            memory_control
-                .allocator_stats()
-                .map(|stats| BuildProcessMemory {
-                    allocated_bytes: stats.allocated_bytes,
-                    active_bytes: stats.active_bytes,
-                    resident_bytes: stats.resident_bytes,
-                    mapped_bytes: stats.mapped_bytes,
-                })
-        })
+        let build_memory_control = memory_control;
+        builder.process_memory_sampler(move || sample_process_memory(&build_memory_control))
     } else {
         builder
     };
-    let project = builder
+    let mut project = builder
         .build()
         .context("while attempting to build project")?;
+    if include_memory {
+        let finish_memory_control = memory_control;
+        project
+            .split_indexing()
+            .finish_profiled(move || sample_process_memory(&finish_memory_control))
+            .context("while attempting to finish deferred indexing")?;
+    } else {
+        project
+            .split_indexing()
+            .finish()
+            .context("while attempting to finish deferred indexing")?;
+    }
     let profile_snapshot = profile_run.map(ProfileRun::finish);
 
     let analyze_report = data::AnalyzeReport::build(
@@ -110,6 +115,17 @@ pub(crate) fn analyze(
     );
 
     output::write_report(&analyze_report, output_format, include_memory)
+}
+
+fn sample_process_memory(memory_control: &impl MemoryControl) -> Option<BuildProcessMemory> {
+    memory_control
+        .allocator_stats()
+        .map(|stats| BuildProcessMemory {
+            allocated_bytes: stats.allocated_bytes,
+            active_bytes: stats.active_bytes,
+            resident_bytes: stats.resident_bytes,
+            mapped_bytes: stats.mapped_bytes,
+        })
 }
 
 fn measure_time<T>(operation: impl FnOnce() -> anyhow::Result<T>) -> anyhow::Result<(T, Duration)> {

--- a/crates/rust-glancer/src/compare_lsp/execution.rs
+++ b/crates/rust-glancer/src/compare_lsp/execution.rs
@@ -106,6 +106,15 @@ pub(crate) enum RawOutcome {
 }
 
 impl RawOutcome {
+    fn status_label(&self) -> &'static str {
+        match self {
+            Self::Success { .. } => "success",
+            Self::Error { .. } => "error",
+            Self::Timeout => "timeout",
+            Self::TransportFailure { .. } => "transport_failure",
+        }
+    }
+
     fn from_request(_kind: QueryKind, outcome: RequestOutcome) -> Self {
         match outcome {
             RequestOutcome::Success(value) => Self::Success { raw: value },
@@ -121,13 +130,41 @@ pub(crate) async fn run(
     servers: &mut StartedServers,
 ) -> anyhow::Result<ExecutionSummary> {
     let mut results = Vec::new();
+    let total_queries = fixture.query_cases().len();
 
-    for query_case in fixture.query_cases() {
+    for (query_index, query_case) in fixture.query_cases().iter().enumerate() {
         // Convert compact fixture entries into typed LSP request payloads at the last boundary.
         // The stored vector stays easy to audit while serde/ls_types still own protocol shape.
         let request = QueryRequest::from_case(fixture.root(), query_case)?;
+        tracing::info!(
+            query_index = query_index + 1,
+            total_queries,
+            label = query_case.label(),
+            method = request.method,
+            "compare-lsp query started"
+        );
         let rust_glancer = execute_rust_glancer(servers, query_case.kind(), &request).await;
+        tracing::debug!(
+            query_index = query_index + 1,
+            total_queries,
+            label = query_case.label(),
+            method = request.method,
+            server = "rust-glancer",
+            elapsed_ms = rust_glancer.latency().as_millis(),
+            status = rust_glancer.value().status_label(),
+            "compare-lsp query server completed"
+        );
         let rust_analyzer = execute_rust_analyzer(servers, query_case.kind(), &request).await;
+        tracing::debug!(
+            query_index = query_index + 1,
+            total_queries,
+            label = query_case.label(),
+            method = request.method,
+            server = "rust-analyzer",
+            elapsed_ms = rust_analyzer.latency().as_millis(),
+            status = rust_analyzer.value().status_label(),
+            "compare-lsp query server completed"
+        );
 
         results.push(QueryExecution {
             label: query_case.label(),
@@ -136,6 +173,8 @@ pub(crate) async fn run(
             rust_analyzer,
         });
     }
+
+    tracing::info!(total_queries, "compare-lsp query execution completed");
 
     Ok(ExecutionSummary { results })
 }

--- a/crates/rust-glancer/src/compare_lsp/mod.rs
+++ b/crates/rust-glancer/src/compare_lsp/mod.rs
@@ -34,12 +34,14 @@ pub(crate) async fn run(
         servers.rust_glancer_command_label(),
         servers.rust_glancer_readiness().initialize_latency(),
         servers.rust_glancer_readiness().ready_latency(),
+        servers.rust_glancer_readiness().settle_latency(),
     );
     let rust_analyzer = report::ServerReport::capture(
         servers.rust_analyzer_readiness().name(),
         servers.rust_analyzer_command_label(),
         servers.rust_analyzer_readiness().initialize_latency(),
         servers.rust_analyzer_readiness().ready_latency(),
+        servers.rust_analyzer_readiness().settle_latency(),
     );
     let execution = execution::run(&fixture, &mut servers).await;
 

--- a/crates/rust-glancer/src/compare_lsp/report/server.rs
+++ b/crates/rust-glancer/src/compare_lsp/report/server.rs
@@ -14,6 +14,7 @@ pub(crate) struct ServerReport {
     command: String,
     initialize_ms: f64,
     ready_ms: f64,
+    settle_ms: f64,
 }
 
 impl ServerReport {
@@ -22,12 +23,14 @@ impl ServerReport {
         command: &str,
         initialize_latency: Duration,
         ready_latency: Duration,
+        settle_latency: Duration,
     ) -> Self {
         Self {
             name: name.to_string(),
             command: command.to_string(),
             initialize_ms: duration_ms(initialize_latency),
             ready_ms: duration_ms(ready_latency),
+            settle_ms: duration_ms(settle_latency),
         }
     }
 
@@ -51,7 +54,8 @@ impl ServerReport {
             .text_column("server")
             .text_column("command")
             .duration_column_as("initialize_ms", "Initialize")
-            .duration_column_as("ready_ms", "Ready");
+            .duration_column_as("ready_ms", "Ready")
+            .duration_column_as("settle_ms", "Settle");
     }
 
     fn append_row(&self, table: &mut ReportTableBuilder) {
@@ -59,7 +63,8 @@ impl ServerReport {
             row.text("server", &self.name)
                 .text("command", &self.command)
                 .duration_ms("initialize_ms", self.initialize_ms)
-                .duration_ms("ready_ms", self.ready_ms);
+                .duration_ms("ready_ms", self.ready_ms)
+                .duration_ms("settle_ms", self.settle_ms);
         });
     }
 }

--- a/crates/rust-glancer/src/compare_lsp/server/mod.rs
+++ b/crates/rust-glancer/src/compare_lsp/server/mod.rs
@@ -12,6 +12,7 @@ mod uri;
 
 use std::time::Duration;
 
+use anyhow::Context as _;
 use serde_json::Value;
 
 use crate::compare_lsp::{fixture::Fixture, lsp_client::RequestOutcome, query::QueryCase};
@@ -43,6 +44,18 @@ impl StartedServers {
         let rust_analyzer_readiness = rust_analyzer_server
             .initialize_fixture(fixture.root(), &source_paths)
             .await?;
+        let rust_glancer_readiness = rust_glancer_readiness.with_settle_latency(
+            rust_glancer_server
+                .settle_after_readiness()
+                .await
+                .context("Waiting for rust-glancer post-ready settle failed")?,
+        );
+        let rust_analyzer_readiness = rust_analyzer_readiness.with_settle_latency(
+            rust_analyzer_server
+                .settle_after_readiness()
+                .await
+                .context("Waiting for rust-analyzer post-ready settle failed")?,
+        );
 
         Ok(Self {
             rust_glancer_server,
@@ -122,6 +135,7 @@ pub(crate) struct ServerReadiness {
     name: &'static str,
     initialize_latency: Duration,
     ready_latency: Duration,
+    settle_latency: Duration,
 }
 
 impl ServerReadiness {
@@ -134,7 +148,13 @@ impl ServerReadiness {
             name,
             initialize_latency,
             ready_latency,
+            settle_latency: Duration::ZERO,
         }
+    }
+
+    pub(super) fn with_settle_latency(mut self, settle_latency: Duration) -> Self {
+        self.settle_latency = settle_latency;
+        self
     }
 
     pub(crate) fn name(&self) -> &'static str {
@@ -147,6 +167,10 @@ impl ServerReadiness {
 
     pub(crate) fn ready_latency(&self) -> Duration {
         self.ready_latency
+    }
+
+    pub(crate) fn settle_latency(&self) -> Duration {
+        self.settle_latency
     }
 }
 

--- a/crates/rust-glancer/src/compare_lsp/server/process.rs
+++ b/crates/rust-glancer/src/compare_lsp/server/process.rs
@@ -29,9 +29,12 @@ use super::{ServerReadiness, command::ServerKind, stderr::StderrCapture, uri::fi
 
 const INITIALIZE_TIMEOUT: Duration = Duration::from_secs(120);
 const READY_TIMEOUT: Duration = Duration::from_secs(120);
+const SETTLE_TIMEOUT: Duration = Duration::from_secs(120);
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 const PROCESS_EXIT_TIMEOUT: Duration = Duration::from_secs(120);
 const RUST_GLANCER_READY_METHOD: &str = "rust-glancer/activeWorkspaceChanged";
+const RUST_GLANCER_DEFERRED_INDEXING_FINISHED_METHOD: &str =
+    "rust-glancer/deferredIndexingFinished";
 const RUST_ANALYZER_READY_METHOD: &str = "experimental/serverStatus";
 
 /// One live LSP server with the client-side transport needed to drive it.
@@ -43,6 +46,7 @@ pub(super) struct RunningServer {
     client: TowerLspTransport,
     stderr: StderrCapture,
     exited: bool,
+    rust_glancer_deferred_indexing_finished: bool,
 }
 
 impl RunningServer {
@@ -91,6 +95,7 @@ impl RunningServer {
             client,
             stderr,
             exited: false,
+            rust_glancer_deferred_indexing_finished: false,
         })
     }
 
@@ -99,6 +104,12 @@ impl RunningServer {
         fixture_root: &Path,
         source_paths: &[&'static str],
     ) -> anyhow::Result<ServerReadiness> {
+        tracing::info!(
+            server = self.kind.display_name(),
+            root = %fixture_root.display(),
+            opened_files = source_paths.len(),
+            "initializing compare-lsp server"
+        );
         let initialize_params = self.initialize_params(fixture_root)?;
         let started_at = Instant::now();
         let initialize = self
@@ -111,6 +122,11 @@ impl RunningServer {
             .await;
         self.expect_success(request::Initialize::METHOD, initialize)?;
         let initialize_latency = started_at.elapsed();
+        tracing::info!(
+            server = self.kind.display_name(),
+            elapsed_ms = initialize_latency.as_millis(),
+            "compare-lsp initialize completed"
+        );
 
         // After `initialized`, both servers should see the same in-memory document set. This keeps
         // the later query requests about server behavior rather than file-watcher timing.
@@ -130,15 +146,67 @@ impl RunningServer {
         for source_path in source_paths {
             self.open_source_file(fixture_root, source_path).await?;
         }
+        tracing::info!(
+            server = self.kind.display_name(),
+            "waiting for compare-lsp server readiness"
+        );
         let ready_started_at = Instant::now();
         self.wait_until_ready().await?;
         let ready_latency = ready_started_at.elapsed();
+        tracing::info!(
+            server = self.kind.display_name(),
+            elapsed_ms = ready_latency.as_millis(),
+            "compare-lsp server readiness observed"
+        );
 
         Ok(ServerReadiness::new(
             self.kind.display_name(),
             initialize_latency,
             ready_latency,
         ))
+    }
+
+    /// Wait for any background work that should not be charged to measured query latency.
+    ///
+    /// Rust-glancer reports structural readiness before deferred body indexes finish. That is the
+    /// behavior users care about for editor responsiveness, so `ready_ms` stops there. The
+    /// comparison harness then waits for the explicit deferred-indexing notification before firing
+    /// measured body-sensitive queries, and reports that extra wait as `settle_ms`.
+    pub(super) async fn settle_after_readiness(&mut self) -> anyhow::Result<Duration> {
+        match self.kind {
+            ServerKind::RustAnalyzer => {
+                tracing::info!(
+                    server = self.kind.display_name(),
+                    "compare-lsp post-ready settle skipped"
+                );
+                Ok(Duration::ZERO)
+            }
+            ServerKind::RustGlancer => {
+                if self.rust_glancer_deferred_indexing_finished {
+                    tracing::info!(
+                        server = self.kind.display_name(),
+                        "compare-lsp post-ready settle already observed"
+                    );
+                    return Ok(Duration::ZERO);
+                }
+
+                tracing::info!(
+                    server = self.kind.display_name(),
+                    "waiting for compare-lsp post-ready settle"
+                );
+                let started_at = Instant::now();
+                self.wait_until_deferred_indexing_finished()
+                    .await
+                    .context("Waiting for rust-glancer deferred indexing after readiness failed")?;
+                let settle_latency = started_at.elapsed();
+                tracing::info!(
+                    server = self.kind.display_name(),
+                    elapsed_ms = settle_latency.as_millis(),
+                    "compare-lsp post-ready settle observed"
+                );
+                Ok(settle_latency)
+            }
+        }
     }
 
     /// Run the LSP shutdown handshake, then wait until the OS process exits.
@@ -291,6 +359,7 @@ impl RunningServer {
                         self.stderr_note(),
                     )
                 })?;
+                self.observe_deferred_indexing_finished(&notification);
                 match self.readiness_notification(&notification) {
                     ReadinessNotification::Ready => return Ok(()),
                     ReadinessNotification::Failed(message) => anyhow::bail!(
@@ -304,10 +373,56 @@ impl RunningServer {
         .await
         .with_context(|| {
             format!(
-                "Waiting for {} readiness notification timed out",
-                self.kind.display_name()
+                "Waiting for {} readiness notification timed out{}",
+                self.kind.display_name(),
+                self.stderr_note(),
             )
         })?
+    }
+
+    async fn wait_until_deferred_indexing_finished(&mut self) -> anyhow::Result<()> {
+        tokio::time::timeout(SETTLE_TIMEOUT, async {
+            loop {
+                let notification = self.client.next_notification().await.with_context(|| {
+                    format!(
+                        "Waiting for {} deferred indexing notification failed{}",
+                        self.kind.display_name(),
+                        self.stderr_note(),
+                    )
+                })?;
+                if self.observe_deferred_indexing_finished(&notification) {
+                    return Ok(());
+                }
+                if let ReadinessNotification::Failed(message) =
+                    self.readiness_notification(&notification)
+                {
+                    anyhow::bail!(
+                        "{} reported readiness failure while deferred indexing was settling: {message}",
+                        self.kind.display_name(),
+                    );
+                }
+            }
+        })
+        .await
+        .with_context(|| {
+            format!(
+                "Waiting for {} deferred indexing notification timed out{}",
+                self.kind.display_name(),
+                self.stderr_note(),
+            )
+        })?
+    }
+
+    fn observe_deferred_indexing_finished(&mut self, notification: &ServerNotification) -> bool {
+        if !matches!(self.kind, ServerKind::RustGlancer) {
+            return false;
+        }
+        if notification.method() != RUST_GLANCER_DEFERRED_INDEXING_FINISHED_METHOD {
+            return false;
+        }
+
+        self.rust_glancer_deferred_indexing_finished = true;
+        true
     }
 
     fn readiness_notification(&self, notification: &ServerNotification) -> ReadinessNotification {

--- a/crates/rust-glancer/src/logging.rs
+++ b/crates/rust-glancer/src/logging.rs
@@ -17,9 +17,12 @@ use tracing::{
 use tracing_subscriber::{EnvFilter, Layer, layer::Context, prelude::*, registry::LookupSpan};
 
 const ENGINE_ID_ENV: &str = "RUST_GLANCER_ENGINE_ID";
+const LOG_FILTER_ENV: &str = "RUST_GLANCER_LOG";
 const LOG_SCHEMA: &str = "rust-glancer-log/v1";
 const RUST_GLANCER_SPAN_FIELD_PREFIX: &str = "rg.";
-const DEFAULT_LOG_FILTER: &str = "info,tarpc=warn,chalk_engine=warn,chalk_solve=warn,chalk_ir=warn";
+const DEFAULT_LOG_FILTER: &str = "info";
+const DEPENDENCY_LOG_GUARDS: &str =
+    "tarpc=warn,chalk_engine=warn,chalk_solve=warn,chalk_ir=warn,log=warn";
 
 /// Identifies which process emitted an LSP-mode log line.
 ///
@@ -44,8 +47,7 @@ impl LogComponent {
 
 /// Initializes the logger in a human-readable form.
 pub(crate) fn init_plain_tracing() {
-    let filter = EnvFilter::try_from_env("RUST_GLANCER_LOG")
-        .unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_FILTER));
+    let filter = rust_glancer_log_filter();
     tracing_subscriber::fmt()
         .with_env_filter(filter)
         .with_writer(std::io::stderr)
@@ -56,8 +58,7 @@ pub(crate) fn init_plain_tracing() {
 
 /// Initializes the structured JSON logger consumed by the editor extension.
 pub(crate) fn init_lsp_tracing(component: LogComponent) {
-    let filter = EnvFilter::try_from_env("RUST_GLANCER_LOG")
-        .unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_FILTER));
+    let filter = rust_glancer_log_filter();
     tracing_subscriber::registry()
         .with(filter)
         .with(JsonLogLayer {
@@ -66,6 +67,29 @@ pub(crate) fn init_lsp_tracing(component: LogComponent) {
         })
         .try_init()
         .ok();
+}
+
+fn rust_glancer_log_filter() -> EnvFilter {
+    let env_filter = std::env::var(LOG_FILTER_ENV).ok();
+    rust_glancer_log_filter_from(env_filter.as_deref())
+}
+
+fn rust_glancer_log_filter_from(env_filter: Option<&str>) -> EnvFilter {
+    let directives = log_filter_directives(env_filter);
+    EnvFilter::try_new(&directives).unwrap_or_else(|_| EnvFilter::new(log_filter_directives(None)))
+}
+
+fn log_filter_directives(env_filter: Option<&str>) -> String {
+    let user_filter = env_filter
+        .map(str::trim)
+        .filter(|filter| !filter.is_empty())
+        .unwrap_or(DEFAULT_LOG_FILTER);
+
+    // A blanket `debug`/`trace` is useful when debugging rust-glancer itself, but it also turns on
+    // solver and `log`-crate records from dependencies. Chalk and Ena both log inside very hot
+    // paths, often formatting large clauses/types, so keep those targets guarded unless the user
+    // names them explicitly later in the filter string.
+    format!("{DEPENDENCY_LOG_GUARDS},{user_filter}")
 }
 
 /// Emits one editor-facing JSON log record for each tracing event.
@@ -292,6 +316,84 @@ mod tests {
                 .expect("test log buffer should not be poisoned")
                 .push(serde_json::to_string(log).expect("test log should serialize"));
         }
+    }
+
+    fn capture_lsp_logs(filter: EnvFilter, emit_logs: impl FnOnce()) -> Vec<Value> {
+        let lines = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry()
+            .with(filter)
+            .with(JsonLogLayer {
+                component: LogComponent::Server,
+                writer: BufferLogWriter {
+                    lines: Arc::clone(&lines),
+                },
+            });
+
+        tracing::subscriber::with_default(subscriber, emit_logs);
+
+        lines
+            .lock()
+            .expect("test log buffer should not be poisoned")
+            .iter()
+            .map(|line| serde_json::from_str(line).expect("structured log line should be JSON"))
+            .collect()
+    }
+
+    fn log_messages(records: &[Value]) -> Vec<&str> {
+        records
+            .iter()
+            .map(|record| {
+                record["message"]
+                    .as_str()
+                    .expect("structured log should contain a string message")
+            })
+            .collect()
+    }
+
+    #[test]
+    fn default_log_filter_keeps_info_but_guards_noisy_dependencies() {
+        let records = capture_lsp_logs(rust_glancer_log_filter_from(None), || {
+            tracing::info!(target: "rg_lsp_engine", "rust-glancer info should pass");
+            tracing::debug!(target: "rg_lsp_engine", "rust-glancer debug should not pass");
+            tracing::info!(target: "chalk_engine", "chalk info should not pass");
+            tracing::debug!(target: "log", "ena debug should not pass");
+        });
+
+        assert_eq!(log_messages(&records), ["rust-glancer info should pass"]);
+    }
+
+    #[test]
+    fn blanket_log_filter_keeps_noisy_dependencies_guarded() {
+        let records = capture_lsp_logs(rust_glancer_log_filter_from(Some("debug")), || {
+            tracing::debug!(target: "rg_lsp_engine", "rust-glancer debug should pass");
+            tracing::info!(target: "chalk_engine", "chalk info should not pass");
+            tracing::debug!(target: "chalk_solve", "chalk debug should not pass");
+            tracing::debug!(target: "log", "ena debug should not pass");
+        });
+
+        assert_eq!(log_messages(&records), ["rust-glancer debug should pass"]);
+    }
+
+    #[test]
+    fn explicit_dependency_filter_can_override_dependency_guard() {
+        let records = capture_lsp_logs(
+            rust_glancer_log_filter_from(Some("debug,chalk_engine=info,log=debug")),
+            || {
+                tracing::debug!(target: "rg_lsp_engine", "rust-glancer debug should pass");
+                tracing::info!(target: "chalk_engine", "explicit chalk info should pass");
+                tracing::debug!(target: "chalk_engine", "chalk debug should not pass");
+                tracing::debug!(target: "log", "explicit bridged log debug should pass");
+            },
+        );
+
+        assert_eq!(
+            log_messages(&records),
+            [
+                "rust-glancer debug should pass",
+                "explicit chalk info should pass",
+                "explicit bridged log debug should pass"
+            ]
+        );
     }
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -1,10 +1,5 @@
 [advisories]
 version = 2
-ignore = [
-  # Gungraun uses bincode internally to pass benchmark definitions to its
-  # runner. The dependency is limited to the Linux CI benchmark harness.
-  "RUSTSEC-2025-0141",
-]
 unmaintained = "workspace"
 
 [licenses]

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -20,4 +20,5 @@ export const SERVER_COMMANDS = {
 
 export const SERVER_NOTIFICATIONS = {
   activeWorkspaceChanged: "rust-glancer/activeWorkspaceChanged",
+  deferredIndexingFinished: "rust-glancer/deferredIndexingFinished",
 } as const;

--- a/editors/code/src/language-client/language-client-session.ts
+++ b/editors/code/src/language-client/language-client-session.ts
@@ -123,8 +123,12 @@ export class LanguageClientSession implements vscode.Disposable {
           this.isActiveRustDocumentDirty(),
         );
       }),
-      client.onNotification(SERVER_NOTIFICATIONS.deferredIndexingFinished, () => {
-        this.clientStatus.deferredIndexingFinished(this.isActiveRustDocumentDirty());
+      client.onNotification(SERVER_NOTIFICATIONS.deferredIndexingFinished, (params) => {
+        const status = params as DeferredIndexingFinishedParams;
+        this.clientStatus.deferredIndexingFinished(
+          status.root,
+          this.isActiveRustDocumentDirty(),
+        );
       }),
     );
 
@@ -226,4 +230,8 @@ interface ActiveWorkspaceChangedParams {
   readonly root: string;
   readonly state: ActiveWorkspaceState;
   readonly message?: string;
+}
+
+interface DeferredIndexingFinishedParams {
+  readonly root: string;
 }

--- a/editors/code/src/language-client/language-client-session.ts
+++ b/editors/code/src/language-client/language-client-session.ts
@@ -125,10 +125,7 @@ export class LanguageClientSession implements vscode.Disposable {
       }),
       client.onNotification(SERVER_NOTIFICATIONS.deferredIndexingFinished, (params) => {
         const status = params as DeferredIndexingFinishedParams;
-        this.clientStatus.deferredIndexingFinished(
-          status.root,
-          this.isActiveRustDocumentDirty(),
-        );
+        this.clientStatus.deferredIndexingFinished(status.root, this.isActiveRustDocumentDirty());
       }),
     );
 

--- a/editors/code/src/language-client/language-client-session.ts
+++ b/editors/code/src/language-client/language-client-session.ts
@@ -123,6 +123,9 @@ export class LanguageClientSession implements vscode.Disposable {
           this.isActiveRustDocumentDirty(),
         );
       }),
+      client.onNotification(SERVER_NOTIFICATIONS.deferredIndexingFinished, () => {
+        this.clientStatus.deferredIndexingFinished(this.isActiveRustDocumentDirty());
+      }),
     );
 
     try {

--- a/editors/code/src/status/client-status.ts
+++ b/editors/code/src/status/client-status.ts
@@ -32,6 +32,7 @@ export interface ClientStatusView {
   starting(details: StatusDetails): void;
   indexing(details?: StatusDetails): void;
   ready(details?: StatusDetails): void;
+  readyWithDeferredIndexing(details?: StatusDetails): void;
   stale(details?: StatusDetails): void;
   diagnosticsRunning(command: string | undefined, details?: StatusDetails): void;
   diagnosticsFailed(details?: StatusDetails): void;
@@ -54,6 +55,8 @@ export class ClientStatus {
   private failureReason: string | undefined;
   private activeWorkspaceState: ActiveWorkspaceState | undefined;
   private activeWorkspaceFailureReason: string | undefined;
+  private deferredIndexingRunning = false;
+  private deferredIndexingFinishedSeen = false;
   private currentStatus: StatusSnapshot = {
     state: "created",
     text: "",
@@ -80,6 +83,8 @@ export class ClientStatus {
     this.failureReason = undefined;
     this.activeWorkspaceState = undefined;
     this.activeWorkspaceFailureReason = undefined;
+    this.deferredIndexingRunning = false;
+    this.deferredIndexingFinishedSeen = false;
     this.details = details;
     this.show("starting", "$(sync~spin) Rust Glancer: starting", () => this.view.starting(details));
   }
@@ -91,7 +96,7 @@ export class ClientStatus {
     const nextDetails =
       activeWorkspaceRoot === undefined ? details : { ...details, activeWorkspaceRoot };
     this.details = nextDetails;
-    this.show("ready", "$(check) Rust Glancer: ready", () => this.view.ready(nextDetails));
+    this.refresh(false);
   }
 
   public indexing(): void {
@@ -116,6 +121,15 @@ export class ClientStatus {
 
     this.activeWorkspaceState = state;
     this.activeWorkspaceFailureReason = state === "failed" ? message : undefined;
+    if (state === "indexing") {
+      this.deferredIndexingRunning = false;
+      this.deferredIndexingFinishedSeen = false;
+    } else if (state === "failed") {
+      this.deferredIndexingRunning = false;
+      this.deferredIndexingFinishedSeen = false;
+    } else {
+      this.deferredIndexingRunning = state === "ready" && !this.deferredIndexingFinishedSeen;
+    }
     this.details = {
       ...this.details,
       activeWorkspaceRoot: root,
@@ -123,10 +137,22 @@ export class ClientStatus {
     this.refresh(isActiveRustDocumentDirty);
   }
 
+  public deferredIndexingFinished(isActiveRustDocumentDirty: boolean): void {
+    if (this.details === undefined) {
+      return;
+    }
+
+    this.deferredIndexingRunning = false;
+    this.deferredIndexingFinishedSeen = true;
+    this.refresh(isActiveRustDocumentDirty);
+  }
+
   public stopped(reason: string, details: StatusDetails | undefined = this.details): void {
     this.running = false;
     this.resetDiagnostics();
     this.failureReason = undefined;
+    this.deferredIndexingRunning = false;
+    this.deferredIndexingFinishedSeen = false;
     this.details = details;
     this.show("stopped", "$(circle-slash) Rust Glancer: stopped", () =>
       this.view.stopped(reason, details ?? {}),
@@ -137,6 +163,8 @@ export class ClientStatus {
     this.running = false;
     this.resetDiagnostics();
     this.failureReason = reason;
+    this.deferredIndexingRunning = false;
+    this.deferredIndexingFinishedSeen = false;
     this.details = details;
     this.show("failed", "$(error) Rust Glancer: failed", () =>
       this.view.failed(reason, details ?? {}),
@@ -182,6 +210,12 @@ export class ClientStatus {
     } else if (this.diagnosticsFailed) {
       this.show("diagnostics-failed", "$(error) Rust Glancer: cargo check failed", () =>
         this.view.diagnosticsFailed(this.details),
+      );
+    } else if (this.deferredIndexingRunning) {
+      // The engine is already usable here; the marker only says that background indexing has not
+      // sent its finish notification yet.
+      this.show("ready", "~ Rust Glancer: ready", () =>
+        this.view.readyWithDeferredIndexing(this.details),
       );
     } else {
       this.show("ready", "$(check) Rust Glancer: ready", () => this.view.ready(this.details));

--- a/editors/code/src/status/client-status.ts
+++ b/editors/code/src/status/client-status.ts
@@ -55,8 +55,7 @@ export class ClientStatus {
   private failureReason: string | undefined;
   private activeWorkspaceState: ActiveWorkspaceState | undefined;
   private activeWorkspaceFailureReason: string | undefined;
-  private deferredIndexingRunning = false;
-  private deferredIndexingFinishedSeen = false;
+  private readonly rootsWithFinishedDeferredIndexing = new Set<string>();
   private currentStatus: StatusSnapshot = {
     state: "created",
     text: "",
@@ -83,8 +82,7 @@ export class ClientStatus {
     this.failureReason = undefined;
     this.activeWorkspaceState = undefined;
     this.activeWorkspaceFailureReason = undefined;
-    this.deferredIndexingRunning = false;
-    this.deferredIndexingFinishedSeen = false;
+    this.rootsWithFinishedDeferredIndexing.clear();
     this.details = details;
     this.show("starting", "$(sync~spin) Rust Glancer: starting", () => this.view.starting(details));
   }
@@ -104,6 +102,9 @@ export class ClientStatus {
       return;
     }
 
+    if (this.details.activeWorkspaceRoot !== undefined) {
+      this.rootsWithFinishedDeferredIndexing.delete(this.details.activeWorkspaceRoot);
+    }
     this.show("indexing", "$(sync~spin) Rust Glancer: indexing", () =>
       this.view.indexing(this.details),
     );
@@ -121,14 +122,8 @@ export class ClientStatus {
 
     this.activeWorkspaceState = state;
     this.activeWorkspaceFailureReason = state === "failed" ? message : undefined;
-    if (state === "indexing") {
-      this.deferredIndexingRunning = false;
-      this.deferredIndexingFinishedSeen = false;
-    } else if (state === "failed") {
-      this.deferredIndexingRunning = false;
-      this.deferredIndexingFinishedSeen = false;
-    } else {
-      this.deferredIndexingRunning = state === "ready" && !this.deferredIndexingFinishedSeen;
+    if (state !== "ready") {
+      this.rootsWithFinishedDeferredIndexing.delete(root);
     }
     this.details = {
       ...this.details,
@@ -137,13 +132,12 @@ export class ClientStatus {
     this.refresh(isActiveRustDocumentDirty);
   }
 
-  public deferredIndexingFinished(isActiveRustDocumentDirty: boolean): void {
+  public deferredIndexingFinished(root: string, isActiveRustDocumentDirty: boolean): void {
     if (this.details === undefined) {
       return;
     }
 
-    this.deferredIndexingRunning = false;
-    this.deferredIndexingFinishedSeen = true;
+    this.rootsWithFinishedDeferredIndexing.add(root);
     this.refresh(isActiveRustDocumentDirty);
   }
 
@@ -151,8 +145,7 @@ export class ClientStatus {
     this.running = false;
     this.resetDiagnostics();
     this.failureReason = undefined;
-    this.deferredIndexingRunning = false;
-    this.deferredIndexingFinishedSeen = false;
+    this.rootsWithFinishedDeferredIndexing.clear();
     this.details = details;
     this.show("stopped", "$(circle-slash) Rust Glancer: stopped", () =>
       this.view.stopped(reason, details ?? {}),
@@ -163,8 +156,7 @@ export class ClientStatus {
     this.running = false;
     this.resetDiagnostics();
     this.failureReason = reason;
-    this.deferredIndexingRunning = false;
-    this.deferredIndexingFinishedSeen = false;
+    this.rootsWithFinishedDeferredIndexing.clear();
     this.details = details;
     this.show("failed", "$(error) Rust Glancer: failed", () =>
       this.view.failed(reason, details ?? {}),
@@ -211,7 +203,7 @@ export class ClientStatus {
       this.show("diagnostics-failed", "$(error) Rust Glancer: cargo check failed", () =>
         this.view.diagnosticsFailed(this.details),
       );
-    } else if (this.deferredIndexingRunning) {
+    } else if (this.deferredIndexingIsRunningForActiveWorkspace()) {
       // The engine is already usable here; the marker only says that background indexing has not
       // sent its finish notification yet.
       this.show("ready", "~ Rust Glancer: ready", () =>
@@ -220,6 +212,15 @@ export class ClientStatus {
     } else {
       this.show("ready", "$(check) Rust Glancer: ready", () => this.view.ready(this.details));
     }
+  }
+
+  private deferredIndexingIsRunningForActiveWorkspace(): boolean {
+    const root = this.details?.activeWorkspaceRoot;
+    return (
+      this.activeWorkspaceState === "ready" &&
+      root !== undefined &&
+      !this.rootsWithFinishedDeferredIndexing.has(root)
+    );
   }
 
   public handleWorkDoneProgress(

--- a/editors/code/src/status/status-view.ts
+++ b/editors/code/src/status/status-view.ts
@@ -50,6 +50,10 @@ export class StatusView implements vscode.Disposable {
     this.showState("ready", "$(check) Rust Glancer: ready", "Ready", details);
   }
 
+  public readyWithDeferredIndexing(details: StatusDetails = this.details): void {
+    this.showState("ready", "~ Rust Glancer: ready", "Ready, finishing deferred indexing", details);
+  }
+
   public stale(details: StatusDetails = this.details): void {
     this.showState(
       "stale",

--- a/editors/code/test/extension.test.ts
+++ b/editors/code/test/extension.test.ts
@@ -56,15 +56,16 @@ suite("Rust Glancer extension", () => {
 
     const simpleReady = await waitForClientState((state) => readySession(state) !== undefined);
     assert.ok(simpleReady.session);
-    await waitForOutput(
-      /workspace indexing finished.*simple_crate|simple_crate.*workspace indexing finished/,
-    );
+    await waitForOutput(workspaceIndexingFinishedPattern("simple_crate"));
     const activeSimple = await waitForClientState(
       (state) =>
         activeWorkspaceName(readySession(state)) === "simple_crate" &&
         state.status.text.includes("[simple_crate]"),
     );
-    assert.equal(activeSimple.status.text, "$(check) Rust Glancer: ready [simple_crate]");
+    assert.match(
+      activeSimple.status.text,
+      /^(?:~|\$\(check\)) Rust Glancer: ready \[simple_crate\]$/,
+    );
 
     const commands = await vscode.commands.getCommands(true);
     assert.ok(commands.includes(EXTENSION_COMMANDS.restartServer));
@@ -82,9 +83,7 @@ suite("Rust Glancer extension", () => {
     await vscode.window.showTextDocument(document);
 
     await waitForClientState((state) => readySession(state) !== undefined);
-    await waitForOutput(
-      /workspace indexing finished.*moderate_crate|moderate_crate.*workspace indexing finished/,
-    );
+    await waitForOutput(workspaceIndexingFinishedPattern("moderate_crate"));
     const multiRootReady = await waitForClientState(
       (state) =>
         activeWorkspaceName(readySession(state)) === "moderate_crate" &&
@@ -163,6 +162,12 @@ async function waitForOutput(pattern: RegExp): Promise<string> {
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function workspaceIndexingFinishedPattern(workspaceName: string): RegExp {
+  return new RegExp(
+    `workspace (?:early-start )?indexing finished.*${workspaceName}|${workspaceName}.*workspace (?:early-start )?indexing finished`,
+  );
 }
 
 function ensureWorkspaceFolder(uri: vscode.Uri, name: string): void {

--- a/editors/code/unit/client-status.test.ts
+++ b/editors/code/unit/client-status.test.ts
@@ -62,22 +62,34 @@ describe("client status state precedence", () => {
     assert.equal(status.snapshot().failureReason, undefined);
   });
 
+  it("shows a ready status while deferred indexing finishes", () => {
+    const status = clientStatus();
+    status.starting(DETAILS);
+    status.ready(DETAILS);
+
+    status.activeWorkspace("/workspace/project_c", "ready", undefined, false);
+    assert.equal(render(status), "ready: ~ Rust Glancer: ready [project_c]");
+
+    status.deferredIndexingFinished(false);
+    assert.equal(render(status), "ready: $(check) Rust Glancer: ready [project_c]");
+  });
+
   it("preserves active workspace label across language-client ready transitions", () => {
     const status = clientStatus();
     status.starting(DETAILS);
     status.ready(DETAILS);
-    status.activeWorkspace("/workspace/project_c", "ready", undefined, false);
+    status.activeWorkspace("/workspace/project_d", "ready", undefined, false);
 
     status.ready({
       ...DETAILS,
       workspaceRoot: "/workspace/restarted-window",
     });
 
-    assert.equal(render(status), "ready: $(check) Rust Glancer: ready [project_c]");
+    assert.equal(render(status), "ready: ~ Rust Glancer: ready [project_d]");
     assert.deepEqual(status.snapshot().details, {
       ...DETAILS,
       workspaceRoot: "/workspace/restarted-window",
-      activeWorkspaceRoot: "/workspace/project_c",
+      activeWorkspaceRoot: "/workspace/project_d",
     });
   });
 });
@@ -96,6 +108,7 @@ function noopView(): ClientStatusView {
     starting() {},
     indexing() {},
     ready() {},
+    readyWithDeferredIndexing() {},
     stale() {},
     diagnosticsRunning() {},
     diagnosticsFailed() {},

--- a/editors/code/unit/client-status.test.ts
+++ b/editors/code/unit/client-status.test.ts
@@ -70,8 +70,32 @@ describe("client status state precedence", () => {
     status.activeWorkspace("/workspace/project_c", "ready", undefined, false);
     assert.equal(render(status), "ready: ~ Rust Glancer: ready [project_c]");
 
-    status.deferredIndexingFinished(false);
+    status.deferredIndexingFinished("/workspace/project_c", false);
     assert.equal(render(status), "ready: $(check) Rust Glancer: ready [project_c]");
+  });
+
+  it("keeps deferred indexing state scoped to workspace roots", () => {
+    const status = clientStatus();
+    status.starting(DETAILS);
+    status.ready(DETAILS);
+
+    status.activeWorkspace("/workspace/project_a", "ready", undefined, false);
+    status.deferredIndexingFinished("/workspace/project_b", false);
+    assert.equal(render(status), "ready: ~ Rust Glancer: ready [project_a]");
+
+    status.activeWorkspace("/workspace/project_b", "ready", undefined, false);
+    assert.equal(render(status), "ready: $(check) Rust Glancer: ready [project_b]");
+  });
+
+  it("does not show deferred indexing when finish arrives before ready", () => {
+    const status = clientStatus();
+    status.starting(DETAILS);
+    status.ready(DETAILS);
+
+    status.deferredIndexingFinished("/workspace/project_e", false);
+    status.activeWorkspace("/workspace/project_e", "ready", undefined, false);
+
+    assert.equal(render(status), "ready: $(check) Rust Glancer: ready [project_e]");
   });
 
   it("preserves active workspace label across language-client ready transitions", () => {


### PR DESCRIPTION
Introduces split indexing: we do the minimum work before calling engine indexing done, and then in background finish lowering bodies.

This makes initial indexing much faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coverage-aware body IR materialization with split-indexing modes (full vs early-start) and on-demand query materialization.
  * Added deferred indexing completion notifications and UI state to show “ready” while background work finishes.
  * Added enhanced analysis/reporting for body IR coverage breakdowns and readiness timing.

* **Bug Fixes**
  * Improved memory profile baseline comparisons, including correct checkpoint row alignment and more consistent missing data handling.

* **Other**
  * Updated LSP comparison to include “settle” latency, and adjusted cache policy matching to use target coverage completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->