### PR TITLE
feat: Make all-offloadable the default strategy

### DIFF
--- a/crates/lsp/engine/src/engine/project/tests/mod.rs
+++ b/crates/lsp/engine/src/engine/project/tests/mod.rs
@@ -377,6 +377,9 @@ fn deferred_lifecycle_tracks_published_generations_not_foreground_activity() {
         .initialize(
             fixture.path(""),
             ProjectConfiguration::from(AnalysisConfig {
+                // The final assertions observe resident Body IR, so keep this lifecycle fixture
+                // independent from the client-facing residency default.
+                package_residency_policy: PackageResidencyPolicy::AllResident,
                 sysroot_discovery: SysrootDiscovery::Disabled,
                 ..AnalysisConfig::default()
             }),

--- a/crates/lsp/proto/src/config/analysis.rs
+++ b/crates/lsp/proto/src/config/analysis.rs
@@ -34,9 +34,9 @@ impl AnalysisConfig {
 impl Default for AnalysisConfig {
     fn default() -> Self {
         Self {
-            // LSP keeps the packages users are most likely to edit resident, but otherwise favors
-            // fast initial indexing unless a client explicitly asks to lower peak memory.
-            package_residency_policy: PackageResidencyPolicy::WorkspaceAndPathDepsResident,
+            // Once indexing finishes, prefer low idle memory and load package data back from the
+            // durable cache when a query needs it.
+            package_residency_policy: PackageResidencyPolicy::default(),
             cargo_metadata_config: CargoMetadataConfig::default(),
             sysroot_discovery: SysrootDiscovery::default(),
             indexing_preference: IndexingPerformancePreference::default(),
@@ -53,13 +53,14 @@ mod tests {
     };
 
     #[test]
-    fn defaults_to_workspace_and_path_dependency_residency() {
+    fn defaults_to_all_offloadable_residency() {
         let config = AnalysisConfig::from_initialization_options(None)
             .expect("default analysis config should parse");
 
+        assert_eq!(config, AnalysisConfig::default());
         assert_eq!(
             config.package_residency_policy,
-            PackageResidencyPolicy::WorkspaceAndPathDepsResident,
+            PackageResidencyPolicy::AllOffloadable,
         );
         assert_eq!(config.cargo_metadata_config, CargoMetadataConfig::default(),);
         assert_eq!(config.sysroot_discovery, SysrootDiscovery::Auto);

--- a/crates/lsp/proto/src/config/analysis.rs
+++ b/crates/lsp/proto/src/config/analysis.rs
@@ -7,7 +7,7 @@ use super::{
 };
 
 /// Analysis configuration sent by the LSP client during initialization.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct AnalysisConfig {
     pub package_residency_policy: PackageResidencyPolicy,
     pub cargo_metadata_config: CargoMetadataConfig,
@@ -28,20 +28,6 @@ impl AnalysisConfig {
             )?,
             cfg: AnalysisCfgConfig::from_initialization_options(options)?,
         })
-    }
-}
-
-impl Default for AnalysisConfig {
-    fn default() -> Self {
-        Self {
-            // Once indexing finishes, prefer low idle memory and load package data back from the
-            // durable cache when a query needs it.
-            package_residency_policy: PackageResidencyPolicy::default(),
-            cargo_metadata_config: CargoMetadataConfig::default(),
-            sysroot_discovery: SysrootDiscovery::default(),
-            indexing_preference: IndexingPerformancePreference::default(),
-            cfg: AnalysisCfgConfig::default(),
-        }
     }
 }
 

--- a/crates/lsp/proto/src/config/cache.rs
+++ b/crates/lsp/proto/src/config/cache.rs
@@ -4,12 +4,13 @@ use serde::{Deserialize, Serialize};
 use super::section;
 
 /// Protocol-level cache residency policy requested by an LSP client.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
 pub enum PackageResidencyPolicy {
     AllResident,
     WorkspaceResident,
     WorkspaceAndPathDepsResident,
     WorkspacePathAndDirectDepsResident,
+    #[default]
     AllOffloadable,
 }
 
@@ -19,7 +20,7 @@ impl PackageResidencyPolicy {
             .and_then(|cache| cache.get("packageResidency"))
             .and_then(LSPAny::as_str)
             .and_then(Self::from_config_name)
-            .unwrap_or(Self::WorkspaceAndPathDepsResident)
+            .unwrap_or_default()
     }
 
     /// Stable kebab-case name accepted in LSP initialization options.

--- a/crates/lsp/proto/src/config/cache.rs
+++ b/crates/lsp/proto/src/config/cache.rs
@@ -10,6 +10,7 @@ pub enum PackageResidencyPolicy {
     WorkspaceResident,
     WorkspaceAndPathDepsResident,
     WorkspacePathAndDirectDepsResident,
+    /// Prefer low idle memory and load package data back from the durable cache on demand.
     #[default]
     AllOffloadable,
 }

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -75,7 +75,7 @@ just client lint
   "rust-glancer.cargo.target": null,
   "rust-glancer.cfg.test": true,
   "rust-glancer.cfg.atoms": [],
-  "rust-glancer.cache.packageResidency": "workspace-and-path-deps",
+  "rust-glancer.cache.packageResidency": "all-offloadable",
   "rust-glancer.trace.server": "off",
   "rust-glancer.diagnostics.onStartup": false,
   "rust-glancer.diagnostics.onSave": false,

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -205,7 +205,7 @@
             "Keep workspace packages, local path dependencies, and direct dependencies in memory.",
             "Offload every package that can be written to the package cache."
           ],
-          "default": "workspace-and-path-deps",
+          "default": "all-offloadable",
           "description": "Controls which package analysis artifacts remain resident after indexing. Restart the rust-glancer server after changing this setting."
         },
         "rust-glancer.diagnostics.onStartup": {

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -110,7 +110,7 @@ export namespace ExtensionConfig {
           config,
           "cache.packageResidency",
           PACKAGE_RESIDENCY_VALUES,
-          "workspace-and-path-deps",
+          "all-offloadable",
         ),
       },
       diagnostics: {


### PR DESCRIPTION
Fixes #133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `all-offloadable` package residency option to the VS Code extension.
  * Updated configuration validation and defaults to support the new option.

* **Documentation**
  * Updated the documented cache residency setting to use `all-offloadable`.

* **Bug Fixes**
  * Improved default package caching behavior to favor lower idle memory usage while loading data from durable cache as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->