### PR TITLE
feat: Better support for records in expressions/patterns

### DIFF
--- a/crates/engine/analysis/src/tests/references.rs
+++ b/crates/engine/analysis/src/tests/references.rs
@@ -69,6 +69,102 @@ pub fn use_it() {
 }
 
 #[test]
+fn finds_record_constructor_references() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_record_constructor_references"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub mod model {
+    pub struct Qual$qualified_decl$ified<T> {
+        pub value: T,
+    }
+}
+
+pub struct Us$user_decl$er<T> {
+    pub value: T,
+}
+
+pub enum Action<T> {
+    Start { value: T },
+}
+
+use crate::User as Account;
+
+pub fn make(value: u8) {
+    struct Local {
+        value: u8,
+    }
+
+    let _plain = User { value };
+    let _generic = User::<u8> { value };
+    let _qualified = model::Qual$qualified_use$ified::<u8> { value };
+    let _alias = Acc$alias_use$ount { value };
+    let _variant = Action::Sta$variant_use$rt { value };
+    let _local = Loc$local_use$al { value };
+}
+"#,
+        &[
+            AnalysisQuery::references(
+                "record struct references from declaration",
+                "user_decl",
+                ReferenceQuery::all(),
+            ),
+            AnalysisQuery::references(
+                "record struct references from imported constructor alias without declaration",
+                "alias_use",
+                ReferenceQuery::all().without_declaration(),
+            ),
+            AnalysisQuery::references(
+                "qualified generic record constructor references",
+                "qualified_use",
+                ReferenceQuery::all(),
+            ),
+            AnalysisQuery::references(
+                "record variant constructor references",
+                "variant_use",
+                ReferenceQuery::all(),
+            ),
+            AnalysisQuery::references(
+                "body-local record constructor references",
+                "local_use",
+                ReferenceQuery::all(),
+            ),
+        ],
+        expect![[r#"
+            record struct references from declaration
+            - `User` @ src/lib.rs:7:12-7:16
+            - `User` @ src/lib.rs:15:12-15:16
+            - `User` @ src/lib.rs:22:18-22:22
+            - `User` @ src/lib.rs:23:20-23:24
+            - `Account` @ src/lib.rs:25:18-25:25
+
+            record struct references from imported constructor alias without declaration
+            - `User` @ src/lib.rs:15:12-15:16
+            - `User` @ src/lib.rs:22:18-22:22
+            - `User` @ src/lib.rs:23:20-23:24
+            - `Account` @ src/lib.rs:25:18-25:25
+
+            qualified generic record constructor references
+            - `Qualified` @ src/lib.rs:2:16-2:25
+            - `Qualified` @ src/lib.rs:24:29-24:38
+
+            record variant constructor references
+            - `Start` @ src/lib.rs:12:5-12:10
+            - `Start` @ src/lib.rs:26:28-26:33
+
+            body-local record constructor references
+            - `Local` @ src/lib.rs:18:12-18:17
+            - `Local` @ src/lib.rs:27:18-27:23
+        "#]],
+    );
+}
+
+#[test]
 fn finds_item_initializer_references() {
     check_analysis_queries(
         r#"

--- a/crates/engine/analysis/src/tests/rename.rs
+++ b/crates/engine/analysis/src/tests/rename.rs
@@ -331,6 +331,86 @@ pub fn use_fn(account: Account) -> api::User {
 }
 
 #[test]
+fn rename_reuses_record_constructor_occurrences() {
+    check_analysis_queries(
+        r#"
+//- /Cargo.toml
+[package]
+name = "analysis_rename_record_constructors"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub mod model {
+    pub struct Qual$qualified_decl$ified<T> {
+        pub value: T,
+    }
+}
+
+pub struct Us$user_decl$er<T> {
+    pub value: T,
+}
+
+pub enum Action<T> {
+    Start { value: T },
+}
+
+use crate::User as Account;
+
+pub fn make(value: u8) {
+    struct Loc$local_decl$al {
+        value: u8,
+    }
+
+    let _plain = User { value };
+    let _generic = User::<u8> { value };
+    let _qualified = model::Qual$qualified_use$ified::<u8> { value };
+    let _alias = Acc$alias_use$ount { value };
+    let _variant = Action::Sta$variant_use$rt { value };
+    let _local = Loc$local_use$al { value };
+}
+"#,
+        &[
+            AnalysisQuery::rename(
+                "rename record struct from declaration",
+                "user_decl",
+                "Entity",
+            ),
+            AnalysisQuery::rename(
+                "rename qualified generic record from use",
+                "qualified_use",
+                "Scoped",
+            ),
+            AnalysisQuery::rename("rename record variant from use", "variant_use", "Begin"),
+            AnalysisQuery::rename("rename body-local record from use", "local_use", "Nested"),
+        ],
+        expect![[r#"
+            rename record struct from declaration
+            - target `User` @ src/lib.rs:7:12-7:16
+            - `User` -> `Entity` @ src/lib.rs:7:12-7:16
+            - `User` -> `Entity` @ src/lib.rs:15:12-15:16
+            - `User` -> `Entity` @ src/lib.rs:22:18-22:22
+            - `User` -> `Entity` @ src/lib.rs:23:20-23:24
+
+            rename qualified generic record from use
+            - target `Qualified` @ src/lib.rs:24:29-24:38
+            - `Qualified` -> `Scoped` @ src/lib.rs:2:16-2:25
+            - `Qualified` -> `Scoped` @ src/lib.rs:24:29-24:38
+
+            rename record variant from use
+            - target `Start` @ src/lib.rs:26:28-26:33
+            - `Start` -> `Begin` @ src/lib.rs:12:5-12:10
+            - `Start` -> `Begin` @ src/lib.rs:26:28-26:33
+
+            rename body-local record from use
+            - target `Local` @ src/lib.rs:27:18-27:23
+            - `Local` -> `Nested` @ src/lib.rs:18:12-18:17
+            - `Local` -> `Nested` @ src/lib.rs:27:18-27:23
+        "#]],
+    );
+}
+
+#[test]
 fn rename_respects_nested_body_shadowing() {
     check_analysis_queries(
         r#"

--- a/crates/engine/body-ir/src/ir/body/path.rs
+++ b/crates/engine/body-ir/src/ir/body/path.rs
@@ -195,6 +195,11 @@ impl BodyPath {
         self.segments.get(segment_idx).map(BodyPathSegment::span)
     }
 
+    /// Returns the source span of the final segment, such as `User` in `model::User`.
+    pub fn last_segment_span(&self) -> Option<Span> {
+        self.segments.last().map(BodyPathSegment::span)
+    }
+
     pub fn segment_count(&self) -> usize {
         self.segments.len()
     }

--- a/crates/engine/ir-view/src/source/occurrence.rs
+++ b/crates/engine/ir-view/src/source/occurrence.rs
@@ -247,8 +247,8 @@ impl<'a, 'db> SourceOccurrenceView<'a, 'db> {
     ///
     /// Expression-backed occurrences intentionally expose only `ExprRef`, so callers that need a
     /// cheap source label can ask the view to inspect the lowered expression. For example, this
-    /// returns `user` for a path expression, `push` for `items.push(value)`, and `name` for
-    /// `user.name`; literals and operators return `None`.
+    /// returns `user` for a path expression, `push` for `items.push(value)`, `name` for
+    /// `user.name`, and `User` for `model::User { name }`; literals and operators return `None`.
     pub fn expr_source_label(&self, expr: ExprRef) -> anyhow::Result<Option<String>> {
         let Some(body_data) = self.db.body_ir.body(expr.body_ir())? else {
             return Ok(None);
@@ -265,6 +265,11 @@ impl<'a, 'db> SourceOccurrenceView<'a, 'db> {
             rg_body_ir::ExprKind::Field { field, .. } => {
                 field.as_ref().map(|field| field.declaration_label())
             }
+            rg_body_ir::ExprKind::Record {
+                path: Some(path), ..
+            } => path
+                .as_def_map_path()
+                .and_then(|path| path.last_segment_label()),
             _ => None,
         };
         Ok(label)

--- a/crates/engine/ir-view/src/source/occurrence.rs
+++ b/crates/engine/ir-view/src/source/occurrence.rs
@@ -258,18 +258,16 @@ impl<'a, 'db> SourceOccurrenceView<'a, 'db> {
         };
 
         let label = match &expr_data.kind {
-            rg_body_ir::ExprKind::Path { path } => path
+            rg_body_ir::ExprKind::Path { path }
+            | rg_body_ir::ExprKind::Record {
+                path: Some(path), ..
+            } => path
                 .as_def_map_path()
                 .and_then(|path| path.last_segment_label()),
             rg_body_ir::ExprKind::MethodCall { method_name, .. } => Some(method_name.to_string()),
             rg_body_ir::ExprKind::Field { field, .. } => {
                 field.as_ref().map(|field| field.declaration_label())
             }
-            rg_body_ir::ExprKind::Record {
-                path: Some(path), ..
-            } => path
-                .as_def_map_path()
-                .and_then(|path| path.last_segment_label()),
             _ => None,
         };
         Ok(label)

--- a/crates/engine/ir-view/src/source/scan/body/cursor.rs
+++ b/crates/engine/ir-view/src/source/scan/body/cursor.rs
@@ -140,7 +140,7 @@ impl<'txn, 'db> BodyCursorScanner<'txn, 'db> {
                 // Record expression keys can resolve to fields, while the record expression itself
                 // is still an ordinary expression candidate.
                 self.consider_record_expr_fields(body_ref, expr, &mut best);
-                let span = Self::member_reference_span(expr)
+                let span = Self::expression_reference_span(expr)
                     .filter(|span| span.touches(self.offset))
                     .unwrap_or(expr.source.span);
                 best.consider(
@@ -447,13 +447,19 @@ impl<'txn, 'db> BodyCursorScanner<'txn, 'db> {
         });
     }
 
-    fn member_reference_span(expr: &ExprData) -> Option<Span> {
+    fn expression_reference_span(expr: &ExprData) -> Option<Span> {
         match &expr.kind {
             ExprKind::Path { path } if path.segment_count() == 1 => path.segment_span(0),
             ExprKind::MethodCall {
                 method_name_span, ..
             } => *method_name_span,
             ExprKind::Field { field_span, .. } => *field_span,
+            ExprKind::Record {
+                path: Some(path), ..
+            } => path
+                .segment_count()
+                .checked_sub(1)
+                .and_then(|idx| path.segment_span(idx)),
             _ => None,
         }
     }

--- a/crates/engine/ir-view/src/source/scan/body/cursor.rs
+++ b/crates/engine/ir-view/src/source/scan/body/cursor.rs
@@ -456,10 +456,7 @@ impl<'txn, 'db> BodyCursorScanner<'txn, 'db> {
             ExprKind::Field { field_span, .. } => *field_span,
             ExprKind::Record {
                 path: Some(path), ..
-            } => path
-                .segment_count()
-                .checked_sub(1)
-                .and_then(|idx| path.segment_span(idx)),
+            } => path.last_segment_span(),
             _ => None,
         }
     }

--- a/crates/engine/ir-view/src/source/scan/body/mod.rs
+++ b/crates/engine/ir-view/src/source/scan/body/mod.rs
@@ -174,7 +174,8 @@ pub(crate) enum BodySourceCandidate {
         span: Span,
         surface: BindingSurface,
     },
-    /// Lowered expression node with its useful source spelling, e.g. `id` in `user.id()`.
+    /// Lowered expression node with its useful source spelling, e.g. `id` in `user.id` or `User`
+    /// in `model::User { id }`.
     Expr {
         body: BodyRef,
         expr: ExprId,

--- a/crates/engine/ir-view/src/source/scan/body/path_completion_site.rs
+++ b/crates/engine/ir-view/src/source/scan/body/path_completion_site.rs
@@ -190,7 +190,7 @@ impl<'txn, 'db> PathCompletionSiteScanner<'txn, 'db> {
         path: &BodyPath,
         namespace: ValueOrTypeNamespace,
     ) -> Option<PathCompletionSite> {
-        let last_segment_span = path.segment_span(path.segment_count().checked_sub(1)?)?;
+        let last_segment_span = path.last_segment_span()?;
         let span = self.empty_member_span(path.source_span, last_segment_span)?;
         let qualifier = path.prefix_through(path.segment_count() - 1)?;
 

--- a/crates/engine/ir-view/src/source/scan/body/paths.rs
+++ b/crates/engine/ir-view/src/source/scan/body/paths.rs
@@ -111,8 +111,10 @@ impl<'a> TypePathSourceScanner<'a> {
 ///         ^^^^^ value-path candidate
 /// ```
 ///
-/// Record constructors are the exception: the final segment in `model::User { ... }` is also a
-/// type-path candidate.
+/// Record syntax splits the same-looking path differently. In `model::User { id }`, the lowered
+/// record expression owns `User` and this scanner keeps only the `model` qualifier. In
+/// `let model::User { id } = user`, there is no record expression, so the pattern path owns both
+/// segments.
 pub(super) struct BodyPathSourceScanner<'a> {
     body_ref: BodyRef,
     body: BodyView<'a>,
@@ -120,6 +122,26 @@ pub(super) struct BodyPathSourceScanner<'a> {
     offset: Option<u32>,
     include_single_segment: bool,
     candidates: &'a mut Vec<BodySourceCandidate>,
+}
+
+/// Selects which source fact owns the final segment after qualifiers have been emitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BodyPathFinalSegment {
+    /// A lowered expression owns the final name.
+    ///
+    /// For `model::User { id }`, the record expression represents `User`; this scanner emits only
+    /// the `model` qualifier.
+    Expression,
+    /// The final name belongs to a type path.
+    ///
+    /// For `let model::User { id } = user`, this scanner emits both `model` and `User` because a
+    /// record pattern has no expression id.
+    TypePath,
+    /// The final name belongs to a value path.
+    ///
+    /// For `let action = Action::Start`, `Action` is a type-path qualifier and `Start` is the value
+    /// reference selected by this case.
+    ValuePath,
 }
 
 impl<'a> BodyPathSourceScanner<'a> {
@@ -171,7 +193,7 @@ impl<'a> BodyPathSourceScanner<'a> {
                     path,
                     expr_data.source.file_id,
                     false,
-                    false,
+                    BodyPathFinalSegment::ValuePath,
                 ),
                 ExprKind::Record {
                     path: Some(path), ..
@@ -180,7 +202,7 @@ impl<'a> BodyPathSourceScanner<'a> {
                     path,
                     expr_data.source.file_id,
                     false,
-                    true,
+                    BodyPathFinalSegment::Expression,
                 ),
                 _ => {}
             }
@@ -210,7 +232,7 @@ impl<'a> BodyPathSourceScanner<'a> {
                 path,
                 data.source.file_id,
                 self.include_single_segment,
-                true,
+                BodyPathFinalSegment::TypePath,
             );
         } else if let Some(path) = data.kind.value_path() {
             self.scan_body_path(
@@ -218,7 +240,7 @@ impl<'a> BodyPathSourceScanner<'a> {
                 path,
                 data.source.file_id,
                 self.include_single_segment,
-                false,
+                BodyPathFinalSegment::ValuePath,
             );
         }
     }
@@ -230,7 +252,7 @@ impl<'a> BodyPathSourceScanner<'a> {
         path: &BodyPath,
         file_id: FileId,
         include_single_segment: bool,
-        final_segment_is_type: bool,
+        final_segment: BodyPathFinalSegment,
     ) {
         // Expression paths already have an expression candidate for single-segment names. Segment
         // candidates are only needed for qualified expressions or for pattern paths, which do not
@@ -248,9 +270,11 @@ impl<'a> BodyPathSourceScanner<'a> {
                 let Some(path) = path.prefix_through(idx) else {
                     continue;
                 };
-                if idx + 1 < segment_count || final_segment_is_type {
+                if idx + 1 < segment_count
+                    || matches!(final_segment, BodyPathFinalSegment::TypePath)
+                {
                     // In `Action::Start`, the prefix is still a user-visible type/module path.
-                    // Record constructors also resolve their final segment as a type path.
+                    // Record patterns also resolve their final constructor segment as a type path.
                     self.candidates.push(BodySourceCandidate::TypePath {
                         body: self.body_ref,
                         scope,
@@ -260,14 +284,16 @@ impl<'a> BodyPathSourceScanner<'a> {
                     });
                     continue;
                 }
-                self.candidates.push(BodySourceCandidate::ValueReference {
-                    body: self.body_ref,
-                    scope,
-                    file_id,
-                    span,
-                    source: ValueReferenceSource::Path(path),
-                    surface: ValueReferenceSurface::Plain,
-                });
+                if matches!(final_segment, BodyPathFinalSegment::ValuePath) {
+                    self.candidates.push(BodySourceCandidate::ValueReference {
+                        body: self.body_ref,
+                        scope,
+                        file_id,
+                        span,
+                        source: ValueReferenceSource::Path(path),
+                        surface: ValueReferenceSurface::Plain,
+                    });
+                }
             }
         }
     }

--- a/crates/engine/ir-view/src/source/scan/body/source.rs
+++ b/crates/engine/ir-view/src/source/scan/body/source.rs
@@ -57,7 +57,7 @@ impl<'txn, 'db> BodySourceScanner<'txn, 'db> {
 
             self.push_declaration_candidates(body_ref, body, body_local_items, &mut candidates);
             self.push_macro_call_candidates(body, &mut candidates);
-            self.push_member_reference_candidates(body_ref, body, &mut candidates);
+            self.push_expression_reference_candidates(body_ref, body, &mut candidates);
             self.push_record_field_key_candidates(body_ref, body, &mut candidates);
 
             TypePathSourceScanner::in_crate(body_ref, body, self.file_id, &mut candidates).scan();
@@ -246,8 +246,11 @@ impl<'txn, 'db> BodySourceScanner<'txn, 'db> {
         }
     }
 
-    /// Adds reference-like candidates whose useful span is narrower than the full expression.
-    fn push_member_reference_candidates(
+    /// Adds the editable name span for expressions that resolve as one semantic reference.
+    ///
+    /// This selects `value` in a path, `push` in `items.push(value)`, `name` in `user.name`, and
+    /// `User` in `model::User { name }` instead of indexing each expression's full source range.
+    fn push_expression_reference_candidates(
         &self,
         body_ref: BodyRef,
         body: BodyView<'_>,
@@ -277,6 +280,13 @@ impl<'txn, 'db> BodySourceScanner<'txn, 'db> {
                     ..
                 } => *span,
                 ExprKind::MethodCall { .. } | ExprKind::Field { .. } => expr.source.span,
+                ExprKind::Record {
+                    path: Some(path), ..
+                } => path
+                    .segment_count()
+                    .checked_sub(1)
+                    .and_then(|idx| path.segment_span(idx))
+                    .unwrap_or(expr.source.span),
                 _ => continue,
             };
 

--- a/crates/engine/ir-view/src/source/scan/body/source.rs
+++ b/crates/engine/ir-view/src/source/scan/body/source.rs
@@ -282,11 +282,7 @@ impl<'txn, 'db> BodySourceScanner<'txn, 'db> {
                 ExprKind::MethodCall { .. } | ExprKind::Field { .. } => expr.source.span,
                 ExprKind::Record {
                     path: Some(path), ..
-                } => path
-                    .segment_count()
-                    .checked_sub(1)
-                    .and_then(|idx| path.segment_span(idx))
-                    .unwrap_or(expr.source.span),
+                } => path.last_segment_span().unwrap_or(expr.source.span),
                 _ => continue,
             };
 

--- a/crates/lsp/engine/src/tests/rename_flow.rs
+++ b/crates/lsp/engine/src/tests/rename_flow.rs
@@ -3,7 +3,7 @@
 use expect_test::expect;
 use test_fixture::testonly::MarkedText;
 
-use super::utils::LspEngineFixture;
+use super::utils::{LspEngineFixture, LspQuery};
 
 #[tokio::test]
 async fn rename_returns_workspace_edit_for_clean_document() {
@@ -35,6 +35,74 @@ async fn rename_returns_workspace_edit_for_clean_document() {
                 - /src/lib.rs
                   - 0:11-0:15 -> Account
                   - 3:15-3:19 -> Account
+            "#]],
+        )
+        .await;
+
+    fixture.shutdown().await;
+}
+
+#[tokio::test]
+async fn record_constructor_references_and_rename_flow_through_enabled_test_module() {
+    let fixture = LspEngineFixture::initialized_with_cfg_test(
+        r#"
+        //- /Cargo.toml
+        [package]
+        name = "lsp_record_constructor_test_cfg"
+        version = "0.1.0"
+        edition = "2024"
+
+        //- /src/lib.rs
+        #[cfg(test)]
+        mod tests {
+            pub struct Us$declaration$er<T> {
+                pub value: T,
+            }
+
+            pub fn make(value: u8) {
+                let _user = Us$constructor$er::<u8> { value };
+            }
+        }
+        "#,
+        true,
+    )
+    .await;
+
+    fixture
+        .check(
+            &[
+                LspQuery::references(
+                    "record constructor references from declaration",
+                    "declaration",
+                    true,
+                ),
+                LspQuery::references(
+                    "record constructor references from use without declaration",
+                    "constructor",
+                    false,
+                ),
+            ],
+            expect![[r#"
+                record constructor references from declaration
+                - /src/lib.rs:2:15-2:19
+                - /src/lib.rs:7:20-7:24
+
+                record constructor references from use without declaration
+                - /src/lib.rs:7:20-7:24
+            "#]],
+        )
+        .await;
+
+    fixture
+        .check_rename(
+            "rename record constructor from enabled test module",
+            "constructor",
+            "Account",
+            expect![[r#"
+                rename record constructor from enabled test module
+                - /src/lib.rs
+                  - 2:15-2:19 -> Account
+                  - 7:20-7:24 -> Account
             "#]],
         )
         .await;

--- a/crates/lsp/engine/src/tests/utils.rs
+++ b/crates/lsp/engine/src/tests/utils.rs
@@ -32,9 +32,13 @@ pub(super) struct LspEngineFixture {
 
 impl LspEngineFixture {
     pub(super) async fn initialized(fixture: &str) -> Self {
-        let mut fixture = Self::new(fixture);
-        fixture.initialize().await;
-        fixture
+        Self::initialized_with_engine_config(fixture, Self::engine_config()).await
+    }
+
+    pub(super) async fn initialized_with_cfg_test(fixture: &str, enabled: bool) -> Self {
+        let mut config = Self::engine_config();
+        config.analysis.cfg.test = enabled;
+        Self::initialized_with_engine_config(fixture, config).await
     }
 
     fn new(fixture: &str) -> Self {
@@ -53,16 +57,15 @@ impl LspEngineFixture {
         }
     }
 
-    async fn initialize(&mut self) {
-        self.service
+    async fn initialized_with_engine_config(fixture: &str, config: EngineConfig) -> Self {
+        let fixture = Self::new(fixture);
+        fixture
+            .service
             .clone()
-            .initialize(
-                context::current(),
-                self.fixture.path(""),
-                Self::engine_config(),
-            )
+            .initialize(context::current(), fixture.fixture.path(""), config)
             .await
             .expect("fixture LSP engine should initialize");
+        fixture
     }
 
     fn engine_config() -> EngineConfig {
@@ -372,6 +375,23 @@ impl LspEngineFixture {
                     .goto_definition(context::current(), path, position)
                     .await
                     .expect("goto definition query should succeed");
+
+                writeln!(rendered, "{title}").expect("snapshot should be writable");
+                self.render_locations(rendered, &locations);
+            }
+            LspQuery::References {
+                title,
+                marker,
+                include_declaration,
+            } => {
+                let path = self.marker_path(markers, marker);
+                let position = self.marker_position(markers, marker);
+                let locations = self
+                    .service
+                    .clone()
+                    .references(context::current(), path, position, *include_declaration)
+                    .await
+                    .expect("references query should succeed");
 
                 writeln!(rendered, "{title}").expect("snapshot should be writable");
                 self.render_locations(rendered, &locations);
@@ -708,6 +728,11 @@ pub(super) enum LspQuery {
         title: &'static str,
         marker: &'static str,
     },
+    References {
+        title: &'static str,
+        marker: &'static str,
+        include_declaration: bool,
+    },
     Hover {
         title: &'static str,
         marker: &'static str,
@@ -725,6 +750,18 @@ pub(super) enum LspQuery {
 impl LspQuery {
     pub(super) fn goto_definition(title: &'static str, marker: &'static str) -> Self {
         Self::GotoDefinition { title, marker }
+    }
+
+    pub(super) fn references(
+        title: &'static str,
+        marker: &'static str,
+        include_declaration: bool,
+    ) -> Self {
+        Self::References {
+            title,
+            marker,
+            include_declaration,
+        }
     }
 
     pub(super) fn hover(title: &'static str, marker: &'static str) -> Self {

--- a/crates/rust-glancer/src/compare_lsp/comparison/location.rs
+++ b/crates/rust-glancer/src/compare_lsp/comparison/location.rs
@@ -89,12 +89,10 @@ impl LocationComparison {
         &self.matched
     }
 
-    #[cfg(test)]
     pub(super) fn missing(&self) -> &[NormalizedLocation] {
         &self.missing
     }
 
-    #[cfg(test)]
     pub(super) fn extra(&self) -> &[NormalizedLocation] {
         &self.extra
     }

--- a/crates/rust-glancer/src/compare_lsp/comparison/metrics.rs
+++ b/crates/rust-glancer/src/compare_lsp/comparison/metrics.rs
@@ -7,6 +7,10 @@ pub(crate) struct SetComparisonMetrics {
     pub(crate) rust_glancer_count: usize,
     pub(crate) rust_analyzer_count: usize,
     pub(crate) matched_count: usize,
+    /// Non-identical matches where rust-glancer was proven to retain at least the reference detail.
+    ///
+    /// This is a subset of `matched_count`, not an additional result count.
+    pub(crate) compatible_count: usize,
     pub(crate) missing_count: usize,
     pub(crate) extra_count: usize,
     pub(crate) match_score_percent: f64,
@@ -22,10 +26,30 @@ impl SetComparisonMetrics {
         missing_count: usize,
         extra_count: usize,
     ) -> Self {
+        Self::new_with_compatible_matches(
+            rust_glancer_count,
+            rust_analyzer_count,
+            matched_count,
+            0,
+            missing_count,
+            extra_count,
+        )
+    }
+
+    pub(super) fn new_with_compatible_matches(
+        rust_glancer_count: usize,
+        rust_analyzer_count: usize,
+        exact_match_count: usize,
+        compatible_count: usize,
+        missing_count: usize,
+        extra_count: usize,
+    ) -> Self {
+        let matched_count = exact_match_count + compatible_count;
         Self {
             rust_glancer_count,
             rust_analyzer_count,
             matched_count,
+            compatible_count,
             missing_count,
             extra_count,
             match_score_percent: Self::match_score_percent(

--- a/crates/rust-glancer/src/compare_lsp/comparison/mod.rs
+++ b/crates/rust-glancer/src/compare_lsp/comparison/mod.rs
@@ -67,23 +67,25 @@ impl ComparisonSummary {
         &self.aggregates
     }
 
-    /// One normalized completeness score for the whole benchmark run.
+    /// One normalized semantic-equivalence score for the benchmark run.
     ///
-    /// Each method contributes equally, regardless of how many raw locations/ranges/hints it
-    /// returns. Non-comparable queries reduce that method's contribution before the method scores
-    /// are averaged.
+    /// Each semantic method contributes equally, regardless of how many raw items it returns.
+    /// Presence-only hover coverage and the intentionally presentation-tolerant inlay comparison
+    /// remain visible in their own aggregates, but do not claim semantic equivalence here.
+    /// Non-comparable queries reduce a scored method's contribution before method scores are
+    /// averaged.
     pub(crate) fn equivalence_score_percent(&self) -> Option<f64> {
-        if self.aggregates.is_empty() {
-            return None;
+        let mut total = 0.0;
+        let mut method_count = 0;
+        for aggregate in &self.aggregates {
+            let Some(score) = aggregate.equivalence_score_percent() else {
+                continue;
+            };
+            total += score;
+            method_count += 1;
         }
 
-        let total = self
-            .aggregates
-            .iter()
-            .map(MethodAggregate::equivalence_score_percent)
-            .sum::<f64>();
-
-        Some(total / self.aggregates.len() as f64)
+        (method_count > 0).then(|| total / method_count as f64)
     }
 }
 
@@ -224,6 +226,24 @@ impl QueryComparison {
                         "compare-lsp location divergence"
                     );
                 }
+                QueryComparisonResult::PrepareRenames(comparison)
+                    if !comparison.compatible().is_empty()
+                        || !comparison.missing().is_empty()
+                        || !comparison.extra().is_empty() =>
+                {
+                    tracing::debug!(
+                        target: "rust_glancer::compare_lsp::divergence",
+                        query = query.label(),
+                        method = query.kind().lsp_method(),
+                        compatible_count = comparison.compatible().len(),
+                        missing_count = comparison.missing().len(),
+                        extra_count = comparison.extra().len(),
+                        compatible = ?comparison.compatible(),
+                        missing = ?comparison.missing(),
+                        extra = ?comparison.extra(),
+                        "compare-lsp prepare-rename difference"
+                    );
+                }
                 QueryComparisonResult::RenameEdits(comparison)
                     if !comparison.missing().is_empty() || !comparison.extra().is_empty() =>
                 {
@@ -238,7 +258,7 @@ impl QueryComparison {
                         "compare-lsp rename divergence"
                     );
                 }
-                QueryComparisonResult::Symbols(comparison)
+                QueryComparisonResult::Ranges(comparison)
                     if !comparison.missing().is_empty() || !comparison.extra().is_empty() =>
                 {
                     tracing::debug!(
@@ -249,7 +269,25 @@ impl QueryComparison {
                         extra_count = comparison.extra().len(),
                         missing = ?comparison.missing(),
                         extra = ?comparison.extra(),
-                        "compare-lsp symbol divergence"
+                        "compare-lsp document-highlight divergence"
+                    );
+                }
+                QueryComparisonResult::Symbols(comparison)
+                    if !comparison.compatible().is_empty()
+                        || !comparison.missing().is_empty()
+                        || !comparison.extra().is_empty() =>
+                {
+                    tracing::debug!(
+                        target: "rust_glancer::compare_lsp::divergence",
+                        query = query.label(),
+                        method = query.kind().lsp_method(),
+                        compatible_count = comparison.compatible().len(),
+                        missing_count = comparison.missing().len(),
+                        extra_count = comparison.extra().len(),
+                        compatible = ?comparison.compatible(),
+                        missing = ?comparison.missing(),
+                        extra = ?comparison.extra(),
+                        "compare-lsp symbol difference"
                     );
                 }
                 _ => {}
@@ -413,8 +451,13 @@ impl MethodAggregate {
         &self.data
     }
 
-    fn equivalence_score_percent(&self) -> f64 {
-        self.data.equivalence_score_percent()
+    fn equivalence_score_percent(&self) -> Option<f64> {
+        self.is_equivalence_scored()
+            .then(|| self.data.equivalence_score_percent())
+    }
+
+    pub(crate) fn is_equivalence_scored(&self) -> bool {
+        self.method.is_equivalence_scored()
     }
 }
 
@@ -516,6 +559,10 @@ impl QueryMethod {
             Self::Hover => QueryKind::Hover.lsp_method(),
         }
     }
+
+    pub(crate) fn is_equivalence_scored(self) -> bool {
+        !matches!(self, Self::InlayHint | Self::Hover)
+    }
 }
 
 #[cfg(test)]
@@ -592,6 +639,11 @@ mod tests {
         assert_eq!(metrics.set.extra_count, 1);
         assert_eq!(metrics.set.recall_percent, Some(50.0),);
         assert_eq!(metrics.set.match_score_percent, 50.0);
+        assert_eq!(
+            comparison.equivalence_score_percent(),
+            Some(25.0),
+            "one non-comparable query halves the method's 50% set score",
+        );
     }
 
     #[test]
@@ -637,6 +689,11 @@ mod tests {
         assert_eq!(metrics.missing_count, 1);
         assert_eq!(metrics.extra_count, 0);
         assert_eq!(summary.non_comparable_count, 1);
+        assert_eq!(
+            comparison.equivalence_score_percent(),
+            None,
+            "presence-only hover coverage must not claim semantic equivalence",
+        );
     }
 
     fn locations(locations: Vec<NormalizedLocation>) -> NormalizedOutcome {

--- a/crates/rust-glancer/src/compare_lsp/comparison/mod.rs
+++ b/crates/rust-glancer/src/compare_lsp/comparison/mod.rs
@@ -204,6 +204,58 @@ impl QueryComparison {
             },
         };
 
+        // Detailed result lists are useful while investigating semantic gaps, but far too noisy for
+        // the normal comparison report. Keep one structured record per divergent query behind a
+        // dedicated debug target so `agent-debug --log ...` can capture it in the run artifact.
+        if tracing::enabled!(target: "rust_glancer::compare_lsp::divergence", tracing::Level::DEBUG)
+        {
+            match &result {
+                QueryComparisonResult::Locations(comparison)
+                    if !comparison.missing().is_empty() || !comparison.extra().is_empty() =>
+                {
+                    tracing::debug!(
+                        target: "rust_glancer::compare_lsp::divergence",
+                        query = query.label(),
+                        method = query.kind().lsp_method(),
+                        missing_count = comparison.missing().len(),
+                        extra_count = comparison.extra().len(),
+                        missing = ?comparison.missing(),
+                        extra = ?comparison.extra(),
+                        "compare-lsp location divergence"
+                    );
+                }
+                QueryComparisonResult::RenameEdits(comparison)
+                    if !comparison.missing().is_empty() || !comparison.extra().is_empty() =>
+                {
+                    tracing::debug!(
+                        target: "rust_glancer::compare_lsp::divergence",
+                        query = query.label(),
+                        method = query.kind().lsp_method(),
+                        missing_count = comparison.missing().len(),
+                        extra_count = comparison.extra().len(),
+                        missing = ?comparison.missing(),
+                        extra = ?comparison.extra(),
+                        "compare-lsp rename divergence"
+                    );
+                }
+                QueryComparisonResult::Symbols(comparison)
+                    if !comparison.missing().is_empty() || !comparison.extra().is_empty() =>
+                {
+                    tracing::debug!(
+                        target: "rust_glancer::compare_lsp::divergence",
+                        query = query.label(),
+                        method = query.kind().lsp_method(),
+                        missing_count = comparison.missing().len(),
+                        extra_count = comparison.extra().len(),
+                        missing = ?comparison.missing(),
+                        extra = ?comparison.extra(),
+                        "compare-lsp symbol divergence"
+                    );
+                }
+                _ => {}
+            }
+        }
+
         Self {
             label: query.label(),
             method: QueryMethod::from_kind(query.kind()),

--- a/crates/rust-glancer/src/compare_lsp/comparison/range.rs
+++ b/crates/rust-glancer/src/compare_lsp/comparison/range.rs
@@ -33,9 +33,9 @@ impl RangeComparison {
             .copied()
             .collect::<BTreeSet<_>>();
 
-        // Highlights are scoped to the requested document, so the range itself is the stable
-        // comparable unit. Kind is deliberately ignored for now; engines often differ on read/write
-        // classification while still finding the same occurrences.
+        // Text/Read/Write kinds are a part of protocol, but they have very minor impact on the LSP experience,
+        // thus we intentionally ignore them. It is unlikely that anyone will notice, and there are way more
+        // high-priority work out there. It's not a TODO, it's a deprioritized item.
         let matched = rust_glancer_ranges
             .intersection(&rust_analyzer_ranges)
             .copied()
@@ -66,6 +66,14 @@ impl RangeComparison {
             self.missing.len(),
             self.extra.len(),
         )
+    }
+
+    pub(super) fn missing(&self) -> &[NormalizedRange] {
+        &self.missing
+    }
+
+    pub(super) fn extra(&self) -> &[NormalizedRange] {
+        &self.extra
     }
 }
 

--- a/crates/rust-glancer/src/compare_lsp/comparison/rename.rs
+++ b/crates/rust-glancer/src/compare_lsp/comparison/rename.rs
@@ -194,6 +194,14 @@ impl RenameEditComparison {
             rust_analyzer_unmapped: self.rust_analyzer_unmapped.clone(),
         }
     }
+
+    pub(super) fn missing(&self) -> &[NormalizedTextEdit] {
+        &self.missing
+    }
+
+    pub(super) fn extra(&self) -> &[NormalizedTextEdit] {
+        &self.extra
+    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/rust-glancer/src/compare_lsp/comparison/rename.rs
+++ b/crates/rust-glancer/src/compare_lsp/comparison/rename.rs
@@ -19,6 +19,7 @@ pub(crate) struct PrepareRenameComparison {
     rust_glancer_count: usize,
     rust_analyzer_count: usize,
     matched: Vec<NormalizedPrepareRenameTarget>,
+    compatible: Vec<(NormalizedPrepareRenameTarget, NormalizedPrepareRenameTarget)>,
     missing: Vec<NormalizedPrepareRenameTarget>,
     extra: Vec<NormalizedPrepareRenameTarget>,
 }
@@ -39,36 +40,72 @@ impl PrepareRenameComparison {
             .cloned()
             .collect::<BTreeSet<_>>();
 
-        let matched = rust_glancer_targets
+        let mut matched = rust_glancer_targets
             .intersection(&rust_analyzer_targets)
             .cloned()
-            .collect();
-        let missing = rust_analyzer_targets
+            .collect::<Vec<_>>();
+        let mut missing = rust_analyzer_targets
             .difference(&rust_glancer_targets)
             .cloned()
-            .collect();
-        let extra = rust_glancer_targets
+            .collect::<Vec<_>>();
+        let unmatched_extra = rust_glancer_targets
             .difference(&rust_analyzer_targets)
             .cloned()
-            .collect();
+            .collect::<Vec<_>>();
+
+        // Optional response data is directional. A valid rust-glancer placeholder is compatible
+        // with rust-analyzer returning only the same range; omitting rust-analyzer's placeholder is
+        // still reported as a loss.
+        let mut compatible = Vec::new();
+        let mut extra = Vec::new();
+        for rust_glancer_target in unmatched_extra {
+            let Some(reference_index) = missing
+                .iter()
+                .position(|reference| rust_glancer_target.is_no_worse_match_for(reference))
+            else {
+                extra.push(rust_glancer_target);
+                continue;
+            };
+
+            let rust_analyzer_target = missing.remove(reference_index);
+            matched.push(rust_glancer_target.clone());
+            compatible.push((rust_glancer_target, rust_analyzer_target));
+        }
+        matched.sort();
 
         Self {
             rust_glancer_count: rust_glancer_targets.len(),
             rust_analyzer_count: rust_analyzer_targets.len(),
             matched,
+            compatible,
             missing,
             extra,
         }
     }
 
     pub(crate) fn metrics(&self) -> SetComparisonMetrics {
-        SetComparisonMetrics::new(
+        SetComparisonMetrics::new_with_compatible_matches(
             self.rust_glancer_count,
             self.rust_analyzer_count,
-            self.matched.len(),
+            self.matched.len() - self.compatible.len(),
+            self.compatible.len(),
             self.missing.len(),
             self.extra.len(),
         )
+    }
+
+    pub(super) fn compatible(
+        &self,
+    ) -> &[(NormalizedPrepareRenameTarget, NormalizedPrepareRenameTarget)] {
+        &self.compatible
+    }
+
+    pub(super) fn missing(&self) -> &[NormalizedPrepareRenameTarget] {
+        &self.missing
+    }
+
+    pub(super) fn extra(&self) -> &[NormalizedPrepareRenameTarget] {
+        &self.extra
     }
 }
 
@@ -80,6 +117,7 @@ pub(crate) struct PrepareRenameAggregate {
     rust_glancer_targets: usize,
     rust_analyzer_targets: usize,
     matched_targets: usize,
+    compatible_targets: usize,
     missing_targets: usize,
     extra_targets: usize,
 }
@@ -93,6 +131,7 @@ impl PrepareRenameAggregate {
                 self.rust_glancer_targets += comparison.rust_glancer_count;
                 self.rust_analyzer_targets += comparison.rust_analyzer_count;
                 self.matched_targets += comparison.matched.len();
+                self.compatible_targets += comparison.compatible.len();
                 self.missing_targets += comparison.missing.len();
                 self.extra_targets += comparison.extra.len();
             }
@@ -114,10 +153,11 @@ impl PrepareRenameAggregate {
     }
 
     pub(crate) fn metrics(&self) -> SetComparisonMetrics {
-        SetComparisonMetrics::new(
+        SetComparisonMetrics::new_with_compatible_matches(
             self.rust_glancer_targets,
             self.rust_analyzer_targets,
-            self.matched_targets,
+            self.matched_targets - self.compatible_targets,
+            self.compatible_targets,
             self.missing_targets,
             self.extra_targets,
         )
@@ -261,5 +301,81 @@ impl RenameEditAggregate {
             rust_glancer_unmapped_count: self.rust_glancer_unmapped_edits,
             rust_analyzer_unmapped_count: self.rust_analyzer_unmapped_edits,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::compare_lsp::normalization::{
+        NormalizedPrepareRenameSet, NormalizedPrepareRenameTarget, NormalizedRange,
+    };
+
+    use super::PrepareRenameComparison;
+
+    #[test]
+    fn accepts_a_valid_placeholder_when_the_reference_returns_only_a_range() {
+        let range = Some(NormalizedRange::test_new(3, 8, 3, 17));
+        let rust_glancer = targets(vec![NormalizedPrepareRenameTarget::test_new(
+            range,
+            Some("user_name"),
+            true,
+        )]);
+        let rust_analyzer = targets(vec![NormalizedPrepareRenameTarget::test_new(
+            range, None, true,
+        )]);
+
+        let comparison = PrepareRenameComparison::new(&rust_glancer, &rust_analyzer);
+        let metrics = comparison.metrics();
+
+        assert_eq!(metrics.matched_count, 1);
+        assert_eq!(metrics.compatible_count, 1);
+        assert_eq!(metrics.missing_count, 0);
+        assert_eq!(metrics.extra_count, 0);
+    }
+
+    #[test]
+    fn rejects_dropping_a_reference_placeholder() {
+        let range = Some(NormalizedRange::test_new(3, 8, 3, 17));
+        let rust_glancer = targets(vec![NormalizedPrepareRenameTarget::test_new(
+            range, None, true,
+        )]);
+        let rust_analyzer = targets(vec![NormalizedPrepareRenameTarget::test_new(
+            range,
+            Some("user_name"),
+            true,
+        )]);
+
+        let comparison = PrepareRenameComparison::new(&rust_glancer, &rust_analyzer);
+        let metrics = comparison.metrics();
+
+        assert_eq!(metrics.matched_count, 0);
+        assert_eq!(metrics.compatible_count, 0);
+        assert_eq!(metrics.missing_count, 1);
+        assert_eq!(metrics.extra_count, 1);
+    }
+
+    #[test]
+    fn rejects_a_placeholder_that_does_not_match_source() {
+        let range = Some(NormalizedRange::test_new(3, 8, 3, 17));
+        let rust_glancer = targets(vec![NormalizedPrepareRenameTarget::test_new(
+            range,
+            Some("other_name"),
+            false,
+        )]);
+        let rust_analyzer = targets(vec![NormalizedPrepareRenameTarget::test_new(
+            range, None, true,
+        )]);
+
+        let comparison = PrepareRenameComparison::new(&rust_glancer, &rust_analyzer);
+        let metrics = comparison.metrics();
+
+        assert_eq!(metrics.matched_count, 0);
+        assert_eq!(metrics.compatible_count, 0);
+        assert_eq!(metrics.missing_count, 1);
+        assert_eq!(metrics.extra_count, 1);
+    }
+
+    fn targets(targets: Vec<NormalizedPrepareRenameTarget>) -> NormalizedPrepareRenameSet {
+        NormalizedPrepareRenameSet::test_from_targets(targets)
     }
 }

--- a/crates/rust-glancer/src/compare_lsp/comparison/symbol.rs
+++ b/crates/rust-glancer/src/compare_lsp/comparison/symbol.rs
@@ -16,6 +16,7 @@ pub(crate) struct SymbolComparison {
     rust_glancer_count: usize,
     rust_analyzer_count: usize,
     matched: Vec<NormalizedSymbol>,
+    compatible: Vec<(NormalizedSymbol, NormalizedSymbol)>,
     missing: Vec<NormalizedSymbol>,
     extra: Vec<NormalizedSymbol>,
     rust_glancer_unmapped_count: usize,
@@ -40,23 +41,41 @@ impl SymbolComparison {
             .cloned()
             .collect::<BTreeSet<_>>();
 
-        let matched = rust_glancer_symbols
+        let mut matched = rust_glancer_symbols
             .intersection(&rust_analyzer_symbols)
             .cloned()
-            .collect();
-        let missing = rust_analyzer_symbols
+            .collect::<Vec<_>>();
+        let mut missing = rust_analyzer_symbols
             .difference(&rust_glancer_symbols)
             .cloned()
-            .collect();
-        let extra = rust_glancer_symbols
+            .collect::<Vec<_>>();
+        let unmatched_extra = rust_glancer_symbols
             .difference(&rust_analyzer_symbols)
             .cloned()
-            .collect();
+            .collect::<Vec<_>>();
+
+        let mut compatible = Vec::new();
+        let mut extra = Vec::new();
+        for rust_glancer_symbol in unmatched_extra {
+            let Some(reference_index) = missing
+                .iter()
+                .position(|reference| rust_glancer_symbol.is_no_worse_match_for(reference))
+            else {
+                extra.push(rust_glancer_symbol);
+                continue;
+            };
+
+            let rust_analyzer_symbol = missing.remove(reference_index);
+            matched.push(rust_glancer_symbol.clone());
+            compatible.push((rust_glancer_symbol, rust_analyzer_symbol));
+        }
+        matched.sort();
 
         Self {
             rust_glancer_count: rust_glancer_symbols.len(),
             rust_analyzer_count: rust_analyzer_symbols.len(),
             matched,
+            compatible,
             missing,
             extra,
             rust_glancer_unmapped_count: rust_glancer.unmapped_count(),
@@ -68,10 +87,11 @@ impl SymbolComparison {
 
     pub(crate) fn metrics(&self) -> MappedSetComparisonMetrics {
         MappedSetComparisonMetrics {
-            set: SetComparisonMetrics::new(
+            set: SetComparisonMetrics::new_with_compatible_matches(
                 self.rust_glancer_count,
                 self.rust_analyzer_count,
-                self.matched.len(),
+                self.matched.len() - self.compatible.len(),
+                self.compatible.len(),
                 self.missing.len(),
                 self.extra.len(),
             ),
@@ -89,6 +109,10 @@ impl SymbolComparison {
     pub(super) fn extra(&self) -> &[NormalizedSymbol] {
         &self.extra
     }
+
+    pub(super) fn compatible(&self) -> &[(NormalizedSymbol, NormalizedSymbol)] {
+        &self.compatible
+    }
 }
 
 #[derive(Debug, Default)]
@@ -99,6 +123,7 @@ pub(crate) struct SymbolAggregate {
     rust_glancer_symbols: usize,
     rust_analyzer_symbols: usize,
     matched_symbols: usize,
+    compatible_symbols: usize,
     missing_symbols: usize,
     extra_symbols: usize,
     rust_glancer_unmapped_symbols: usize,
@@ -114,6 +139,7 @@ impl SymbolAggregate {
                 self.rust_glancer_symbols += comparison.rust_glancer_count;
                 self.rust_analyzer_symbols += comparison.rust_analyzer_count;
                 self.matched_symbols += comparison.matched.len();
+                self.compatible_symbols += comparison.compatible.len();
                 self.missing_symbols += comparison.missing.len();
                 self.extra_symbols += comparison.extra.len();
                 self.rust_glancer_unmapped_symbols += comparison.rust_glancer_unmapped_count;
@@ -138,15 +164,96 @@ impl SymbolAggregate {
 
     pub(crate) fn metrics(&self) -> MappedSetAggregateMetrics {
         MappedSetAggregateMetrics {
-            set: SetComparisonMetrics::new(
+            set: SetComparisonMetrics::new_with_compatible_matches(
                 self.rust_glancer_symbols,
                 self.rust_analyzer_symbols,
-                self.matched_symbols,
+                self.matched_symbols - self.compatible_symbols,
+                self.compatible_symbols,
                 self.missing_symbols,
                 self.extra_symbols,
             ),
             rust_glancer_unmapped_count: self.rust_glancer_unmapped_symbols,
             rust_analyzer_unmapped_count: self.rust_analyzer_unmapped_symbols,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ls_types::SymbolKind;
+
+    use crate::compare_lsp::normalization::{
+        NormalizedRange, NormalizedSymbol, NormalizedSymbolSet,
+    };
+
+    use super::SymbolComparison;
+
+    #[test]
+    fn accepts_method_as_a_more_specific_function_classification() {
+        let range = NormalizedRange::test_new(8, 11, 8, 15);
+        let rust_glancer = symbols(vec![symbol(SymbolKind::METHOD, range)]);
+        let rust_analyzer = symbols(vec![symbol(SymbolKind::FUNCTION, range)]);
+
+        let comparison = SymbolComparison::new(&rust_glancer, &rust_analyzer);
+        let metrics = comparison.metrics().set;
+
+        assert_eq!(metrics.matched_count, 1);
+        assert_eq!(metrics.compatible_count, 1);
+        assert_eq!(metrics.missing_count, 0);
+        assert_eq!(metrics.extra_count, 0);
+    }
+
+    #[test]
+    fn rejects_function_when_the_reference_knows_it_is_a_method() {
+        let range = NormalizedRange::test_new(8, 11, 8, 15);
+        let rust_glancer = symbols(vec![symbol(SymbolKind::FUNCTION, range)]);
+        let rust_analyzer = symbols(vec![symbol(SymbolKind::METHOD, range)]);
+
+        let comparison = SymbolComparison::new(&rust_glancer, &rust_analyzer);
+        let metrics = comparison.metrics().set;
+
+        assert_eq!(metrics.matched_count, 0);
+        assert_eq!(metrics.compatible_count, 0);
+        assert_eq!(metrics.missing_count, 1);
+        assert_eq!(metrics.extra_count, 1);
+    }
+
+    #[test]
+    fn keeps_broader_rust_glancer_symbol_ranges_as_divergences() {
+        let focused = NormalizedRange::test_new(8, 5, 8, 15);
+        let whole_impl = NormalizedRange::test_new(8, 0, 14, 1);
+        let rust_glancer = symbols(vec![symbol(SymbolKind::OBJECT, whole_impl)]);
+        let rust_analyzer = symbols(vec![symbol(SymbolKind::OBJECT, focused)]);
+
+        let comparison = SymbolComparison::new(&rust_glancer, &rust_analyzer);
+        let metrics = comparison.metrics().set;
+
+        assert_eq!(metrics.matched_count, 0);
+        assert_eq!(metrics.compatible_count, 0);
+        assert_eq!(metrics.missing_count, 1);
+        assert_eq!(metrics.extra_count, 1);
+    }
+
+    #[test]
+    fn keeps_unrelated_lossy_type_kinds_as_divergences() {
+        let range = NormalizedRange::test_new(8, 5, 8, 14);
+        let rust_glancer = symbols(vec![symbol(SymbolKind::CLASS, range)]);
+        let rust_analyzer = symbols(vec![symbol(SymbolKind::TYPE_PARAMETER, range)]);
+
+        let comparison = SymbolComparison::new(&rust_glancer, &rust_analyzer);
+        let metrics = comparison.metrics().set;
+
+        assert_eq!(metrics.matched_count, 0);
+        assert_eq!(metrics.compatible_count, 0);
+        assert_eq!(metrics.missing_count, 1);
+        assert_eq!(metrics.extra_count, 1);
+    }
+
+    fn symbols(symbols: Vec<NormalizedSymbol>) -> NormalizedSymbolSet {
+        NormalizedSymbolSet::test_from_symbols(symbols)
+    }
+
+    fn symbol(kind: SymbolKind, range: NormalizedRange) -> NormalizedSymbol {
+        NormalizedSymbol::test_new("save", kind, Some("src/lib.rs"), Some(range))
     }
 }

--- a/crates/rust-glancer/src/compare_lsp/comparison/symbol.rs
+++ b/crates/rust-glancer/src/compare_lsp/comparison/symbol.rs
@@ -81,6 +81,14 @@ impl SymbolComparison {
             rust_analyzer_unmapped: self.rust_analyzer_unmapped.clone(),
         }
     }
+
+    pub(super) fn missing(&self) -> &[NormalizedSymbol] {
+        &self.missing
+    }
+
+    pub(super) fn extra(&self) -> &[NormalizedSymbol] {
+        &self.extra
+    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/rust-glancer/src/compare_lsp/execution.rs
+++ b/crates/rust-glancer/src/compare_lsp/execution.rs
@@ -52,6 +52,7 @@ pub(crate) enum ServerUnderTest {
 pub(crate) struct QueryExecution {
     label: &'static str,
     kind: QueryKind,
+    target: QueryTarget,
     rust_glancer: RawServerOutcome,
     rust_analyzer: RawServerOutcome,
 }
@@ -63,6 +64,10 @@ impl QueryExecution {
 
     pub(crate) fn kind(&self) -> QueryKind {
         self.kind
+    }
+
+    pub(crate) fn target(&self) -> QueryTarget {
+        self.target
     }
 
     pub(crate) fn outcome(&self, server: ServerUnderTest) -> &RawServerOutcome {
@@ -169,6 +174,7 @@ pub(crate) async fn run(
         results.push(QueryExecution {
             label: query_case.label(),
             kind: query_case.kind(),
+            target: query_case.target(),
             rust_glancer,
             rust_analyzer,
         });

--- a/crates/rust-glancer/src/compare_lsp/normalization.rs
+++ b/crates/rust-glancer/src/compare_lsp/normalization.rs
@@ -22,7 +22,7 @@ use serde_json::Value;
 use crate::compare_lsp::{
     execution::{ExecutionSummary, QueryExecution, RawOutcome, RawServerOutcome, ServerUnderTest},
     fixture::Fixture,
-    query::QueryKind,
+    query::{QueryKind, QueryTarget},
 };
 
 /// Query outcomes after protocol shapes and file URIs have been made comparable.
@@ -77,11 +77,13 @@ impl NormalizedQueryExecution {
             rust_glancer: NormalizedServerOutcome::from_raw(
                 fixture_root,
                 query.kind(),
+                query.target(),
                 query.outcome(ServerUnderTest::RustGlancer),
             ),
             rust_analyzer: NormalizedServerOutcome::from_raw(
                 fixture_root,
                 query.kind(),
+                query.target(),
                 query.outcome(ServerUnderTest::RustAnalyzer),
             ),
         }
@@ -125,10 +127,15 @@ pub(crate) struct NormalizedServerOutcome {
 }
 
 impl NormalizedServerOutcome {
-    fn from_raw(fixture_root: &Path, kind: QueryKind, outcome: &RawServerOutcome) -> Self {
+    fn from_raw(
+        fixture_root: &Path,
+        kind: QueryKind,
+        target: QueryTarget,
+        outcome: &RawServerOutcome,
+    ) -> Self {
         Self {
             latency: outcome.latency(),
-            value: NormalizedOutcome::from_raw(fixture_root, kind, outcome.value()),
+            value: NormalizedOutcome::from_raw(fixture_root, kind, target, outcome.value()),
         }
     }
 
@@ -165,7 +172,12 @@ pub(crate) enum NormalizedOutcome {
 }
 
 impl NormalizedOutcome {
-    fn from_raw(fixture_root: &Path, kind: QueryKind, raw_outcome: &RawOutcome) -> Self {
+    fn from_raw(
+        fixture_root: &Path,
+        kind: QueryKind,
+        target: QueryTarget,
+        raw_outcome: &RawOutcome,
+    ) -> Self {
         match raw_outcome {
             RawOutcome::Success { raw, .. } => match kind {
                 QueryKind::References { .. }
@@ -177,10 +189,12 @@ impl NormalizedOutcome {
                         Err(message) => Self::MalformedSuccess { message },
                     }
                 }
-                QueryKind::PrepareRename => match NormalizedPrepareRenameSet::from_json(raw) {
-                    Ok(targets) => Self::PrepareRenames(targets),
-                    Err(message) => Self::MalformedSuccess { message },
-                },
+                QueryKind::PrepareRename => {
+                    match NormalizedPrepareRenameSet::from_json(fixture_root, target, raw) {
+                        Ok(targets) => Self::PrepareRenames(targets),
+                        Err(message) => Self::MalformedSuccess { message },
+                    }
+                }
                 QueryKind::Rename => match NormalizedTextEditSet::from_json(fixture_root, raw) {
                     Ok(edits) => Self::RenameEdits(edits),
                     Err(message) => Self::MalformedSuccess { message },
@@ -227,7 +241,11 @@ pub(crate) struct NormalizedPrepareRenameSet {
 }
 
 impl NormalizedPrepareRenameSet {
-    fn from_json(raw: &Value) -> Result<Self, String> {
+    fn from_json(
+        fixture_root: &Path,
+        query_target: QueryTarget,
+        raw: &Value,
+    ) -> Result<Self, String> {
         if raw.is_null() {
             return Ok(Self {
                 targets: Vec::new(),
@@ -245,17 +263,26 @@ impl NormalizedPrepareRenameSet {
             PrepareRenameResponse::Range(range) => Some(NormalizedPrepareRenameTarget {
                 range: Some(NormalizedRange::from_lsp(range)),
                 default_behavior: false,
+                placeholder: None,
+                placeholder_matches_source: true,
             }),
-            PrepareRenameResponse::RangeWithPlaceholder { range, .. } => {
+            PrepareRenameResponse::RangeWithPlaceholder { range, placeholder } => {
+                let range = NormalizedRange::from_lsp(range);
+                let selected_text = range.source_text_for_query(fixture_root, query_target)?;
+
                 Some(NormalizedPrepareRenameTarget {
-                    range: Some(NormalizedRange::from_lsp(range)),
+                    range: Some(range),
                     default_behavior: false,
+                    placeholder_matches_source: placeholder == selected_text,
+                    placeholder: Some(placeholder),
                 })
             }
             PrepareRenameResponse::DefaultBehavior { default_behavior } => default_behavior
                 .then_some(NormalizedPrepareRenameTarget {
                     range: None,
                     default_behavior: true,
+                    placeholder: None,
+                    placeholder_matches_source: true,
                 }),
         };
 
@@ -266,6 +293,11 @@ impl NormalizedPrepareRenameSet {
 
     pub(crate) fn targets(&self) -> &[NormalizedPrepareRenameTarget] {
         &self.targets
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_from_targets(targets: Vec<NormalizedPrepareRenameTarget>) -> Self {
+        Self { targets }
     }
 }
 
@@ -577,6 +609,20 @@ impl NormalizedSymbolSet {
             .map(UnmappedLocation::summary)
             .collect()
     }
+
+    #[cfg(test)]
+    pub(crate) fn test_from_symbols(symbols: Vec<NormalizedSymbol>) -> Self {
+        let symbols = symbols
+            .into_iter()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+
+        Self {
+            symbols,
+            unmapped: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -701,7 +747,12 @@ impl ProtocolLocation {
     fn range(&self) -> Range {
         match self {
             Self::Location(location) => location.range,
-            Self::LocationLink(location) => location.target_range,
+            // `Location` has only the range an editor should focus. The equivalent field in a
+            // `LocationLink` is `targetSelectionRange`; `targetRange` may cover the whole item.
+            //
+            // For `fn load_user() { ... }`, compare the `load_user` selection rather than the
+            // complete function body.
+            Self::LocationLink(location) => location.target_selection_range,
         }
     }
 }
@@ -710,6 +761,44 @@ impl ProtocolLocation {
 pub(crate) struct NormalizedPrepareRenameTarget {
     range: Option<NormalizedRange>,
     default_behavior: bool,
+    placeholder: Option<String>,
+    placeholder_matches_source: bool,
+}
+
+impl NormalizedPrepareRenameTarget {
+    /// An optional, source-accurate placeholder makes a response more useful, not incompatible.
+    ///
+    /// For example, rust-analyzer may return only the range for `user_name`, while rust-glancer
+    /// returns the same range plus `"user_name"` as the editor's initial rename text. The reverse
+    /// direction is not accepted because dropping a reference placeholder loses information.
+    pub(crate) fn is_no_worse_match_for(&self, reference: &Self) -> bool {
+        if self.range != reference.range || self.default_behavior != reference.default_behavior {
+            return false;
+        }
+
+        match (&self.placeholder, &reference.placeholder) {
+            (Some(placeholder), Some(reference_placeholder)) => {
+                self.placeholder_matches_source && placeholder == reference_placeholder
+            }
+            (Some(_), None) => self.placeholder_matches_source,
+            (None, None) => true,
+            (None, Some(_)) => false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_new(
+        range: Option<NormalizedRange>,
+        placeholder: Option<&'static str>,
+        placeholder_matches_source: bool,
+    ) -> Self {
+        Self {
+            range,
+            default_behavior: false,
+            placeholder: placeholder.map(str::to_string),
+            placeholder_matches_source,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -819,6 +908,20 @@ pub(crate) struct NormalizedSymbol {
 }
 
 impl NormalizedSymbol {
+    /// Match a more specific Rust member classification without treating kinds as interchangeable.
+    ///
+    /// LSP has separate `Method` and `Function` kinds. rust-analyzer sometimes reports an
+    /// `impl User { fn save(&self) {} }` member as `Function`, while rust-glancer retains `Method`.
+    /// Accept that direction only; reporting the same member as a plain function when the reference
+    /// knows it is a method still remains a quality loss.
+    pub(crate) fn is_no_worse_match_for(&self, reference: &Self) -> bool {
+        self.name == reference.name
+            && self.path == reference.path
+            && self.range == reference.range
+            && self.kind == symbol_kind_code(SymbolKind::METHOD)
+            && reference.kind == symbol_kind_code(SymbolKind::FUNCTION)
+    }
+
     fn push_document_symbol(symbol: DocumentSymbol, symbols: &mut BTreeSet<Self>) {
         let children = symbol.children.unwrap_or_default();
         symbols.insert(Self {
@@ -914,6 +1017,21 @@ impl NormalizedSymbol {
             range,
         })
     }
+
+    #[cfg(test)]
+    pub(crate) fn test_new(
+        name: &'static str,
+        kind: SymbolKind,
+        path: Option<&'static str>,
+        range: Option<NormalizedRange>,
+    ) -> Self {
+        Self {
+            name: name.to_string(),
+            kind: symbol_kind_code(kind),
+            path: path.map(str::to_string),
+            range,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -947,6 +1065,79 @@ impl NormalizedRange {
             end_line: range.end.line,
             end_character: range.end.character,
         }
+    }
+
+    fn source_text_for_query(
+        self,
+        fixture_root: &Path,
+        query_target: QueryTarget,
+    ) -> Result<String, String> {
+        let source_path = match query_target {
+            QueryTarget::Position { source_path, .. } | QueryTarget::Rename { source_path, .. } => {
+                source_path
+            }
+            QueryTarget::File { .. } | QueryTarget::Workspace { .. } => {
+                return Err("prepare-rename query does not identify a source position".to_string());
+            }
+        };
+        let path = fixture_root.join(source_path);
+        let source = std::fs::read_to_string(&path).map_err(|error| {
+            format!(
+                "reading prepare-rename source {} failed: {error}",
+                path.display(),
+            )
+        })?;
+
+        self.source_text(&source)
+            .map(str::to_string)
+            .ok_or_else(|| {
+                format!(
+                    "prepare-rename range {:?} does not select valid source in {}",
+                    self,
+                    path.display(),
+                )
+            })
+    }
+
+    /// Convert LSP's UTF-16 coordinates before slicing fixture source.
+    ///
+    /// A range such as `0:1..0:3` selects the two-code-unit `😀`, even though the same text takes
+    /// four UTF-8 bytes in the fixture file.
+    fn source_text(self, source: &str) -> Option<&str> {
+        let start = Self::source_offset(source, self.start_line, self.start_character)?;
+        let end = Self::source_offset(source, self.end_line, self.end_character)?;
+        (start <= end).then(|| &source[start..end])
+    }
+
+    fn source_offset(source: &str, line: u32, character: u32) -> Option<usize> {
+        let mut line_start = 0;
+        for _ in 0..line {
+            let next_line = source[line_start..].find('\n')?;
+            line_start += next_line + 1;
+        }
+
+        let remaining = &source[line_start..];
+        let mut line_end = remaining
+            .find('\n')
+            .map_or(source.len(), |offset| line_start + offset);
+        if line_end > line_start && source.as_bytes()[line_end - 1] == b'\r' {
+            line_end -= 1;
+        }
+        let line_text = &source[line_start..line_end];
+        let character = usize::try_from(character).ok()?;
+        let mut utf16_offset = 0;
+
+        for (byte_offset, value) in line_text.char_indices() {
+            if utf16_offset == character {
+                return Some(line_start + byte_offset);
+            }
+            utf16_offset += value.len_utf16();
+            if utf16_offset > character {
+                return None;
+            }
+        }
+
+        (utf16_offset == character).then_some(line_end)
     }
 }
 
@@ -1052,7 +1243,11 @@ mod tests {
 
     use serde_json::{Value, json};
 
-    use super::{NormalizedLocationSet, NormalizedRange};
+    use crate::compare_lsp::query::{QueryTarget, SourcePosition};
+
+    use super::{
+        NormalizedLocationSet, NormalizedPrepareRenameSet, NormalizedRange, NormalizedRangeSet,
+    };
 
     #[test]
     fn normalizes_location_arrays_to_fixture_relative_sets() {
@@ -1089,7 +1284,7 @@ mod tests {
         let uri = file_uri(&root, "crates/core/src/lib.rs");
         let raw = json!({
             "targetUri": uri,
-            "targetRange": range_json(10, 4, 10, 16),
+            "targetRange": range_json(9, 0, 14, 1),
             "targetSelectionRange": range_json(10, 4, 10, 16),
         });
 
@@ -1107,6 +1302,101 @@ mod tests {
                 end_line: 10,
                 end_character: 16,
             },
+        );
+    }
+
+    #[test]
+    fn validates_prepare_rename_placeholders_against_utf16_source_ranges() {
+        let root = fixture_root("prepare-rename-placeholder");
+        let source_path = "src/lib.rs";
+        let path = root.join(source_path);
+        fs::create_dir_all(path.parent().expect("source should have a parent"))
+            .expect("source parent should be created");
+        fs::write(&path, "let 😀user_name = 1;\n").expect("source should be written");
+        let raw = json!({
+            "range": range_json(0, 6, 0, 15),
+            "placeholder": "user_name",
+        });
+        let query_target = QueryTarget::Position {
+            source_path,
+            position: SourcePosition::test_new(0, 8),
+        };
+
+        let targets = NormalizedPrepareRenameSet::from_json(&root, query_target, &raw)
+            .expect("prepare-rename response should normalize");
+
+        assert_eq!(targets.targets.len(), 1);
+        assert!(
+            targets.targets[0].placeholder_matches_source,
+            "the placeholder should equal the UTF-16-selected source text",
+        );
+    }
+
+    #[test]
+    fn keeps_incorrect_prepare_rename_placeholders_visible_to_comparison() {
+        let root = fixture_root("prepare-rename-wrong-placeholder");
+        let source_path = "src/lib.rs";
+        let path = root.join(source_path);
+        fs::create_dir_all(path.parent().expect("source should have a parent"))
+            .expect("source parent should be created");
+        fs::write(&path, "let user_name = 1;\n").expect("source should be written");
+        let raw = json!({
+            "range": range_json(0, 4, 0, 13),
+            "placeholder": "other_name",
+        });
+        let query_target = QueryTarget::Position {
+            source_path,
+            position: SourcePosition::test_new(0, 6),
+        };
+
+        let targets = NormalizedPrepareRenameSet::from_json(&root, query_target, &raw)
+            .expect("prepare-rename response should normalize");
+
+        assert!(
+            !targets.targets[0].placeholder_matches_source,
+            "an invalid placeholder must not qualify as a compatible enhancement",
+        );
+    }
+
+    #[test]
+    fn ignores_document_highlight_access_kinds() {
+        let raw = json!([
+            {
+                "range": range_json(2, 4, 2, 8),
+                "kind": 2,
+            },
+            {
+                "range": range_json(2, 4, 2, 8),
+                "kind": 3,
+            },
+            {
+                "range": range_json(4, 0, 4, 3),
+            },
+            {
+                "range": range_json(4, 0, 4, 3),
+                "kind": 1,
+            },
+        ]);
+
+        let ranges = NormalizedRangeSet::from_json(&raw).expect("highlights should normalize");
+
+        assert_eq!(
+            ranges.ranges.len(),
+            2,
+            "highlights at the same range should collapse regardless of their access kind",
+        );
+    }
+
+    #[test]
+    fn slices_source_ranges_in_utf16_coordinates() {
+        let source = "a😀b";
+        let range = NormalizedRange::test_new(0, 1, 0, 3);
+
+        assert_eq!(range.source_text(source), Some("😀"));
+        assert_eq!(
+            NormalizedRange::test_new(0, 2, 0, 3).source_text(source),
+            None,
+            "a position inside a surrogate pair is not a valid LSP boundary",
         );
     }
 

--- a/crates/rust-glancer/src/compare_lsp/query/model.rs
+++ b/crates/rust-glancer/src/compare_lsp/query/model.rs
@@ -137,6 +137,11 @@ impl SourcePosition {
     pub(crate) fn to_lsp(self) -> ls_types::Position {
         ls_types::Position::new(self.line, self.character)
     }
+
+    #[cfg(test)]
+    pub(crate) const fn test_new(line: u32, character: u32) -> Self {
+        Self { line, character }
+    }
 }
 
 /// LSP request family plus method-specific options needed for comparison.

--- a/crates/rust-glancer/src/compare_lsp/report/aggregate.rs
+++ b/crates/rust-glancer/src/compare_lsp/report/aggregate.rs
@@ -20,6 +20,7 @@ pub(super) struct MethodAggregateReport {
     query_count: usize,
     comparable_count: usize,
     non_comparable_count: usize,
+    equivalence_scored: bool,
     #[serde(flatten)]
     data: MethodAggregateDataReport,
 }
@@ -32,6 +33,7 @@ impl MethodAggregateReport {
             query_count: summary.query_count,
             comparable_count: summary.comparable_count,
             non_comparable_count: summary.non_comparable_count,
+            equivalence_scored: aggregate.is_equivalence_scored(),
             data: MethodAggregateDataReport::capture(aggregate.data()),
         }
     }
@@ -57,9 +59,11 @@ impl MethodAggregateReport {
             .count_column("queries")
             .count_column("comparable")
             .count_column("non_comparable")
+            .column_as("scored", "Scored", ReportAlign::Center, None)
             .count_column("rust_glancer")
             .count_column("rust_analyzer")
             .count_column("matched")
+            .count_column("compatible")
             .count_column("missing")
             .count_column("extra")
             .column_as(
@@ -92,7 +96,8 @@ impl MethodAggregateReport {
                 .value(
                     "non_comparable",
                     ReportValue::count(self.non_comparable_count),
-                );
+                )
+                .value("scored", ReportValue::Bool(self.equivalence_scored));
 
             self.data.append_row_cells(row);
         });
@@ -146,6 +151,7 @@ struct LocationAggregateReport {
     rust_glancer_count: usize,
     rust_analyzer_count: usize,
     matched_count: usize,
+    compatible_count: usize,
     missing_count: usize,
     extra_count: usize,
     rust_glancer_unmapped_count: usize,
@@ -165,6 +171,7 @@ impl LocationAggregateReport {
                 ReportValue::count(self.rust_analyzer_count),
             )
             .value("matched", ReportValue::count(self.matched_count))
+            .value("compatible", ReportValue::count(self.compatible_count))
             .value("missing", ReportValue::count(self.missing_count))
             .value("extra", ReportValue::count(self.extra_count))
             .value(
@@ -190,6 +197,7 @@ impl From<MappedSetAggregateMetrics> for LocationAggregateReport {
             rust_glancer_count: metrics.set.rust_glancer_count,
             rust_analyzer_count: metrics.set.rust_analyzer_count,
             matched_count: metrics.set.matched_count,
+            compatible_count: metrics.set.compatible_count,
             missing_count: metrics.set.missing_count,
             extra_count: metrics.set.extra_count,
             rust_glancer_unmapped_count: metrics.rust_glancer_unmapped_count,
@@ -206,6 +214,7 @@ struct RangeAggregateReport {
     rust_glancer_count: usize,
     rust_analyzer_count: usize,
     matched_count: usize,
+    compatible_count: usize,
     missing_count: usize,
     extra_count: usize,
     match_score_percent: f64,
@@ -223,6 +232,7 @@ impl RangeAggregateReport {
                 ReportValue::count(self.rust_analyzer_count),
             )
             .value("matched", ReportValue::count(self.matched_count))
+            .value("compatible", ReportValue::count(self.compatible_count))
             .value("missing", ReportValue::count(self.missing_count))
             .value("extra", ReportValue::count(self.extra_count))
             .value(
@@ -240,6 +250,7 @@ impl From<SetComparisonMetrics> for RangeAggregateReport {
             rust_glancer_count: metrics.rust_glancer_count,
             rust_analyzer_count: metrics.rust_analyzer_count,
             matched_count: metrics.matched_count,
+            compatible_count: metrics.compatible_count,
             missing_count: metrics.missing_count,
             extra_count: metrics.extra_count,
             match_score_percent: metrics.match_score_percent,
@@ -254,6 +265,7 @@ struct SymbolAggregateReport {
     rust_glancer_count: usize,
     rust_analyzer_count: usize,
     matched_count: usize,
+    compatible_count: usize,
     missing_count: usize,
     extra_count: usize,
     rust_glancer_unmapped_count: usize,
@@ -273,6 +285,7 @@ impl SymbolAggregateReport {
                 ReportValue::count(self.rust_analyzer_count),
             )
             .value("matched", ReportValue::count(self.matched_count))
+            .value("compatible", ReportValue::count(self.compatible_count))
             .value("missing", ReportValue::count(self.missing_count))
             .value("extra", ReportValue::count(self.extra_count))
             .value(
@@ -298,6 +311,7 @@ impl From<MappedSetAggregateMetrics> for SymbolAggregateReport {
             rust_glancer_count: metrics.set.rust_glancer_count,
             rust_analyzer_count: metrics.set.rust_analyzer_count,
             matched_count: metrics.set.matched_count,
+            compatible_count: metrics.set.compatible_count,
             missing_count: metrics.set.missing_count,
             extra_count: metrics.set.extra_count,
             rust_glancer_unmapped_count: metrics.rust_glancer_unmapped_count,

--- a/crates/rust-glancer/src/compare_lsp/report/query.rs
+++ b/crates/rust-glancer/src/compare_lsp/report/query.rs
@@ -23,6 +23,7 @@ const HIGHLIGHT_LIMIT: usize = 10;
 pub(super) struct QueryReport {
     label: String,
     method: String,
+    equivalence_scored: bool,
     rust_glancer_ms: f64,
     rust_analyzer_ms: f64,
     result: QueryResultReport,
@@ -30,9 +31,11 @@ pub(super) struct QueryReport {
 
 impl QueryReport {
     pub(super) fn capture(query: &QueryComparison) -> Self {
+        let method = query.method();
         Self {
             label: query.label().to_string(),
-            method: query.method().lsp_method().to_string(),
+            method: method.lsp_method().to_string(),
+            equivalence_scored: method.is_equivalence_scored(),
             rust_glancer_ms: duration_ms(query.rust_glancer_latency()),
             rust_analyzer_ms: duration_ms(query.rust_analyzer_latency()),
             result: QueryResultReport::capture(query.result()),
@@ -149,6 +152,7 @@ impl QueryReport {
     fn lowest_match_score_queries(queries: &[Self]) -> Vec<(&Self, QueryCounts)> {
         let mut lowest = queries
             .iter()
+            .filter(|query| query.equivalence_scored)
             .filter_map(|query| query.counts().map(|counts| (query, counts)))
             .filter(|(_, counts)| counts.match_score_percent < 100.0)
             .collect::<Vec<_>>();
@@ -163,6 +167,7 @@ impl QueryReport {
     fn lowest_recall_queries(queries: &[Self]) -> Vec<(&Self, QueryCounts)> {
         let mut lowest = queries
             .iter()
+            .filter(|query| query.equivalence_scored)
             .filter_map(|query| query.counts().map(|counts| (query, counts)))
             .filter(|(_, counts)| counts.recall_percent.is_some_and(|recall| recall < 100.0))
             .collect::<Vec<_>>();
@@ -178,6 +183,7 @@ impl QueryReport {
     fn lowest_precision_queries(queries: &[Self]) -> Vec<(&Self, QueryCounts)> {
         let mut lowest = queries
             .iter()
+            .filter(|query| query.equivalence_scored)
             .filter_map(|query| query.counts().map(|counts| (query, counts)))
             .filter(|(_, counts)| {
                 counts
@@ -250,6 +256,7 @@ impl QueryReport {
             .count_column("rust_glancer_count")
             .count_column("rust_analyzer_count")
             .count_column("matched")
+            .count_column("compatible")
             .count_column("missing")
             .count_column("extra");
     }
@@ -342,6 +349,7 @@ impl QueryReport {
             .count_column("rust_glancer_count")
             .count_column("rust_analyzer_count")
             .count_column("matched")
+            .count_column("compatible")
             .count_column("missing")
             .count_column("extra")
             .column_as(
@@ -515,6 +523,7 @@ struct QueryCounts {
     rust_glancer_count: usize,
     rust_analyzer_count: usize,
     matched_count: usize,
+    compatible_count: usize,
     missing_count: usize,
     extra_count: usize,
     match_score_percent: f64,
@@ -533,6 +542,7 @@ impl QueryCounts {
             ReportValue::count(self.rust_analyzer_count),
         )
         .value("matched", ReportValue::count(self.matched_count))
+        .value("compatible", ReportValue::count(self.compatible_count))
         .value("missing", ReportValue::count(self.missing_count))
         .value("extra", ReportValue::count(self.extra_count))
         .value(
@@ -563,6 +573,7 @@ impl QueryCounts {
             ReportValue::count(self.rust_analyzer_count),
         )
         .value("matched", ReportValue::count(self.matched_count))
+        .value("compatible", ReportValue::count(self.compatible_count))
         .value("missing", ReportValue::count(self.missing_count))
         .value("extra", ReportValue::count(self.extra_count));
     }
@@ -609,6 +620,7 @@ struct LocationQueryReport {
     rust_glancer_count: usize,
     rust_analyzer_count: usize,
     matched_count: usize,
+    compatible_count: usize,
     missing_count: usize,
     extra_count: usize,
     rust_glancer_unmapped_count: usize,
@@ -636,6 +648,7 @@ impl From<&LocationQueryReport> for QueryCounts {
             rust_glancer_count: report.rust_glancer_count,
             rust_analyzer_count: report.rust_analyzer_count,
             matched_count: report.matched_count,
+            compatible_count: report.compatible_count,
             missing_count: report.missing_count,
             extra_count: report.extra_count,
             match_score_percent: report.match_score_percent,
@@ -651,6 +664,7 @@ impl From<MappedSetComparisonMetrics> for LocationQueryReport {
             rust_glancer_count: metrics.set.rust_glancer_count,
             rust_analyzer_count: metrics.set.rust_analyzer_count,
             matched_count: metrics.set.matched_count,
+            compatible_count: metrics.set.compatible_count,
             missing_count: metrics.set.missing_count,
             extra_count: metrics.set.extra_count,
             rust_glancer_unmapped_count: metrics.rust_glancer_unmapped_count,
@@ -669,6 +683,7 @@ struct RangeQueryReport {
     rust_glancer_count: usize,
     rust_analyzer_count: usize,
     matched_count: usize,
+    compatible_count: usize,
     missing_count: usize,
     extra_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -690,6 +705,7 @@ impl From<&RangeQueryReport> for QueryCounts {
             rust_glancer_count: report.rust_glancer_count,
             rust_analyzer_count: report.rust_analyzer_count,
             matched_count: report.matched_count,
+            compatible_count: report.compatible_count,
             missing_count: report.missing_count,
             extra_count: report.extra_count,
             match_score_percent: report.match_score_percent,
@@ -705,6 +721,7 @@ impl From<SetComparisonMetrics> for RangeQueryReport {
             rust_glancer_count: metrics.rust_glancer_count,
             rust_analyzer_count: metrics.rust_analyzer_count,
             matched_count: metrics.matched_count,
+            compatible_count: metrics.compatible_count,
             missing_count: metrics.missing_count,
             extra_count: metrics.extra_count,
             match_score_percent: metrics.match_score_percent,
@@ -719,6 +736,7 @@ struct SymbolQueryReport {
     rust_glancer_count: usize,
     rust_analyzer_count: usize,
     matched_count: usize,
+    compatible_count: usize,
     missing_count: usize,
     extra_count: usize,
     rust_glancer_unmapped_count: usize,
@@ -746,6 +764,7 @@ impl From<&SymbolQueryReport> for QueryCounts {
             rust_glancer_count: report.rust_glancer_count,
             rust_analyzer_count: report.rust_analyzer_count,
             matched_count: report.matched_count,
+            compatible_count: report.compatible_count,
             missing_count: report.missing_count,
             extra_count: report.extra_count,
             match_score_percent: report.match_score_percent,
@@ -761,6 +780,7 @@ impl From<MappedSetComparisonMetrics> for SymbolQueryReport {
             rust_glancer_count: metrics.set.rust_glancer_count,
             rust_analyzer_count: metrics.set.rust_analyzer_count,
             matched_count: metrics.set.matched_count,
+            compatible_count: metrics.set.compatible_count,
             missing_count: metrics.set.missing_count,
             extra_count: metrics.set.extra_count,
             rust_glancer_unmapped_count: metrics.rust_glancer_unmapped_count,


### PR DESCRIPTION
1. Fixes some issues with compare-lsp tooling to make it both more useful and more representative.
2. Adds better support for record syntax in expressions/patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved reference discovery and rename support for record constructors across qualified, generic, enum variant, imported/aliased, and local usages.
  * Enhanced editor navigation spans for record expressions to better highlight the relevant name.
  * Comparison reporting now includes compatible matches and a clearer signal for which results contribute to equivalence scoring.
* **Bug Fixes**
  * Strengthened prepare-rename placeholder validation, including correct handling of UTF-16 selection for displayed text.
  * Improved LSP location mapping to use the editor-focused target range.
  * Refined symbol and rename comparison accuracy by treating “compatible” results separately from strict matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->