### PR TITLE
feat: Indexing and performance optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,6 +1681,7 @@ dependencies = [
  "anyhow",
  "derive_more",
  "expect-test",
+ "rayon",
  "rg_arena",
  "rg_cfg_eval",
  "rg_ir_model",
@@ -1694,6 +1695,7 @@ dependencies = [
  "rg_text",
  "rg_tt",
  "rg_workspace",
+ "rustc-hash 2.1.2",
  "test_fixture",
  "wincode",
 ]

--- a/crates/engine/body-ir/src/build/lower/mod.rs
+++ b/crates/engine/body-ir/src/build/lower/mod.rs
@@ -3,7 +3,10 @@
 //! This pass does not resolve names. It records the source shape, lexical scopes,
 //! and visibility-order binding boundaries so the later resolution pass can stay focused.
 
-use std::time::{Duration, Instant};
+use std::{
+    num::NonZeroUsize,
+    time::{Duration, Instant},
+};
 
 mod body;
 mod builder;
@@ -90,6 +93,7 @@ pub(super) fn build_packages(
     package_count: usize,
     policy: BodyIrBuildPolicy,
     interners: &mut PackageNameInterners,
+    worker_limit: Option<NonZeroUsize>,
 ) -> anyhow::Result<Vec<LoweredPackageBodies>> {
     validate_package_inputs(parse, package_count, interners)?;
 
@@ -104,6 +108,7 @@ pub(super) fn build_packages(
         interners,
         &selected,
         &mut packages,
+        worker_limit,
     )?;
 
     Ok(packages
@@ -119,6 +124,7 @@ pub(super) fn build_selected_packages(
     scope: BodyIrMaterialization<'_>,
     package_slots: &[PackageSlot],
     interners: &mut PackageNameInterners,
+    worker_limit: Option<NonZeroUsize>,
 ) -> anyhow::Result<Vec<(PackageSlot, LoweredPackageBodies)>> {
     validate_package_inputs(parse, parse.package_count(), interners)?;
     validate_selected_packages(parse.package_count(), package_slots)?;
@@ -139,6 +145,7 @@ pub(super) fn build_selected_packages(
         interners,
         &selected,
         &mut packages,
+        worker_limit,
     )?;
 
     Ok(packages
@@ -148,6 +155,7 @@ pub(super) fn build_selected_packages(
         .collect())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_package_outputs(
     parse: &ParseDb,
     def_map: &DefMapReadTxn<'_>,
@@ -156,6 +164,7 @@ fn build_package_outputs(
     interners: &mut PackageNameInterners,
     selected: &[bool],
     packages: &mut [Option<LoweredPackageBodies>],
+    worker_limit: Option<NonZeroUsize>,
 ) -> anyhow::Result<()> {
     anyhow::ensure!(
         selected.len() == parse.package_count(),
@@ -164,7 +173,7 @@ fn build_package_outputs(
         parse.package_count(),
     );
 
-    let thread_pool = local_thread_pool("rg-body-lower")?;
+    let thread_pool = local_thread_pool("rg-body-lower", worker_limit)?;
 
     // Body lowering is package-local: each worker receives one parse package, one name interner,
     // and one output slot. Non-selected rebuild slots stay absent from this temporary output.

--- a/crates/engine/body-ir/src/build/mod.rs
+++ b/crates/engine/body-ir/src/build/mod.rs
@@ -181,6 +181,27 @@ impl<'db, 'names> BodyIrDbPackageRebuilder<'db, 'names> {
     }
 
     pub fn build(self) -> anyhow::Result<BodyIrDb> {
+        self.build_with_optional_package_priority(None, &|_, _| {})
+    }
+
+    /// Build every selected package once while publishing priority packages as they resolve.
+    ///
+    /// The callback receives a compact copy. The ordinary build still retains all resolved
+    /// packages until its two-phase compaction, so publication does not change the final database
+    /// or split one build into cache-cold sub-builds.
+    pub fn build_with_package_priority(
+        self,
+        priority_packages: &(dyn Fn() -> Vec<PackageSlot> + Sync),
+        publish_priority: &(dyn Fn(PackageSlot, PackageBodies) + Sync),
+    ) -> anyhow::Result<BodyIrDb> {
+        self.build_with_optional_package_priority(Some(priority_packages), publish_priority)
+    }
+
+    fn build_with_optional_package_priority(
+        self,
+        priority_packages: Option<&(dyn Fn() -> Vec<PackageSlot> + Sync)>,
+        publish_priority: &(dyn Fn(PackageSlot, PackageBodies) + Sync),
+    ) -> anyhow::Result<BodyIrDb> {
         // 1. Start with the old snapshot so untouched package slots remain shared. The read
         // transactions may load dependencies from the bounded subset while selected packages are
         // rebuilt in memory.
@@ -222,6 +243,8 @@ impl<'db, 'names> BodyIrDbPackageRebuilder<'db, 'names> {
             self.interners,
             &def_map_txn,
             &semantic_ir_txn,
+            priority_packages,
+            publish_priority,
         )
         .context("while attempting to resolve rebuilt body IR packages")?;
         let resolution_ms = resolution_started.elapsed().as_millis();

--- a/crates/engine/body-ir/src/build/mod.rs
+++ b/crates/engine/body-ir/src/build/mod.rs
@@ -9,7 +9,7 @@ mod query_source;
 mod resolve;
 mod state;
 
-use std::time::Instant;
+use std::{num::NonZeroUsize, time::Instant};
 
 use anyhow::Context as _;
 
@@ -87,6 +87,7 @@ impl<'db, 'names> BodyIrDbBuilder<'db, 'names> {
             self.semantic_ir.package_count(),
             self.policy,
             self.interners.as_mut(),
+            None,
         )?;
         let resolved = resolve::resolve_packages(
             packages,
@@ -94,6 +95,7 @@ impl<'db, 'names> BodyIrDbBuilder<'db, 'names> {
             self.interners.as_mut(),
             &def_map_txn,
             &semantic_ir_txn,
+            None,
         )
         .context("while attempting to resolve body IR packages")?;
         let packages = compact_packages_two_phase(resolved);
@@ -132,6 +134,7 @@ pub struct BodyIrDbPackageRebuilder<'db, 'names> {
     def_map_loader: PackageLoader<'db, DefMapPackage>,
     semantic_ir_loader: PackageLoader<'db, PackageIr>,
     subset: &'db PackageSubset,
+    worker_limit: Option<NonZeroUsize>,
 }
 
 impl<'db, 'names> BodyIrDbPackageRebuilder<'db, 'names> {
@@ -160,6 +163,7 @@ impl<'db, 'names> BodyIrDbPackageRebuilder<'db, 'names> {
             def_map_loader,
             semantic_ir_loader,
             subset,
+            worker_limit: None,
         }
     }
 
@@ -177,6 +181,15 @@ impl<'db, 'names> BodyIrDbPackageRebuilder<'db, 'names> {
 
     pub fn selected_files(mut self, files: Vec<BodyIrFile>) -> Self {
         self.materialization = BodyIrMaterializationPlan::SelectedFiles(files);
+        self
+    }
+
+    /// Bounds package-level lowering and resolution pools for this build.
+    ///
+    /// `None` keeps Rayon's machine-default pool width. A limit is useful for indexing modes that
+    /// prefer lower per-worker allocation overlap over maximum package throughput.
+    pub fn worker_limit(mut self, worker_limit: Option<NonZeroUsize>) -> Self {
+        self.worker_limit = worker_limit;
         self
     }
 
@@ -230,6 +243,7 @@ impl<'db, 'names> BodyIrDbPackageRebuilder<'db, 'names> {
             materialization,
             &packages,
             self.interners,
+            self.worker_limit,
         )
         .context("while attempting to lower rebuilt body IR packages")?;
         let lowering_ms = lowering_started.elapsed().as_millis();
@@ -245,6 +259,7 @@ impl<'db, 'names> BodyIrDbPackageRebuilder<'db, 'names> {
             &semantic_ir_txn,
             priority_packages,
             publish_priority,
+            self.worker_limit,
         )
         .context("while attempting to resolve rebuilt body IR packages")?;
         let resolution_ms = resolution_started.elapsed().as_millis();
@@ -272,6 +287,7 @@ impl<'db, 'names> BodyIrDbPackageRebuilder<'db, 'names> {
         tracing::trace!(
             ?materialization,
             package_count = packages.len(),
+            worker_limit = self.worker_limit.map(NonZeroUsize::get),
             clone_ms,
             setup_ms,
             lowering_ms,
@@ -316,9 +332,21 @@ fn compact_package_copy(package: &PackageBodies) -> PackageBodies {
     compacted
 }
 
-fn local_thread_pool(thread_name_prefix: &'static str) -> anyhow::Result<rayon::ThreadPool> {
-    rayon::ThreadPoolBuilder::new()
-        .thread_name(move |index| format!("{thread_name_prefix}-{index}"))
+fn local_thread_pool(
+    thread_name_prefix: &'static str,
+    worker_limit: Option<NonZeroUsize>,
+) -> anyhow::Result<rayon::ThreadPool> {
+    let mut builder = rayon::ThreadPoolBuilder::new()
+        .thread_name(move |index| format!("{thread_name_prefix}-{index}"));
+    if let Some(worker_limit) = worker_limit {
+        let worker_count = std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(worker_limit.get())
+            .min(worker_limit.get());
+        builder = builder.num_threads(worker_count);
+    }
+
+    builder
         .build()
         .with_context(|| format!("while attempting to create {thread_name_prefix} thread pool"))
 }
@@ -328,4 +356,25 @@ fn normalized_package_slots(packages: &[PackageSlot]) -> Vec<PackageSlot> {
     slots.sort_by_key(|slot| slot.0);
     slots.dedup();
     slots
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use super::local_thread_pool;
+
+    #[test]
+    fn body_ir_thread_pool_honors_worker_limit() {
+        let worker_limit = NonZeroUsize::new(2).expect("test worker limit should be non-zero");
+        let expected_workers = std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(worker_limit.get())
+            .min(worker_limit.get());
+
+        let thread_pool = local_thread_pool("rg-body-test", Some(worker_limit))
+            .expect("limited Body IR thread pool should build");
+
+        assert_eq!(thread_pool.current_num_threads(), expected_workers);
+    }
 }

--- a/crates/engine/body-ir/src/build/resolve.rs
+++ b/crates/engine/body-ir/src/build/resolve.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::{BTreeSet, VecDeque},
+    num::NonZeroUsize,
     sync::Mutex,
     time::{Duration, Instant},
 };
@@ -34,10 +35,11 @@ pub(super) fn resolve_packages(
     interners: &mut PackageNameInterners,
     def_map: &DefMapReadTxn<'_>,
     semantic_ir: &SemanticIrReadTxn<'_>,
+    worker_limit: Option<NonZeroUsize>,
 ) -> anyhow::Result<Vec<PackageBodies>> {
     let profile_context = rg_profile::ProfileThreadContext::capture();
     let declarations = TraitSelectionDeclarationCache::new();
-    let thread_pool = local_thread_pool("rg-body-resolve")?;
+    let thread_pool = local_thread_pool("rg-body-resolve", worker_limit)?;
     let resolved = thread_pool
         .install(|| {
             packages
@@ -69,6 +71,7 @@ pub(super) fn resolve_packages(
 /// workers can then touch the same interner, so package resolution needs no extra synchronization.
 /// The jobs also share canonical crate declaration lowering, while keeping their visibility and
 /// solver state inside the corresponding crate session.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn resolve_selected_packages(
     packages: Vec<(PackageSlot, LoweredPackageBodies)>,
     parse: &rg_parse::ParseDb,
@@ -77,6 +80,7 @@ pub(super) fn resolve_selected_packages(
     semantic_ir: &SemanticIrReadTxn<'_>,
     priority_packages: Option<&(dyn Fn() -> Vec<PackageSlot> + Sync)>,
     publish_priority: &(dyn Fn(PackageSlot, PackageBodies) + Sync),
+    worker_limit: Option<NonZeroUsize>,
 ) -> anyhow::Result<Vec<(PackageSlot, PackageBodies)>> {
     let profile_context = rg_profile::ProfileThreadContext::capture();
     let declarations = TraitSelectionDeclarationCache::new();
@@ -116,7 +120,7 @@ pub(super) fn resolve_selected_packages(
         next_package_idx = package_slot.0 + 1;
     }
 
-    let thread_pool = local_thread_pool("rg-body-resolve")?;
+    let thread_pool = local_thread_pool("rg-body-resolve", worker_limit)?;
     let Some(priority_packages) = priority_packages else {
         let resolved = thread_pool
             .install(|| {

--- a/crates/engine/body-ir/src/build/resolve.rs
+++ b/crates/engine/body-ir/src/build/resolve.rs
@@ -1,12 +1,17 @@
 //! Resolves lowered Body IR while a build mutator has privileged package access.
 
-use std::time::{Duration, Instant};
+use std::{
+    collections::{BTreeSet, VecDeque},
+    sync::Mutex,
+    time::{Duration, Instant},
+};
 
 use anyhow::Context as _;
 use rayon::prelude::*;
 use rg_def_map::{DefMapReadTxn, PackageSlot};
 use rg_ir_model::{CrateId, CrateRef};
 use rg_semantic_ir::SemanticIrReadTxn;
+use rg_std::Shrink;
 use rg_text::{NameInterner, PackageNameInterners};
 
 use crate::{CrateBodies, PackageBodies};
@@ -60,6 +65,8 @@ pub(super) fn resolve_selected_packages(
     interners: &mut PackageNameInterners,
     def_map: &DefMapReadTxn<'_>,
     semantic_ir: &SemanticIrReadTxn<'_>,
+    priority_packages: Option<&(dyn Fn() -> Vec<PackageSlot> + Sync)>,
+    publish_priority: &(dyn Fn(PackageSlot, PackageBodies) + Sync),
 ) -> anyhow::Result<Vec<(PackageSlot, PackageBodies)>> {
     let profile_context = rg_profile::ProfileThreadContext::capture();
     // Selected rebuilds are sparse, but resolution may discover nested bodies and lower them,
@@ -98,28 +105,141 @@ pub(super) fn resolve_selected_packages(
         next_package_idx = package_slot.0 + 1;
     }
 
-    // Every job now has exclusive access to one interner, so resolution can run in parallel.
     let thread_pool = local_thread_pool("rg-body-resolve")?;
-    let resolved = thread_pool
-        .install(|| {
-            jobs.into_par_iter()
-                .map(|(package_slot, parse_package, package, interner)| {
-                    let _profile_guard = profile_context.enter();
-                    let package = resolve_package(
-                        package_slot,
-                        parse_package,
-                        package,
-                        interner,
-                        def_map,
-                        semantic_ir,
-                    )?;
-                    Ok((package_slot, package))
-                })
-                .collect::<anyhow::Result<Vec<_>>>()
-        })
-        .context("while attempting to resolve selected body IR packages")?;
+    let Some(priority_packages) = priority_packages else {
+        let resolved = thread_pool
+            .install(|| {
+                jobs.into_par_iter()
+                    .map(|(package_slot, parse_package, package, interner)| {
+                        let _profile_guard = profile_context.enter();
+                        let package = resolve_package(
+                            package_slot,
+                            parse_package,
+                            package,
+                            interner,
+                            def_map,
+                            semantic_ir,
+                        )?;
+                        Ok((package_slot, package))
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()
+            })
+            .context("while attempting to resolve selected body IR packages")?;
+        return Ok(resolved);
+    };
+
+    // Rayon normally commits the entire indexed iterator to its work-stealing queues up front.
+    // Keep package jobs in this small shared queue instead so a didOpen arriving during resolution
+    // can move its package ahead of work that has not started yet. Workers hold the lock only while
+    // selecting a package; resolution itself remains fully parallel.
+    let job_count = jobs.len();
+    let jobs = Mutex::new(VecDeque::from(jobs));
+    let resolved = Mutex::new(Vec::with_capacity(job_count));
+    let worker_count = thread_pool.current_num_threads().min(job_count);
+    thread_pool.scope(|scope| {
+        for _ in 0..worker_count {
+            scope.spawn(|_| {
+                loop {
+                    let priorities = priority_packages().into_iter().collect::<BTreeSet<_>>();
+                    ResolvedPackage::publish_resolved_priorities(
+                        &resolved,
+                        &priorities,
+                        publish_priority,
+                    );
+
+                    let job = {
+                        let mut jobs = jobs
+                            .lock()
+                            .expect("Body IR package resolution queue should not be poisoned");
+                        let job_idx = jobs
+                            .iter()
+                            .position(|(package, _, _, _)| priorities.contains(package))
+                            .unwrap_or(0);
+                        jobs.remove(job_idx)
+                    };
+                    let Some((package_slot, parse_package, package, interner)) = job else {
+                        break;
+                    };
+
+                    let result = (|| {
+                        let _profile_guard = profile_context.enter();
+                        let package = resolve_package(
+                            package_slot,
+                            parse_package,
+                            package,
+                            interner,
+                            def_map,
+                            semantic_ir,
+                        )?;
+                        Ok(ResolvedPackage {
+                            package: package_slot,
+                            bodies: package,
+                            priority_published: false,
+                        })
+                    })();
+                    resolved
+                        .lock()
+                        .expect("Body IR package resolution results should not be poisoned")
+                        .push(result);
+                }
+            });
+        }
+    });
+
+    // Capture a priority update that raced with the last worker returning. If it arrived any later,
+    // the complete result is already about to be published through the ordinary final path.
+    let priorities = priority_packages().into_iter().collect::<BTreeSet<_>>();
+    ResolvedPackage::publish_resolved_priorities(&resolved, &priorities, publish_priority);
+    let mut resolved = resolved
+        .into_inner()
+        .expect("Body IR package resolution results should not be poisoned")
+        .into_iter()
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .map(|resolved| (resolved.package, resolved.bodies))
+        .collect::<Vec<_>>();
+    resolved.sort_by_key(|(package, _)| package.0);
 
     Ok(resolved)
+}
+
+#[derive(Debug)]
+struct ResolvedPackage {
+    package: PackageSlot,
+    bodies: PackageBodies,
+    priority_published: bool,
+}
+
+impl ResolvedPackage {
+    /// Publish compact copies for packages that became editor priorities after resolving.
+    fn publish_resolved_priorities(
+        resolved: &Mutex<Vec<anyhow::Result<Self>>>,
+        priorities: &BTreeSet<PackageSlot>,
+        publish_priority: &(dyn Fn(PackageSlot, PackageBodies) + Sync),
+    ) {
+        let publications = {
+            let mut resolved = resolved
+                .lock()
+                .expect("Body IR package resolution results should not be poisoned");
+            resolved
+                .iter_mut()
+                .filter_map(|resolved| resolved.as_mut().ok())
+                .filter(|resolved| {
+                    !resolved.priority_published && priorities.contains(&resolved.package)
+                })
+                .map(|resolved| {
+                    resolved.priority_published = true;
+                    let mut publishable = resolved.bodies.clone();
+                    Shrink::shrink_to_fit(&mut publishable);
+                    (resolved.package, publishable)
+                })
+                .collect::<Vec<_>>()
+        };
+
+        for (package, bodies) in publications {
+            publish_priority(package, bodies);
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/engine/body-ir/src/build/resolve.rs
+++ b/crates/engine/body-ir/src/build/resolve.rs
@@ -13,6 +13,7 @@ use rg_ir_model::{CrateId, CrateRef};
 use rg_semantic_ir::SemanticIrReadTxn;
 use rg_std::Shrink;
 use rg_text::{NameInterner, PackageNameInterners};
+use rg_ty::TraitSelectionDeclarationCache;
 
 use crate::{CrateBodies, PackageBodies};
 
@@ -22,6 +23,11 @@ use super::{local_thread_pool, lower::LoweredPackageBodies, state::CrateBodyBuil
 // normal scheduling variance.
 const SLOW_PACKAGE_RESOLUTION: Duration = Duration::from_secs(2);
 
+/// Resolve all materialized packages against one semantic snapshot.
+///
+/// Each crate still needs its own trait-selection session because impl visibility and solver
+/// answers depend on the use-site crate. Canonical crate declaration shapes do not, so package
+/// workers share one build-scoped declaration cache.
 pub(super) fn resolve_packages(
     packages: Vec<LoweredPackageBodies>,
     parse: &rg_parse::ParseDb,
@@ -30,6 +36,7 @@ pub(super) fn resolve_packages(
     semantic_ir: &SemanticIrReadTxn<'_>,
 ) -> anyhow::Result<Vec<PackageBodies>> {
     let profile_context = rg_profile::ProfileThreadContext::capture();
+    let declarations = TraitSelectionDeclarationCache::new();
     let thread_pool = local_thread_pool("rg-body-resolve")?;
     let resolved = thread_pool
         .install(|| {
@@ -47,6 +54,7 @@ pub(super) fn resolve_packages(
                         interner,
                         def_map,
                         semantic_ir,
+                        &declarations,
                     )
                 })
                 .collect::<anyhow::Result<Vec<_>>>()
@@ -59,6 +67,8 @@ pub(super) fn resolve_packages(
 ///
 /// Before starting Rayon jobs, give each package mutable access to its own name interner. No two
 /// workers can then touch the same interner, so package resolution needs no extra synchronization.
+/// The jobs also share canonical crate declaration lowering, while keeping their visibility and
+/// solver state inside the corresponding crate session.
 pub(super) fn resolve_selected_packages(
     packages: Vec<(PackageSlot, LoweredPackageBodies)>,
     parse: &rg_parse::ParseDb,
@@ -69,6 +79,7 @@ pub(super) fn resolve_selected_packages(
     publish_priority: &(dyn Fn(PackageSlot, PackageBodies) + Sync),
 ) -> anyhow::Result<Vec<(PackageSlot, PackageBodies)>> {
     let profile_context = rg_profile::ProfileThreadContext::capture();
+    let declarations = TraitSelectionDeclarationCache::new();
     // Selected rebuilds are sparse, but resolution may discover nested bodies and lower them,
     // which needs mutable access to the matching package name interner. The rebuilder normalizes
     // package slots, so walking the interner slice left-to-right lets us prepare disjoint jobs that
@@ -119,6 +130,7 @@ pub(super) fn resolve_selected_packages(
                             interner,
                             def_map,
                             semantic_ir,
+                            &declarations,
                         )?;
                         Ok((package_slot, package))
                     })
@@ -170,6 +182,7 @@ pub(super) fn resolve_selected_packages(
                             interner,
                             def_map,
                             semantic_ir,
+                            &declarations,
                         )?;
                         Ok(ResolvedPackage {
                             package: package_slot,
@@ -250,6 +263,7 @@ fn resolve_package(
     interner: &mut NameInterner,
     def_map_txn: &DefMapReadTxn<'_>,
     semantic_ir: &SemanticIrReadTxn<'_>,
+    declarations: &TraitSelectionDeclarationCache,
 ) -> anyhow::Result<PackageBodies> {
     let crate_count = package.len();
     let span = tracing::debug_span!(
@@ -274,8 +288,11 @@ fn resolve_package(
                 crate_id: CrateId(crate_idx),
             };
 
-            CrateBodyBuildState::new(crate_ref, parse_package, crate_bodies, interner)
-                .resolve(def_map_txn, semantic_ir)
+            CrateBodyBuildState::new(crate_ref, parse_package, crate_bodies, interner).resolve(
+                def_map_txn,
+                semantic_ir,
+                declarations,
+            )
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
 

--- a/crates/engine/body-ir/src/build/state.rs
+++ b/crates/engine/body-ir/src/build/state.rs
@@ -17,7 +17,7 @@ use rg_semantic_ir::{
 };
 use rg_std::ExpectedUnique;
 use rg_text::NameInterner;
-use rg_ty::TraitSelectionSession;
+use rg_ty::{TraitSelectionDeclarationCache, TraitSelectionSession};
 
 use crate::{
     BodyFacts, BodyLocalItems, BodyOwner, CrateBodies, CurrentBody,
@@ -142,10 +142,15 @@ impl<'crate_data> CrateBodyBuildState<'crate_data> {
     }
 
     /// Resolve one lowered crate and persist its crate-wide item lookup index with Body IR.
+    ///
+    /// The crate gets its own use-site visibility, candidate indexes, and solver answers. Only
+    /// canonical crate declarations are reused from the cache owned by the surrounding project
+    /// build.
     pub(super) fn resolve(
         mut self,
         def_map: &DefMapReadTxn<'_>,
         semantic_ir: &SemanticIrReadTxn<'_>,
+        declarations: &TraitSelectionDeclarationCache,
     ) -> anyhow::Result<CrateBodies> {
         let span = tracing::debug_span!(
             "body_ir_crate_resolution",
@@ -196,7 +201,8 @@ impl<'crate_data> CrateBodyBuildState<'crate_data> {
                 "slow Body IR crate resolution phase"
             );
         }
-        let trait_selection = TraitSelectionSession::new(self.crate_ref);
+        let trait_selection =
+            TraitSelectionSession::new_with_declaration_cache(self.crate_ref, declarations.clone());
         let semantic_timings = self.resolve_semantics(
             def_map,
             semantic_ir,

--- a/crates/engine/body-ir/src/resolution/query/associated_item.rs
+++ b/crates/engine/body-ir/src/resolution/query/associated_item.rs
@@ -505,9 +505,7 @@ where
         let semantic_trait_impls = self
             .context
             .item_lookup_index()
-            .trait_impls_for_type(ty.def)
-            .cloned()
-            .unwrap_or_default();
+            .trait_impls_for_type(ty.def);
         self.push_trait_associated_const_candidates_for_impls(
             &mut items,
             semantic_trait_impls,

--- a/crates/engine/body-ir/src/resolution/query/traits.rs
+++ b/crates/engine/body-ir/src/resolution/query/traits.rs
@@ -149,9 +149,7 @@ where
             let semantic_impls = self
                 .context
                 .item_lookup_index()
-                .trait_impls_for_type(ty.def)
-                .cloned()
-                .unwrap_or_default();
+                .trait_impls_for_type(ty.def);
             self.push_matching_qualified_trait_impls(&mut impls, semantic_impls, ty, application)?;
         }
 

--- a/crates/engine/body-ir/src/store/db.rs
+++ b/crates/engine/body-ir/src/store/db.rs
@@ -126,6 +126,16 @@ impl BodyIrDb {
             .and_then(|entry| entry.as_resident())
     }
 
+    /// Returns whether one package slot exists but its Body IR payload is not resident.
+    ///
+    /// This distinguishes a deliberately lazy slot from an invalid slot; [`Self::resident_package`]
+    /// returns `None` for both.
+    pub fn package_is_offloaded(&self, package: PackageSlot) -> bool {
+        self.packages
+            .raw_entry(package)
+            .is_some_and(|entry| entry.is_offloaded())
+    }
+
     /// Replaces one package payload while preserving the surrounding package-store shape.
     ///
     /// This is used by project-level monotonic Body IR merges, where a background completion

--- a/crates/engine/def-map/Cargo.toml
+++ b/crates/engine/def-map/Cargo.toml
@@ -12,6 +12,8 @@ description.workspace = true
 [dependencies]
 anyhow.workspace = true
 derive_more = { workspace = true, features = ["display"] }
+rayon.workspace = true
+rustc-hash.workspace = true
 wincode.workspace = true
 rg_arena.workspace = true
 rg_cfg_eval.workspace = true

--- a/crates/engine/def-map/src/build/finalize/mod.rs
+++ b/crates/engine/def-map/src/build/finalize/mod.rs
@@ -10,6 +10,7 @@ mod clean;
 mod rebuild;
 
 use anyhow::Context as _;
+use rayon::prelude::*;
 
 use crate::{
     CrateData, CrateResolutionEnv, LocalDefData, LocalEnumVariantData, LocalEnumVariantEntry,
@@ -48,6 +49,10 @@ type CrateScopeMatrix = Vec<ModuleScopeBuilder>;
 
 /// Mutable module scopes for every crate inside one package.
 type PackageScopeMatrix = Vec<CrateScopeMatrix>;
+
+// Below this size, dispatching packages through a worker pool costs more than the import work.
+const PARALLEL_IMPORT_RESOLUTION_PACKAGE_THRESHOLD: usize = 32;
+const LOWER_PEAK_MEMORY_IMPORT_RESOLUTION_THREAD_LIMIT: usize = 2;
 
 /// Collected crate states that must be finalized.
 ///
@@ -239,6 +244,110 @@ impl ScopeMatrix {
                     });
             }
         }
+    }
+}
+
+/// Owns the worker pool used to apply imports for large package sets.
+///
+/// One fixed-point pass reads only from the immutable previous `ScopeMatrix`, while each dirty
+/// package writes to its own part of the next matrix. That makes package-level work independent;
+/// fixed-point passes themselves remain serial so later passes observe a complete snapshot. The
+/// pool is local to finalization, so its worker threads do not become retained LSP state.
+struct ImportResolutionExecutor {
+    performance_preference: MacroExpansionPerformancePreference,
+    thread_pool: Option<rayon::ThreadPool>,
+}
+
+impl ImportResolutionExecutor {
+    fn new(performance_preference: MacroExpansionPerformancePreference) -> Self {
+        Self {
+            performance_preference,
+            thread_pool: None,
+        }
+    }
+
+    /// Apply one complete import pass, using parallel package jobs only when there is enough work.
+    fn apply_pass(
+        &mut self,
+        states: &FinalizeCrateStates,
+        env: &FinalizeResolutionEnv<'_>,
+        next_scopes: &mut ScopeMatrix,
+    ) -> anyhow::Result<()> {
+        let apply_package = |(next_package, package_states): (
+            &mut Option<PackageScopeMatrix>,
+            &Option<PackageCrateStates>,
+        )|
+         -> anyhow::Result<()> {
+            let (Some(next_package), Some(package_states)) =
+                (next_package.as_mut(), package_states.as_ref())
+            else {
+                assert!(
+                    next_package.is_none() && package_states.is_none(),
+                    "scope and crate-state package slots should match"
+                );
+                return Ok(());
+            };
+            assert_eq!(
+                next_package.len(),
+                package_states.len(),
+                "scope and crate-state crate slots should match"
+            );
+
+            for (next_crate, state) in next_package.iter_mut().zip(package_states) {
+                apply_imports(state, env, next_crate).with_context(|| {
+                    format!(
+                        "while attempting to resolve imports for {}",
+                        state.crate_name
+                    )
+                })?;
+            }
+
+            Ok(())
+        };
+
+        let dirty_package_count = states.iter_dirty().count();
+        if dirty_package_count < PARALLEL_IMPORT_RESOLUTION_PACKAGE_THRESHOLD {
+            return next_scopes
+                .packages
+                .iter_mut()
+                .zip(&states.packages)
+                .try_for_each(apply_package);
+        }
+
+        self.thread_pool()?.install(|| {
+            next_scopes
+                .packages
+                .par_iter_mut()
+                .zip(states.packages.par_iter())
+                .try_for_each(apply_package)
+        })
+    }
+
+    fn thread_pool(&mut self) -> anyhow::Result<&rayon::ThreadPool> {
+        if self.thread_pool.is_none() {
+            let mut builder = rayon::ThreadPoolBuilder::new()
+                .thread_name(|index| format!("rg-def-map-imports-{index}"));
+            if self.performance_preference == MacroExpansionPerformancePreference::LowerPeakMemory {
+                // Import jobs are smaller than macro expansion jobs, but their transient scope
+                // tables still multiply with worker count. Honor the same build preference here.
+                let worker_count = std::thread::available_parallelism()
+                    .map(usize::from)
+                    .unwrap_or(LOWER_PEAK_MEMORY_IMPORT_RESOLUTION_THREAD_LIMIT)
+                    .min(LOWER_PEAK_MEMORY_IMPORT_RESOLUTION_THREAD_LIMIT);
+                builder = builder.num_threads(worker_count);
+            }
+
+            self.thread_pool = Some(
+                builder
+                    .build()
+                    .context("while attempting to create import resolution thread pool")?,
+            );
+        }
+
+        Ok(self
+            .thread_pool
+            .as_ref()
+            .expect("import resolution thread pool should be initialized"))
     }
 }
 
@@ -680,6 +789,7 @@ fn finalize_scopes(
     performance_preference: MacroExpansionPerformancePreference,
 ) -> anyhow::Result<()> {
     let mut macro_runtime = MacroExpansionRuntime::new(performance_preference);
+    let mut import_executor = ImportResolutionExecutor::new(performance_preference);
     let mut expansion_passes = 0;
     metric::EXPANSION_PASS_LIMIT.record_count(MAX_MACRO_EXPANSION_PASSES);
 
@@ -690,7 +800,7 @@ fn finalize_scopes(
         // includes items generated by earlier macro rounds, because those items were written back
         // into `states` before the next round begins.
         let timer = metric::TIMING_RESOLVE_IMPORT_SCOPES.start_timer();
-        let mut current_scopes = resolve_import_scopes(old, states)?;
+        let mut current_scopes = resolve_import_scopes(old, states, &mut import_executor)?;
         timer.finish();
 
         // Macro expansion can introduce more macro calls that are visible in the same scope
@@ -703,7 +813,7 @@ fn finalize_scopes(
                 // names generated before the cap settle into module scopes.
                 mark_retryable_macros_skipped_by_limit(states);
                 let timer = metric::TIMING_RESOLVE_IMPORT_SCOPES.start_timer();
-                current_scopes = resolve_import_scopes(old, states)?;
+                current_scopes = resolve_import_scopes(old, states, &mut import_executor)?;
                 timer.finish();
                 freeze_resolved_scopes(old, states, current_scopes)?;
                 return Ok(());
@@ -779,25 +889,19 @@ fn finalize_scopes(
 fn resolve_import_scopes(
     old: Option<&DefMapReadTxn<'_>>,
     states: &FinalizeCrateStates,
+    executor: &mut ImportResolutionExecutor,
 ) -> anyhow::Result<ScopeMatrix> {
+    metric::IMPORT_RESOLUTION_RUNS.inc();
     let mut current_scopes = states.base_scopes();
 
     loop {
+        metric::IMPORT_RESOLUTION_PASSES.inc();
         let mut next_scopes = states.base_scopes();
 
         // Every iteration starts from the directly declared names, then layers import-derived
         // bindings on top of that snapshot.
         let env = FinalizeResolutionEnv::new(old, states, &current_scopes);
-        for package_states in states.iter_dirty() {
-            for state in package_states {
-                apply_imports(state, &env, &mut next_scopes).with_context(|| {
-                    format!(
-                        "while attempting to resolve imports for {}",
-                        state.crate_name
-                    )
-                })?;
-            }
-        }
+        executor.apply_pass(states, &env, &mut next_scopes)?;
         next_scopes.censor_proc_macro_exports(states);
 
         if next_scopes == current_scopes {

--- a/crates/engine/def-map/src/build/imports.rs
+++ b/crates/engine/def-map/src/build/imports.rs
@@ -5,13 +5,10 @@
 //! fixed-point snapshot, then uses the same result shape to record imports that remain unresolved
 //! after the scopes stop changing.
 
-use crate::{CrateResolutionEnv, ScopeResolver};
+use crate::{CrateResolutionEnv, ModuleScopeBuilder, ScopeResolver};
 use rg_ir_model::{CrateRef, DefMapRef, ImportId, ImportRef, ModuleRef};
 
-use super::{
-    collect::CrateState,
-    finalize::{FinalizeCrateStates, ScopeMatrix},
-};
+use super::{collect::CrateState, finalize::FinalizeCrateStates};
 
 /// Unresolved import ids for one module.
 type ModuleUnresolvedImports = Vec<ImportId>;
@@ -68,7 +65,7 @@ impl UnresolvedImports {
 pub(super) fn apply_imports(
     state: &CrateState,
     env: &impl CrateResolutionEnv<Error = rg_package_store::PackageStoreError>,
-    next_scopes: &mut ScopeMatrix,
+    next_scopes: &mut [ModuleScopeBuilder],
 ) -> anyhow::Result<()> {
     let resolver = ScopeResolver::new(env);
     for (import_id, import) in state.def_map_builder.partial().imports_with_ids() {
@@ -79,7 +76,7 @@ pub(super) fn apply_imports(
         };
         let resolution = resolver.resolve_import(import_owner, import_ref, import)?;
         let target_scope = next_scopes
-            .module_scope_mut(state.crate_ref, import.module)
+            .get_mut(import.module.0)
             .expect("crate scope should exist for every import");
         for introduced in resolution.introduced {
             target_scope.insert_binding(&introduced.name, introduced.namespace, introduced.binding);

--- a/crates/engine/def-map/src/profile.rs
+++ b/crates/engine/def-map/src/profile.rs
@@ -16,6 +16,10 @@ declare_metrics! {
         scope "def_map.finalization" {
             /// Number of fixpoint rounds required to finalize all def maps.
             counter ROUNDS = "rounds";
+            /// Number of complete import fixed-point runs.
+            counter IMPORT_RESOLUTION_RUNS = "import_resolution.runs";
+            /// Number of scope snapshots evaluated across all import fixed-point runs.
+            counter IMPORT_RESOLUTION_PASSES = "import_resolution.passes";
             /// Number of macro-expansion passes performed during finalization.
             counter EXPANSION_PASSES = "expansion_passes";
             /// Maximum number of macro-expansion passes allowed for one finalization run.

--- a/crates/engine/def-map/src/scope.rs
+++ b/crates/engine/def-map/src/scope.rs
@@ -5,12 +5,13 @@
 //! merges multiple routes to the same definition. Frozen scopes retain that decision so queries do
 //! not have to reconstruct precedence from a list of candidates.
 
-use std::{cmp::Ordering, collections::HashMap};
+use std::cmp::Ordering;
 
 use rg_ir_model::{DefId, ImportRef, ModuleRef};
 use rg_item_tree::FieldList;
 use rg_std::{MemorySize, Shrink};
 use rg_text::Name;
+use rustc_hash::FxHashMap;
 use wincode::{SchemaRead, SchemaWrite};
 
 /// The three independent meaning slots represented by a DefMap scope.
@@ -392,7 +393,7 @@ pub(crate) struct ScopeNameEntry {
 /// Mutable module scope used while collecting declarations and applying imports.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ModuleScopeBuilder {
-    names: HashMap<Name, ScopeEntryBuilder>,
+    names: FxHashMap<Name, ScopeEntryBuilder>,
 }
 
 impl ModuleScopeBuilder {

--- a/crates/engine/project/src/indexing.rs
+++ b/crates/engine/project/src/indexing.rs
@@ -1,6 +1,10 @@
 //! User-facing indexing trade-offs passed down to build phases.
 
+use std::num::NonZeroUsize;
+
 use rg_def_map::MacroExpansionPerformancePreference;
+
+const LOWER_PEAK_MEMORY_BODY_IR_WORKER_LIMIT: usize = 4;
 
 /// High-level indexing preference selected by users or frontends.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -34,6 +38,19 @@ impl IndexingPerformancePreference {
         match self {
             Self::LowerPeakMemory => MacroExpansionPerformancePreference::LowerPeakMemory,
             Self::FasterBuilds => MacroExpansionPerformancePreference::FasterBuilds,
+        }
+    }
+
+    /// Body IR package workers retain sizeable lowering and resolution temporaries concurrently.
+    /// Four workers preserve useful package parallelism without multiplying those allocations by
+    /// the full machine width.
+    pub(crate) fn body_ir_worker_limit(self) -> Option<NonZeroUsize> {
+        match self {
+            Self::LowerPeakMemory => Some(
+                NonZeroUsize::new(LOWER_PEAK_MEMORY_BODY_IR_WORKER_LIMIT)
+                    .expect("lower-peak-memory Body IR worker limit should be non-zero"),
+            ),
+            Self::FasterBuilds => None,
         }
     }
 }
@@ -71,6 +88,20 @@ mod tests {
         assert_eq!(
             IndexingPerformancePreference::default(),
             IndexingPerformancePreference::FasterBuilds,
+        );
+    }
+
+    #[test]
+    fn lower_peak_memory_limits_body_ir_to_four_workers() {
+        assert_eq!(
+            IndexingPerformancePreference::LowerPeakMemory
+                .body_ir_worker_limit()
+                .map(std::num::NonZeroUsize::get),
+            Some(4),
+        );
+        assert_eq!(
+            IndexingPerformancePreference::FasterBuilds.body_ir_worker_limit(),
+            None,
         );
     }
 }

--- a/crates/engine/project/src/project/build/phases.rs
+++ b/crates/engine/project/src/project/build/phases.rs
@@ -224,16 +224,18 @@ pub(super) fn build(
     // ----------------
     let baseline_body_ir =
         BodyIrDb::from_package_store(offloaded_package_store(parse.package_count()));
-    let mut body_rebuilder = baseline_body_ir.package_rebuilder(
-        &parse,
-        &def_map,
-        &semantic_ir,
-        build_plan.source_packages.as_slice(),
-        &mut names,
-        loaders.def_map,
-        loaders.semantic_ir,
-        &rebuild_subset,
-    );
+    let mut body_rebuilder = baseline_body_ir
+        .package_rebuilder(
+            &parse,
+            &def_map,
+            &semantic_ir,
+            build_plan.source_packages.as_slice(),
+            &mut names,
+            loaders.def_map,
+            loaders.semantic_ir,
+            &rebuild_subset,
+        )
+        .worker_limit(indexing_preference.body_ir_worker_limit());
     body_rebuilder = match split_indexing_mode {
         SplitIndexingMode::Full => body_rebuilder.configured_bodies(body_ir_policy),
         SplitIndexingMode::EarlyStart => body_rebuilder.coverage_only(body_ir_policy),

--- a/crates/engine/project/src/project/mod.rs
+++ b/crates/engine/project/src/project/mod.rs
@@ -74,6 +74,11 @@ impl Project {
         self.state.workspace()
     }
 
+    /// Return package slots whose parsed source inventory contains this path.
+    pub fn package_slots_for_path(&self, path: &Path) -> anyhow::Result<Vec<PackageSlot>> {
+        split_indexing::package_slots_for_path(&self.state, path)
+    }
+
     /// Returns package residency decisions for this project.
     pub fn package_residency_plan(&self) -> &PackageResidencyPlan {
         self.state.package_residency_plan()
@@ -167,8 +172,8 @@ impl Project {
     /// Early-start indexing lets the saved project become queryable while deferred payloads are
     /// still missing. Background completion must run on a clone so it cannot block the command
     /// loop, but callers should not receive that clone as a general-purpose `Project`. Returning a
-    /// narrow handle keeps the only supported detached operation explicit: finish deferred indexing
-    /// and later merge the result back into saved state.
+    /// narrow handle keeps the only supported detached operation explicit: finish deferred indexing,
+    /// publish priority packages early, and return the final result to saved state.
     //
     // TODO: Make project snapshots cheap to detach, especially parse state, so background
     // completion does not have to clone large parse arenas on the caller thread.

--- a/crates/engine/project/src/project/split_indexing.rs
+++ b/crates/engine/project/src/project/split_indexing.rs
@@ -12,7 +12,7 @@
 //! - `materialize` makes the analysis surface needed by one query available, such as one file for
 //!   hover or a mix of files and crates for reference search.
 //! - `DetachedSplitIndexing` and `merge_finished` let an LSP background clone finish deferred
-//!   payloads and merge package-wise improvements back into the saved project.
+//!   payloads, publish priority packages early, and merge those improvements into the saved project.
 //!
 //! That last path has to be monotonic. Query-time materialization may finish a package before the
 //! background clone finishes, so a stale background result must not replace better saved coverage
@@ -61,13 +61,13 @@ pub enum AnalysisSurface<'a> {
 ///
 /// - `materialize` is the on-demand path. It prepares exactly the source surface a query needs
 ///   before that query runs, so reference search and rename do not miss body-local uses.
-/// - `finish` is the background or batch path. It completes the remaining deferred payloads chosen
-///   by the project's configured indexing policy and then reapplies package residency.
+/// - `finish` is the background path. It completes the remaining deferred payloads chosen by the
+///   project's configured indexing policy and then reapplies package residency.
 ///
 /// Detached finishing uses the same policy, but runs through `DetachedSplitIndexing` so callers
 /// cannot accidentally treat a project clone as an ordinary live project. The clone stays hidden
-/// behind that capability until it becomes `FinishedSplitIndexing` and can be merged back into the
-/// saved project.
+/// behind that capability while `FinishedSplitIndexing` package improvements are published back
+/// into the saved project.
 pub struct SplitIndexing<'project> {
     project: &'project mut Project,
 }
@@ -140,21 +140,90 @@ impl DetachedSplitIndexing {
         Self { project }
     }
 
-    /// Finish deferred indexing inside the detached project clone.
+    /// Return the packages still selected by the configured deferred-indexing policy.
+    pub fn unfinished_packages(&self) -> Vec<PackageSlot> {
+        unfinished_split_indexing_packages(&self.project.state)
+    }
+
+    /// Return package slots whose parsed source inventory contains this path.
+    ///
+    /// Editor paths do not have to use the same spelling as Cargo metadata paths, so the lookup
+    /// canonicalizes before consulting the detached project's package-local file tables.
+    pub fn package_slots_for_path(
+        &self,
+        path: &std::path::Path,
+    ) -> anyhow::Result<Vec<PackageSlot>> {
+        package_slots_for_path(&self.project.state, path)
+    }
+
+    /// Finish all deferred work while publishing priority packages as soon as they resolve.
+    ///
+    /// Every package still belongs to one Body IR build. The callback is an early copy-out point,
+    /// not another build boundary, so the remaining background work keeps its ordinary parallel
+    /// scheduling and shared read transactions.
+    pub fn finish_with_package_priority(
+        self,
+        priority_packages: impl Fn() -> Vec<PackageSlot> + Sync,
+        publish_priority: impl Fn(FinishedSplitIndexing) + Sync,
+    ) -> anyhow::Result<FinishedSplitIndexing> {
+        self.finish_with_optional_package_priority(Some(&priority_packages), &publish_priority)
+    }
+
+    /// Finish every remaining package inside the detached project clone.
     pub fn finish(self) -> anyhow::Result<FinishedSplitIndexing> {
-        finish_detached_project(self.project)
+        self.finish_with_optional_package_priority(None, &|_| {})
+    }
+
+    fn finish_with_optional_package_priority(
+        mut self,
+        priority_packages: Option<&(dyn Fn() -> Vec<PackageSlot> + Sync)>,
+        publish_priority: &(dyn Fn(FinishedSplitIndexing) + Sync),
+    ) -> anyhow::Result<FinishedSplitIndexing> {
+        let packages = unfinished_split_indexing_packages(&self.project.state);
+        let publish_package = |package, bodies| {
+            publish_priority(FinishedSplitIndexing {
+                packages: vec![(package, bodies)],
+            });
+        };
+        let mut sampler = BuildMemorySampler::disabled();
+        finish_resident_packages_with_sampler(
+            &mut self.project.state,
+            &packages,
+            priority_packages,
+            &publish_package,
+            &mut sampler,
+        )
+        .context("while attempting to finish detached deferred packages")?;
+        capture_finished_packages(&self.project.state, &packages)
     }
 }
 
-/// Result of finishing split indexing inside a detached project clone.
+pub(super) fn package_slots_for_path(
+    state: &ProjectState,
+    path: &std::path::Path,
+) -> anyhow::Result<Vec<PackageSlot>> {
+    let canonical_path = path
+        .canonicalize()
+        .with_context(|| format!("while attempting to canonicalize {}", path.display()))?;
+    let mut packages = state
+        .parse
+        .file_refs_for_path(&canonical_path)
+        .into_iter()
+        .map(|file| PackageSlot(file.package))
+        .collect::<Vec<_>>();
+    packages.sort_unstable();
+    packages.dedup();
+    Ok(packages)
+}
+
+/// Package payloads finished inside a detached project clone.
 ///
-/// The project stays owned by this value until merge time. That lets the saved project decide,
-/// package by package, whether the detached result is still an improvement over any on-demand work
-/// that happened while the background clone was running.
+/// A background worker can publish one of these values while its detached build continues through
+/// later packages. The saved project still decides package by package whether each payload is an
+/// improvement over on-demand work that happened in parallel.
 #[derive(Debug, Clone, MemorySize)]
 pub struct FinishedSplitIndexing {
-    project: Project,
-    packages: Vec<PackageSlot>,
+    packages: Vec<(PackageSlot, PackageBodies)>,
 }
 
 /// Finish deferred indexing without recording build checkpoints.
@@ -187,28 +256,13 @@ fn materialize_surface(
     }
 }
 
-/// Complete deferred indexing inside a detached project so it can later be merged into saved state.
-fn finish_detached_project(mut project: Project) -> anyhow::Result<FinishedSplitIndexing> {
-    let mut sampler = BuildMemorySampler::disabled();
-    let packages = finish_resident_with_sampler(&mut project.state, &mut sampler)?;
-    Ok(FinishedSplitIndexing { project, packages })
-}
-
 /// Merge a detached finish result, returning whether it improved the saved project.
 fn merge_finished_project(
     state: &mut ProjectState,
     finished: FinishedSplitIndexing,
 ) -> anyhow::Result<bool> {
-    let packages = merge_finished_packages(state, &finished.project.state, &finished.packages)
-        .context("while attempting to merge deferred indexing packages");
-
-    // Package replacement clones the improvements into the saved project. Drop the detached
-    // project before applying residency: it can own a complete second Body IR, and purging while
-    // that clone is alive cannot return its allocator pages. This also matters when on-demand
-    // materialization already produced equal or better coverage and there is nothing to merge.
-    drop(finished);
-
-    let packages = packages?;
+    let packages = merge_finished_packages(state, finished.packages)
+        .context("while attempting to merge deferred indexing packages")?;
     if packages.is_empty() {
         return Ok(false);
     }
@@ -397,27 +451,45 @@ fn finish_resident_with_sampler(
     sampler: &mut BuildMemorySampler,
 ) -> anyhow::Result<Vec<PackageSlot>> {
     let packages = unfinished_split_indexing_packages(state);
+    finish_resident_packages_with_sampler(state, &packages, None, &|_, _| {}, sampler)
+        .context("while attempting to finish resident deferred packages")?;
+    Ok(packages)
+}
+
+/// Complete the already-normalized deferred package set in one Body IR build.
+fn finish_resident_packages_with_sampler(
+    state: &mut ProjectState,
+    packages: &[PackageSlot],
+    priority_packages: Option<&(dyn Fn() -> Vec<PackageSlot> + Sync)>,
+    publish_priority: &(dyn Fn(PackageSlot, PackageBodies) + Sync),
+    sampler: &mut BuildMemorySampler,
+) -> anyhow::Result<()> {
     if packages.is_empty() {
-        return Ok(packages);
+        return Ok(());
     }
 
     let finish_subset =
-        PhasePackageSet::from_slice(&packages).visible_dependency_subset(&state.workspace);
+        PhasePackageSet::from_slice(packages).visible_dependency_subset(&state.workspace);
     let loaders = PackageReadLoaders::new(state);
-    let body_ir = state
+    let rebuilder = state
         .body_ir
         .package_rebuilder(
             &state.parse,
             &state.def_map,
             &state.semantic_ir,
-            &packages,
+            packages,
             &mut state.names,
             loaders.def_map,
             loaders.semantic_ir,
             &finish_subset,
         )
-        .configured_bodies(state.body_ir_policy)
-        .build();
+        .configured_bodies(state.body_ir_policy);
+    let body_ir = match priority_packages {
+        Some(priority_packages) => {
+            rebuilder.build_with_package_priority(priority_packages, publish_priority)
+        }
+        None => rebuilder.build(),
+    };
 
     // Fresh construction evicts this same reloadable text before exposing retained-state memory.
     // Deferred finishing must do so before its purge and checkpoints as well; otherwise source
@@ -432,7 +504,7 @@ fn finish_resident_with_sampler(
         .purge(ProjectMemoryPurgePoint::AfterBodyIrBuild);
     record_project_checkpoint(state, sampler, "after deferred indexing");
 
-    Ok(packages)
+    Ok(())
 }
 
 /// Apply package residency without adding profiler checkpoints.
@@ -475,18 +547,14 @@ fn record_project_checkpoint(
     record_build_checkpoint(label, project_bytes, project_bytes, process_memory);
 }
 
-/// Merge only package-wise coverage improvements from a detached background finish.
-fn merge_finished_packages(
-    state: &mut ProjectState,
-    finished: &ProjectState,
+/// Copy finished packages out of the detached project for final publication.
+fn capture_finished_packages(
+    state: &ProjectState,
     packages: &[PackageSlot],
-) -> anyhow::Result<Vec<PackageSlot>> {
-    let mut replacements = Vec::new();
-
-    // Decide every replacement before mutating the saved project. If the finished payload is
-    // missing a promised package, fail without leaving a half-merged saved state behind.
+) -> anyhow::Result<FinishedSplitIndexing> {
+    let mut finished = Vec::with_capacity(packages.len());
     for &package in packages {
-        let finished_bodies = finished
+        let bodies = state
             .body_ir
             .resident_package(package)
             .with_context(|| {
@@ -494,19 +562,36 @@ fn merge_finished_packages(
                     "while attempting to read finished deferred payload package {}",
                     package.0,
                 )
-            })?;
+            })?
+            .clone();
+        finished.push((package, bodies));
+    }
+    Ok(FinishedSplitIndexing { packages: finished })
+}
+
+/// Merge only package-wise coverage improvements from detached background work.
+fn merge_finished_packages(
+    state: &mut ProjectState,
+    finished: Vec<(PackageSlot, PackageBodies)>,
+) -> anyhow::Result<Vec<PackageSlot>> {
+    let mut replacements = Vec::new();
+
+    // Decide every replacement before mutating the saved project. Query-time preparation may have
+    // finished a package while the detached build was running, in which case equal or older
+    // coverage must not replace it.
+    for (package, finished_bodies) in finished {
         let should_replace = state
             .body_ir
             .resident_package(package)
             .map(|current_bodies| {
-                body_payload_is_coverage_improvement(current_bodies, finished_bodies)
+                body_payload_is_coverage_improvement(current_bodies, &finished_bodies)
             })
             .unwrap_or(true);
 
         // The background clone can lag behind query-time preparation. Keep the saved package when
         // the detached version would only be equal or worse.
         if should_replace {
-            replacements.push((package, finished_bodies.clone()));
+            replacements.push((package, finished_bodies));
         }
     }
 

--- a/crates/engine/project/src/project/split_indexing.rs
+++ b/crates/engine/project/src/project/split_indexing.rs
@@ -583,6 +583,13 @@ fn merge_finished_packages(
     // finished a package while the detached build was running, in which case equal or older
     // coverage must not replace it.
     for (package, finished_bodies) in finished {
+        // An offloaded slot already has a durable package artifact. A priority publication can
+        // reach that state before the final detached result returns the same package, and putting
+        // the duplicate back would turn a deliberately lazy slot into retained Body IR again.
+        if state.body_ir.package_is_offloaded(package) {
+            continue;
+        }
+
         let should_replace = state
             .body_ir
             .resident_package(package)

--- a/crates/engine/project/src/project/split_indexing.rs
+++ b/crates/engine/project/src/project/split_indexing.rs
@@ -345,6 +345,7 @@ fn materialize_files(
             loaders.semantic_ir,
             &rebuild_subset,
         )
+        .worker_limit(state.indexing_preference.body_ir_worker_limit())
         .selected_files(body_files.into_vec())
         .build();
 
@@ -426,6 +427,7 @@ fn materialize_packages(state: &mut ProjectState, packages: &[PackageSlot]) -> a
             loaders.semantic_ir,
             &rebuild_subset,
         )
+        .worker_limit(state.indexing_preference.body_ir_worker_limit())
         // Query-driven finishing intentionally overrides the eager indexing policy. If a query
         // needs to scan a package, missing bodies would be false negatives rather than saved work.
         .configured_bodies(BodyIrBuildPolicy::all_packages())
@@ -483,6 +485,7 @@ fn finish_resident_packages_with_sampler(
             loaders.semantic_ir,
             &finish_subset,
         )
+        .worker_limit(state.indexing_preference.body_ir_worker_limit())
         .configured_bodies(state.body_ir_policy);
     let body_ir = match priority_packages {
         Some(priority_packages) => {

--- a/crates/engine/project/src/project/update/package.rs
+++ b/crates/engine/project/src/project/update/package.rs
@@ -106,16 +106,19 @@ fn try_rebuild_packages(state: &mut ProjectState, packages: &[PackageSlot]) -> a
         .build()
         .context("while attempting to rebuild affected semantic IR packages")?;
 
-    let body_rebuilder = state.body_ir.package_rebuilder(
-        &state.parse,
-        &def_map,
-        &semantic_ir,
-        packages.as_slice(),
-        &mut state.names,
-        loaders.def_map.clone(),
-        loaders.semantic_ir.clone(),
-        &rebuild_subset,
-    );
+    let body_rebuilder = state
+        .body_ir
+        .package_rebuilder(
+            &state.parse,
+            &def_map,
+            &semantic_ir,
+            packages.as_slice(),
+            &mut state.names,
+            loaders.def_map.clone(),
+            loaders.semantic_ir.clone(),
+            &rebuild_subset,
+        )
+        .worker_limit(state.indexing_preference.body_ir_worker_limit());
     let body_rebuilder = match state.split_indexing_mode {
         SplitIndexingMode::Full => body_rebuilder.configured_bodies(state.body_ir_policy),
         SplitIndexingMode::EarlyStart => body_rebuilder.coverage_only(state.body_ir_policy),

--- a/crates/engine/project/src/tests/mod.rs
+++ b/crates/engine/project/src/tests/mod.rs
@@ -1307,6 +1307,78 @@ pub fn dep_value() -> usize {
 }
 
 #[test]
+fn final_detached_merge_keeps_priority_package_offloaded() {
+    let fixture = ProjectSourceFixture::build(
+        r#"
+//- /Cargo.toml
+[package]
+name = "offloaded_priority_merge"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub fn value() -> usize {
+    1
+}
+"#,
+    );
+    let mut project = Project::builder(fixture.workspace_metadata())
+        .split_indexing_mode(SplitIndexingMode::EarlyStart)
+        .package_residency_policy(PackageResidencyPolicy::AllOffloadable)
+        .build()
+        .expect("early-start offloadable project build should succeed");
+    let priority_finished = Arc::new(Mutex::new(None));
+    let priority_publication = Arc::clone(&priority_finished);
+    let final_finished = project
+        .detach_split_indexing()
+        .finish_with_package_priority(
+            || vec![rg_def_map::PackageSlot(0)],
+            move |finished| {
+                let previous = priority_publication
+                    .lock()
+                    .expect("priority publication should not be poisoned")
+                    .replace(finished);
+                assert!(
+                    previous.is_none(),
+                    "one-package build should publish priority data once",
+                );
+            },
+        )
+        .expect("background deferred indexing should succeed");
+    let priority_finished = priority_finished
+        .lock()
+        .expect("priority publication should not be poisoned")
+        .take()
+        .expect("priority package should publish before the final result");
+
+    assert!(
+        project
+            .split_indexing()
+            .merge_finished(priority_finished)
+            .expect("priority package should merge"),
+        "priority publication should finish the saved package",
+    );
+    assert_eq!(
+        project.stats().body_ir.crate_count,
+        0,
+        "priority publication should return the finished package to offloaded residency",
+    );
+
+    assert!(
+        !project
+            .split_indexing()
+            .merge_finished(final_finished)
+            .expect("final background result should reconcile"),
+        "the final result should not reinstall an already-offloaded priority package",
+    );
+    assert_eq!(
+        project.stats().body_ir.crate_count,
+        0,
+        "final reconciliation should preserve offloaded residency",
+    );
+}
+
+#[test]
 fn residency_keeps_partial_deferred_payload_transient_and_resident() {
     let fixture = ProjectSourceFixture::build(
         r#"

--- a/crates/engine/semantic-ir/src/item/lookup_index.rs
+++ b/crates/engine/semantic-ir/src/item/lookup_index.rs
@@ -9,8 +9,8 @@ use std::collections::HashMap;
 
 use rg_def_map::{DefMapSource, PackageSlot};
 use rg_ir_model::{
-    AssocItemId, FunctionRef, ImplRef, SemanticItemRef, TraitDefRef, TraitImplRef, TypeAliasRef,
-    TypeDefRef,
+    AssocItemId, CrateRef, FunctionRef, ImplId, ImplRef, SemanticItemRef, TraitDefRef, TraitId,
+    TraitImplRef, TypeAliasRef, TypeDefRef,
 };
 use rg_item_tree::LangItem;
 use rg_std::{MemorySize, Shrink, UniqueVec};
@@ -36,8 +36,8 @@ pub struct ItemLookupIndex {
     inherent_impls_by_type: HashMap<TypeDefRef, UniqueVec<ImplRef>>,
     inherent_functions_by_type_and_name: HashMap<TypeDefRef, HashMap<Name, UniqueVec<FunctionRef>>>,
     structural_inherent_impls: UniqueVec<ImplRef>,
-    trait_impls_by_type: HashMap<TypeDefRef, UniqueVec<TraitImplRef>>,
-    trait_impls_by_trait: HashMap<TraitDefRef, UniqueVec<TraitImplRef>>,
+    trait_impls_by_type: HashMap<TypeDefRef, UniqueVec<IndexedTraitImplRef>>,
+    trait_impls_by_trait: HashMap<TraitDefRef, UniqueVec<IndexedImplRef>>,
     // Trait impl lookup produces trait identities first; this cache then expands each trait into
     // its associated function declarations without reopening the trait item every time.
     trait_functions_by_trait: HashMap<TraitDefRef, UniqueVec<FunctionRef>>,
@@ -161,13 +161,13 @@ impl ItemLookupIndex {
                 self.trait_impls_by_trait
                     .entry(*trait_ref)
                     .or_default()
-                    .push(trait_impl);
+                    .push(IndexedImplRef::from_crate(impl_ref));
 
                 if let Some(self_ty) = impl_data.resolved_self_ty.as_option() {
                     self.trait_impls_by_type
                         .entry(*self_ty)
                         .or_default()
-                        .push(trait_impl);
+                        .push(IndexedTraitImplRef::from_crate(trait_impl));
                 }
             }
         }
@@ -267,7 +267,11 @@ impl ItemLookupIndex {
     pub fn impls_for_type(&self, ty: TypeDefRef) -> UniqueVec<ImplRef> {
         let mut impls = self.inherent_impls_for_type(ty);
         if let Some(trait_impls) = self.trait_impls_by_type.get(&ty) {
-            impls.extend(trait_impls.iter().map(|trait_impl| trait_impl.impl_ref));
+            impls.extend(
+                trait_impls
+                    .iter()
+                    .map(|trait_impl| trait_impl.expand().impl_ref),
+            );
         }
         impls
     }
@@ -278,21 +282,31 @@ impl ItemLookupIndex {
             .get(&trait_ref)
             .into_iter()
             .flat_map(|trait_impls| trait_impls.iter())
-            .map(|trait_impl| trait_impl.impl_ref)
+            .map(|impl_ref| impl_ref.expand())
             .collect()
     }
 
     /// Returns trait impl candidates indexed for a receiver type.
-    pub fn trait_impls_for_type(&self, ty: TypeDefRef) -> Option<&UniqueVec<TraitImplRef>> {
-        self.trait_impls_by_type.get(&ty)
+    pub fn trait_impls_for_type(&self, ty: TypeDefRef) -> UniqueVec<TraitImplRef> {
+        self.trait_impls_by_type
+            .get(&ty)
+            .into_iter()
+            .flat_map(|trait_impls| trait_impls.iter())
+            .map(|trait_impl| trait_impl.expand())
+            .collect()
     }
 
     /// Returns trait impl candidates indexed by the implemented trait.
     pub fn trait_impls_for_trait(
         &self,
         trait_ref: TraitDefRef,
-    ) -> Option<&UniqueVec<TraitImplRef>> {
-        self.trait_impls_by_trait.get(&trait_ref)
+    ) -> Option<impl ExactSizeIterator<Item = TraitImplRef> + Clone + '_> {
+        self.trait_impls_by_trait.get(&trait_ref).map(move |impls| {
+            impls.iter().map(move |impl_ref| TraitImplRef {
+                impl_ref: impl_ref.expand(),
+                trait_ref,
+            })
+        })
     }
 
     /// Returns trait-declared functions if the trait was visible when the index was built.
@@ -312,6 +326,70 @@ impl ItemLookupIndex {
         Some(IndexedTraitFunctions {
             functions: functions_by_name.get(name),
         })
+    }
+}
+
+/// Crate-only impl identity retained inside a crate-visible lookup index.
+///
+/// A general [`ImplRef`] also has to represent body-local declarations, which makes its
+/// [`rg_ir_model::DefMapRef`] origin larger. Entries collected from semantic item stores cannot be
+/// body-local, so retaining the crate directly avoids paying for that unused variant millions of
+/// times. Query methods expand this back to the ordinary public identity at their boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, SchemaRead, SchemaWrite, MemorySize, Shrink)]
+#[memsize(leaf)]
+#[shrink(leaf)]
+struct IndexedImplRef {
+    crate_ref: CrateRef,
+    id: ImplId,
+}
+
+impl IndexedImplRef {
+    fn from_crate(impl_ref: ImplRef) -> Self {
+        Self {
+            crate_ref: impl_ref
+                .origin
+                .as_crate_ref()
+                .expect("semantic item-store impl should have a crate origin"),
+            id: impl_ref.id,
+        }
+    }
+
+    fn expand(self) -> ImplRef {
+        ImplRef::new(rg_ir_model::DefMapRef::Crate(self.crate_ref), self.id)
+    }
+}
+
+/// Compact trait impl identity used where the trait is not already present as the map key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, SchemaRead, SchemaWrite, MemorySize, Shrink)]
+#[memsize(leaf)]
+#[shrink(leaf)]
+struct IndexedTraitImplRef {
+    impl_ref: IndexedImplRef,
+    trait_crate: CrateRef,
+    trait_id: TraitId,
+}
+
+impl IndexedTraitImplRef {
+    fn from_crate(trait_impl: TraitImplRef) -> Self {
+        Self {
+            impl_ref: IndexedImplRef::from_crate(trait_impl.impl_ref),
+            trait_crate: trait_impl
+                .trait_ref
+                .origin
+                .as_crate_ref()
+                .expect("semantic item-store trait should have a crate origin"),
+            trait_id: trait_impl.trait_ref.id,
+        }
+    }
+
+    fn expand(self) -> TraitImplRef {
+        TraitImplRef {
+            impl_ref: self.impl_ref.expand(),
+            trait_ref: TraitDefRef::new(
+                rg_ir_model::DefMapRef::Crate(self.trait_crate),
+                self.trait_id,
+            ),
+        }
     }
 }
 

--- a/crates/engine/semantic-ir/src/tests/utils.rs
+++ b/crates/engine/semantic-ir/src/tests/utils.rs
@@ -184,10 +184,7 @@ impl<'a> ProjectSemanticQuerySnapshot<'a> {
         type_defs
             .into_iter()
             .map(|ty| {
-                let trait_impls = lookup_index
-                    .trait_impls_for_type(ty)
-                    .cloned()
-                    .unwrap_or_default();
+                let trait_impls = lookup_index.trait_impls_for_type(ty);
                 let mut traits = UniqueVec::new();
                 let mut trait_functions = UniqueVec::new();
                 let mut trait_impl_functions = UniqueVec::new();

--- a/crates/engine/ty/src/associated_item.rs
+++ b/crates/engine/ty/src/associated_item.rs
@@ -41,8 +41,8 @@ use rg_semantic_ir::ItemStoreSource;
 use rg_std::UniqueVec;
 
 use crate::{
-    AdtTy, Clause, ImplMatcher, ItemPathQuery, SemanticSignatureQuery, TraitApplication, Ty,
-    TyContext, TypePathResolver, inference::InferenceTable,
+    AdtTy, Clause, ImplMatcher, ItemPathQuery, TraitApplication, Ty, TyContext, TypePathResolver,
+    inference::InferenceTable,
 };
 
 /// Stable declaration identity returned by associated-item discovery.
@@ -299,10 +299,12 @@ where
 
         // The canonical trait header has already lowered `Self: Super` predicates. Filtering on
         // the trait's own `Self` excludes unrelated bounds on its other generic parameters.
-        if let Some(header) =
-            SemanticSignatureQuery::trait_header_from(self.context.item_paths(), trait_ref)?
+        if let Some(header) = self
+            .context
+            .trait_selection()
+            .trait_header_with(self.context.item_paths(), trait_ref)?
         {
-            for clause in header.clauses {
+            for clause in &header.clauses {
                 let Clause::Implemented(application) = clause else {
                     continue;
                 };

--- a/crates/engine/ty/src/associated_item.rs
+++ b/crates/engine/ty/src/associated_item.rs
@@ -141,9 +141,7 @@ where
                 .inherent_impls_for_type(receiver_ty.def),
             self.context
                 .lookup_index()
-                .trait_impls_for_type(receiver_ty.def)
-                .cloned()
-                .unwrap_or_default(),
+                .trait_impls_for_type(receiver_ty.def),
             true,
         )
     }

--- a/crates/engine/ty/src/generic_arg.rs
+++ b/crates/engine/ty/src/generic_arg.rs
@@ -350,7 +350,7 @@ pub struct TraitRefLowering {
 ///
 /// A bound such as `T: Iterator<Item = User>` becomes one `Implemented` clause for
 /// `T: Iterator` and one `AliasEq` clause for `<T as Iterator>::Item = User`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Clause {
     Implemented(TraitApplication),
     AliasEq { alias: ProjectionTy, ty: Ty },

--- a/crates/engine/ty/src/impl_match/mod.rs
+++ b/crates/engine/ty/src/impl_match/mod.rs
@@ -1,7 +1,8 @@
 //! Canonical impl-header matching for receiver-based item queries.
 //!
-//! All entry points consume `SemanticSignatureQuery::impl_header` results. Syntax HIR remains
-//! available to declaration views, but receiver matching never interprets a `TypeRef` itself.
+//! Every entry point consumes canonical `ImplHeader` values from the signature-lowering boundary.
+//! Syntax HIR remains available to declaration views, but receiver matching never interprets a
+//! `TypeRef` itself.
 
 mod inherent;
 mod trait_methods;
@@ -44,11 +45,11 @@ where
 
     /// Return the canonical header used by every matching operation.
     pub fn impl_header(&self, impl_ref: ImplRef) -> Result<Option<ImplHeader>, D::Error> {
-        self.context.trait_selection().impl_header_with(
-            self.context.item_paths(),
-            &self.resolver,
-            impl_ref,
-        )
+        Ok(self
+            .context
+            .trait_selection()
+            .impl_header_with(self.context.item_paths(), &self.resolver, impl_ref)?
+            .map(|header| (*header).clone()))
     }
 
     /// Match the impl's semantic `Self` pattern and return owner-scoped bindings.

--- a/crates/engine/ty/src/impl_match/trait_methods.rs
+++ b/crates/engine/ty/src/impl_match/trait_methods.rs
@@ -43,9 +43,7 @@ where
         let trait_impls = self
             .context
             .lookup_index()
-            .trait_impls_for_type(receiver_ty.def)
-            .cloned()
-            .unwrap_or_default();
+            .trait_impls_for_type(receiver_ty.def);
         self.trait_function_candidates_from_impls(trait_impls, receiver_ty, method_name, table)
     }
 

--- a/crates/engine/ty/src/implementation.rs
+++ b/crates/engine/ty/src/implementation.rs
@@ -108,12 +108,7 @@ where
         for candidate in autoderef.candidates(AutoderefMode::MethodReceiver, receiver_ty) {
             let candidate = candidate?;
             for ty in candidate.ty().as_adts() {
-                let trait_impls = self
-                    .context
-                    .lookup_index()
-                    .trait_impls_for_type(ty.def)
-                    .cloned()
-                    .unwrap_or_default();
+                let trait_impls = self.context.lookup_index().trait_impls_for_type(ty.def);
                 for trait_impl in trait_impls {
                     if trait_impl.trait_ref != trait_ref {
                         continue;

--- a/crates/engine/ty/src/lib.rs
+++ b/crates/engine/ty/src/lib.rs
@@ -49,8 +49,8 @@ pub use self::{
     signature::{CallableSignature, ImplHeader, SemanticSignatureQuery},
     substitution::Substitution,
     trait_selection::{
-        AssocProjectionResult, TraitGoal, TraitProof, TraitSelection, TraitSelectionQuery,
-        TraitSelectionSession,
+        AssocProjectionResult, TraitGoal, TraitProof, TraitSelection,
+        TraitSelectionDeclarationCache, TraitSelectionQuery, TraitSelectionSession,
     },
     ty::{
         AdtTy, AliasTy, ClosureTy, ClosureTyId, ExpectedAdtTyExt, ExpectedTyExt, FnDefTy, OpaqueTy,

--- a/crates/engine/ty/src/profile.rs
+++ b/crates/engine/ty/src/profile.rs
@@ -2,6 +2,10 @@
 
 use rg_profile::{ProfileDescriptor, ProfileReport, ProfileReportSort, declare_metrics};
 
+const BY_COUNT: ProfileReport = ProfileReport {
+    sort: Some(ProfileReportSort::CountDescending),
+    limit: Some(20),
+};
 const BY_DURATION: ProfileReport = ProfileReport {
     sort: Some(ProfileReportSort::TotalDurationDescending),
     limit: Some(20),
@@ -16,10 +20,30 @@ declare_metrics! {
             counter PROGRAM_BUILDS = "program.builds";
             /// Chalk program build time.
             duration PROGRAM_BUILD_TIME = "timings.program_build";
+            /// Definitions discovered while constructing Chalk programs, grouped by kind.
+            keyed_counter PROGRAM_DEFINITIONS_BY_KIND = "program.definitions" [report super::BY_COUNT, title "Chalk program definitions"];
+            /// Chalk program construction time grouped by materialization phase.
+            keyed_duration PROGRAM_BUILD_TIME_BY_PHASE = "timings.program_build_phase" [report super::BY_DURATION, title "Chalk program build phases"];
             /// Chalk predicate goals sent to the solver.
             counter SOLVER_GOALS = "solver.goals";
             /// Chalk predicate goals that produced an ambiguous answer.
             counter SOLVER_AMBIGUOUS_GOALS = "solver.goals.ambiguous";
+            /// Bounded outcomes grouped by solver operation and result.
+            keyed_counter SOLVER_GOAL_OUTCOMES = "solver.goal_outcomes" [report super::BY_COUNT, title "Chalk solver goal outcomes"];
+            /// Solver goals grouped by the input shape that selected their work budget.
+            keyed_counter SOLVER_GOAL_SHAPES = "solver.goal_shapes" [report super::BY_COUNT, title "Chalk solver goal shapes"];
+            /// Repeated body-local goals served from a previous bounded decline.
+            counter DECLINED_GOAL_REUSES = "solver.declined_goal_reuses";
+            /// Associated projections instantiated directly from a selected native impl.
+            counter NATIVE_ASSOC_PROJECTIONS = "native.assoc_projections";
+            /// Candidate projection probes stopped at an actual recursive impl cycle.
+            counter NATIVE_CANDIDATE_CYCLES = "native.candidate_cycles";
+            /// Candidate projections left for one combined solver goal because the matching impl
+            /// had predicates of its own.
+            counter NATIVE_CANDIDATE_PREDICATE_DECLINES = "native.candidate_predicate_declines";
+            /// Native projection shortcuts skipped because their goal was body-owned or lacked an
+            /// indexable receiver head.
+            counter NATIVE_CANDIDATE_UNSTABLE_DECLINES = "native.candidate_unstable_declines";
             /// Chalk predicate-solving time grouped by goal kind.
             keyed_duration SOLVER_GOAL_TIME_BY_KIND = "timings.solver_goal" [report super::BY_DURATION, title "Chalk solver goals"];
         }

--- a/crates/engine/ty/src/profile.rs
+++ b/crates/engine/ty/src/profile.rs
@@ -22,6 +22,8 @@ declare_metrics! {
             duration PROGRAM_BUILD_TIME = "timings.program_build";
             /// Definitions discovered while constructing Chalk programs, grouped by kind.
             keyed_counter PROGRAM_DEFINITIONS_BY_KIND = "program.definitions" [report super::BY_COUNT, title "Chalk program definitions"];
+            /// Declaration-cache lookups grouped by declaration kind and hit or miss.
+            keyed_counter DECLARATION_CACHE_ACCESSES = "program.declaration_cache" [report super::BY_COUNT, title "Chalk declaration cache"];
             /// Chalk program construction time grouped by materialization phase.
             keyed_duration PROGRAM_BUILD_TIME_BY_PHASE = "timings.program_build_phase" [report super::BY_DURATION, title "Chalk program build phases"];
             /// Chalk predicate goals sent to the solver.

--- a/crates/engine/ty/src/trait_selection/candidate.rs
+++ b/crates/engine/ty/src/trait_selection/candidate.rs
@@ -57,7 +57,7 @@ impl TraitCandidate {
                 visible_impls,
                 self_head,
             )?,
-            None => visible_impls.clone(),
+            None => visible_impls.collect(),
         };
 
         let mut candidates = Vec::new();

--- a/crates/engine/ty/src/trait_selection/chalk/program/build.rs
+++ b/crates/engine/ty/src/trait_selection/chalk/program/build.rs
@@ -63,7 +63,14 @@ impl ChalkProgram {
         let extension_started = Instant::now();
         self.known_items = super::ChalkKnownItems::from_index(lookup_index);
         let discovery_started = Instant::now();
-        let scope = ChalkProgramScope::discover(item_paths, crate_items, session, roots, self)?;
+        let scope = ChalkProgramScope::discover(
+            item_paths,
+            crate_items,
+            lookup_index,
+            session,
+            roots,
+            self,
+        )?;
         let discovery_elapsed = discovery_started.elapsed();
 
         // Associated-type declarations must exist before lowering any trait/impl predicates that

--- a/crates/engine/ty/src/trait_selection/chalk/program/build.rs
+++ b/crates/engine/ty/src/trait_selection/chalk/program/build.rs
@@ -21,8 +21,8 @@ use super::super::lower::{
     ChalkLowerer, GenericBinderEnv, adt_datum, chalk_assoc_type_id, chalk_assoc_type_value_id,
 };
 use super::{ChalkProgram, ChalkProgramRoots, ChalkProgramScope};
+use crate::ItemPathQuery;
 use crate::trait_selection::TraitSelectionSession;
-use crate::{ItemPathQuery, SemanticSignatureQuery};
 
 const INTER: RgChalkInterner = RgChalkInterner;
 
@@ -160,8 +160,9 @@ impl ChalkProgram {
                 .generics()
                 .generics(GenericDefRef::Impl(impl_ref))?;
             let binders = GenericBinderEnv::for_generics(&generics);
-            let associated_ty_value_ids =
-                self.collect_impl_associated_ty_values(item_paths, &binders, impl_ref, trait_ref)?;
+            let associated_ty_value_ids = self.collect_impl_associated_ty_values(
+                item_paths, session, &binders, impl_ref, trait_ref,
+            )?;
             let lowerer = ChalkLowerer::new(&binders).with_associated_tys(&self.associated_tys);
             let Some(datum) = lowerer.impl_datum(header, associated_ty_value_ids) else {
                 continue;
@@ -289,6 +290,7 @@ impl ChalkProgram {
     fn collect_impl_associated_ty_values<'query, D, I>(
         &mut self,
         item_paths: &ItemPathQuery<'query, D, I>,
+        session: &TraitSelectionSession,
         binders: &GenericBinderEnv,
         impl_ref: ImplRef,
         trait_ref: TraitDefRef,
@@ -331,8 +333,7 @@ impl ChalkProgram {
             let Some(type_alias_data) = item_paths.items().type_alias_data(type_alias_ref)? else {
                 continue;
             };
-            let Some(ty) = SemanticSignatureQuery::type_alias_ty_from(item_paths, type_alias_ref)?
-            else {
+            let Some(ty) = session.type_alias_ty_with(item_paths, type_alias_ref)? else {
                 continue;
             };
             let value = ChalkLowerer::new(binders)

--- a/crates/engine/ty/src/trait_selection/chalk/program/build.rs
+++ b/crates/engine/ty/src/trait_selection/chalk/program/build.rs
@@ -64,7 +64,7 @@ impl ChalkProgram {
         self.known_items = super::ChalkKnownItems::from_index(lookup_index);
         let discovery_started = Instant::now();
         let scope = ChalkProgramScope::discover(item_paths, crate_items, session, roots, self)?;
-        let discovery_us = discovery_started.elapsed().as_micros();
+        let discovery_elapsed = discovery_started.elapsed();
 
         // Associated-type declarations must exist before lowering any trait/impl predicates that
         // can mention their projection IDs.
@@ -86,7 +86,7 @@ impl ChalkProgram {
                 self.collect_trait_associated_tys(item_paths, &lowerer, trait_ref, trait_data)?;
             associated_ty_ids_by_trait.insert(trait_ref, associated_ty_ids);
         }
-        let associated_tys_us = associated_tys_started.elapsed().as_micros();
+        let associated_tys_elapsed = associated_tys_started.elapsed();
 
         // Once every associated-type ID exists, trait predicates can safely refer to them.
         let trait_datums_started = Instant::now();
@@ -114,7 +114,7 @@ impl ChalkProgram {
                 .insert(trait_ref, datum.binders.len(INTER));
             self.traits.insert(trait_ref, Arc::new(datum));
         }
-        let trait_datums_us = trait_datums_started.elapsed().as_micros();
+        let trait_datums_elapsed = trait_datums_started.elapsed();
 
         // Function items participate in the same built-in `Fn*` clauses as closures. Their datum
         // is declaration-owned, so materialize the canonical signature once with its generic
@@ -135,7 +135,7 @@ impl ChalkProgram {
             self.ensure_fn_def_datum_adts(item_paths, &datum)?;
             self.functions.insert(function, Arc::new(datum));
         }
-        let function_datums_us = function_datums_started.elapsed().as_micros();
+        let function_datums_elapsed = function_datums_started.elapsed();
 
         // Impl datums use the same registry for their predicates and associated-type values.
         let impl_datums_started = Instant::now();
@@ -174,7 +174,7 @@ impl ChalkProgram {
                 .push(impl_ref);
             self.impls.insert(impl_ref, Arc::new(datum));
         }
-        let impl_datums_us = impl_datums_started.elapsed().as_micros();
+        let impl_datums_elapsed = impl_datums_started.elapsed();
 
         // Opaque bounds are declaration predicates. Materialize them in the solver program while
         // keeping the opaque identity itself compact and independent from those predicates.
@@ -191,7 +191,28 @@ impl ChalkProgram {
             };
             self.opaque_tys.insert(opaque.opaque, Arc::new(datum));
         }
-        let opaque_datums_us = opaque_datums_started.elapsed().as_micros();
+        let opaque_datums_elapsed = opaque_datums_started.elapsed();
+
+        // Program construction is concurrent across use-site crates, so wall time alone cannot
+        // show which repeated semantic operation consumed the worker pool. Keep aggregate input
+        // counts and phase timings alongside the existing total build duration.
+        crate::profile::metric::PROGRAM_DEFINITIONS_BY_KIND
+            .add("traits", scope.definitions.traits.len() as u64);
+        crate::profile::metric::PROGRAM_DEFINITIONS_BY_KIND.add("impls", scope.impls.len() as u64);
+        crate::profile::metric::PROGRAM_DEFINITIONS_BY_KIND
+            .add("opaque_types", scope.definitions.opaque_tys.len() as u64);
+        crate::profile::metric::PROGRAM_DEFINITIONS_BY_KIND
+            .add("functions", scope.definitions.functions.len() as u64);
+        for (phase, elapsed) in [
+            ("scope_discovery", discovery_elapsed),
+            ("associated_types", associated_tys_elapsed),
+            ("trait_datums", trait_datums_elapsed),
+            ("function_datums", function_datums_elapsed),
+            ("impl_datums", impl_datums_elapsed),
+            ("opaque_datums", opaque_datums_elapsed),
+        ] {
+            crate::profile::metric::PROGRAM_BUILD_TIME_BY_PHASE.record(phase, elapsed);
+        }
 
         self.materialized_traits
             .extend(scope.definitions.traits.iter().copied());
@@ -205,12 +226,12 @@ impl ChalkProgram {
                 impl_count = scope.impls.len(),
                 opaque_type_count = scope.definitions.opaque_tys.len(),
                 function_count = scope.definitions.functions.len(),
-                discovery_us,
-                associated_tys_us,
-                trait_datums_us,
-                function_datums_us,
-                impl_datums_us,
-                opaque_datums_us,
+                discovery_us = discovery_elapsed.as_micros(),
+                associated_tys_us = associated_tys_elapsed.as_micros(),
+                trait_datums_us = trait_datums_elapsed.as_micros(),
+                function_datums_us = function_datums_elapsed.as_micros(),
+                impl_datums_us = impl_datums_elapsed.as_micros(),
+                opaque_datums_us = opaque_datums_elapsed.as_micros(),
                 "slow Chalk program materialization phases finished"
             );
         }

--- a/crates/engine/ty/src/trait_selection/chalk/program/mod.rs
+++ b/crates/engine/ty/src/trait_selection/chalk/program/mod.rs
@@ -71,17 +71,18 @@ struct ChalkProgramRoots {
 ///
 /// This is temporary build data. It keeps canonical headers beside their identities so the build
 /// phase does not repeat semantic lowering while it turns the discovered closure into Chalk
-/// datums.
+/// datums. Discovery and materialization therefore read the same declaration values even when
+/// those values are shared with other use-site sessions through the snapshot declaration cache.
 #[derive(Default)]
 struct ChalkProgramScope {
     definitions: ChalkProgramRoots,
-    trait_headers: HashMap<TraitDefRef, crate::signature::TraitHeader>,
+    trait_headers: HashMap<TraitDefRef, Arc<crate::signature::TraitHeader>>,
     impls: Vec<ImplRef>,
     #[cfg(debug_assertions)] // Used to assert uniqueness without expensive `UniqueVec`
     discovered_impls: std::collections::HashSet<ImplRef>,
-    impl_headers: HashMap<ImplRef, crate::ImplHeader>,
+    impl_headers: HashMap<ImplRef, Arc<crate::ImplHeader>>,
     opaque_bounds: HashMap<OpaqueTyRef, (crate::OpaqueTy, Vec<TraitRefLowering>)>,
-    function_signatures: HashMap<FunctionRef, crate::CallableSignature>,
+    function_signatures: HashMap<FunctionRef, Arc<crate::CallableSignature>>,
     loaded_opaque_owners: UniqueVec<GenericDefRef>,
 }
 

--- a/crates/engine/ty/src/trait_selection/chalk/program/mod.rs
+++ b/crates/engine/ty/src/trait_selection/chalk/program/mod.rs
@@ -76,7 +76,9 @@ struct ChalkProgramRoots {
 struct ChalkProgramScope {
     definitions: ChalkProgramRoots,
     trait_headers: HashMap<TraitDefRef, crate::signature::TraitHeader>,
-    impls: UniqueVec<ImplRef>,
+    impls: Vec<ImplRef>,
+    #[cfg(debug_assertions)] // Used to assert uniqueness without expensive `UniqueVec`
+    discovered_impls: std::collections::HashSet<ImplRef>,
     impl_headers: HashMap<ImplRef, crate::ImplHeader>,
     opaque_bounds: HashMap<OpaqueTyRef, (crate::OpaqueTy, Vec<TraitRefLowering>)>,
     function_signatures: HashMap<FunctionRef, crate::CallableSignature>,

--- a/crates/engine/ty/src/trait_selection/chalk/program/roots.rs
+++ b/crates/engine/ty/src/trait_selection/chalk/program/roots.rs
@@ -14,7 +14,7 @@ use rg_semantic_ir::{CrateItemQuery, ItemLookupIndex, ItemStoreSource};
 use super::{ChalkProgram, ChalkProgramRoots, ChalkProgramScope};
 use crate::inference::InferenceTable;
 use crate::trait_selection::TraitSelectionSession;
-use crate::{Clause, ItemPathQuery, SemanticSignatureQuery, TraitRefLowering};
+use crate::{Clause, ItemPathQuery, TraitRefLowering};
 
 impl ChalkProgramRoots {
     pub(super) fn is_empty(&self) -> bool {
@@ -254,9 +254,7 @@ impl ChalkProgramScope {
                     continue;
                 }
 
-                if let Some(header) =
-                    SemanticSignatureQuery::trait_header_from(item_paths, trait_ref)?
-                {
+                if let Some(header) = session.trait_header_with(item_paths, trait_ref)? {
                     scope
                         .definitions
                         .collect_ty(item_paths, &header.self_ty, None)?;
@@ -297,14 +295,20 @@ impl ChalkProgramScope {
                     continue;
                 }
 
-                for (opaque, bounds) in
-                    SemanticSignatureQuery::opaque_bounds_for_owner_from(item_paths, opaque.owner)?
+                for (opaque, bounds) in session
+                    .opaque_bounds_for_owner_with(item_paths, opaque.owner)?
+                    .iter()
                 {
                     scope.definitions.opaque_tys.push(opaque.opaque);
-                    for bound in &bounds {
+                    for bound in bounds {
                         scope.definitions.collect_trait_ref(item_paths, bound)?;
                     }
-                    scope.opaque_bounds.insert(opaque.opaque, (opaque, bounds));
+                    // Discovery borrows this owner summary only while walking it. Keep owned
+                    // values in the program scope so its later materialization is independent
+                    // from that borrow.
+                    scope
+                        .opaque_bounds
+                        .insert(opaque.opaque, (opaque.clone(), bounds.clone()));
                 }
             }
 
@@ -314,8 +318,7 @@ impl ChalkProgramScope {
                 if program.functions.contains_key(&function) {
                     continue;
                 }
-                let Some(signature) = SemanticSignatureQuery::function_from(item_paths, function)?
-                else {
+                let Some(signature) = session.function_signature_with(item_paths, function)? else {
                     continue;
                 };
                 for param in &signature.params {
@@ -389,7 +392,7 @@ impl ChalkProgramScope {
                     origin: impl_ref.origin,
                     id: *id,
                 };
-                if let Some(ty) = SemanticSignatureQuery::type_alias_ty_from(item_paths, alias)? {
+                if let Some(ty) = session.type_alias_ty_with(item_paths, alias)? {
                     self.definitions.collect_ty(item_paths, &ty, None)?;
                 }
             }

--- a/crates/engine/ty/src/trait_selection/chalk/program/roots.rs
+++ b/crates/engine/ty/src/trait_selection/chalk/program/roots.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 
 use rg_def_map::DefMapSource;
 use rg_ir_model::{AssocItemId, ItemOwner, TraitDefRef, TypeAliasRef};
-use rg_semantic_ir::{CrateItemQuery, ItemStoreSource};
+use rg_semantic_ir::{CrateItemQuery, ItemLookupIndex, ItemStoreSource};
 
 use super::{ChalkProgram, ChalkProgramRoots, ChalkProgramScope};
 use crate::inference::InferenceTable;
@@ -222,6 +222,7 @@ impl ChalkProgramScope {
     pub(super) fn discover<'query, D, I>(
         item_paths: &ItemPathQuery<'query, D, I>,
         crate_items: &CrateItemQuery<'query, D, I>,
+        lookup_index: &ItemLookupIndex,
         session: &TraitSelectionSession,
         roots: &ChalkProgramRoots,
         program: &ChalkProgram,
@@ -265,44 +266,24 @@ impl ChalkProgramScope {
                     scope.trait_headers.insert(trait_ref, header);
                 }
 
-                for impl_ref in crate_items.impls_for_trait(trait_ref)? {
-                    if !scope.impls.push(impl_ref) {
-                        continue;
-                    }
-                    let Some(header) =
-                        session.impl_header_with(item_paths, item_paths, impl_ref)?
-                    else {
-                        continue;
-                    };
-                    scope
-                        .definitions
-                        .collect_ty(item_paths, &header.self_ty, None)?;
-                    if let Some(trait_ref) = &header.trait_ref {
-                        scope.definitions.collect_trait_ref(item_paths, trait_ref)?;
-                    }
-                    scope
-                        .definitions
-                        .collect_clauses(item_paths, &header.clauses, None)?;
-
-                    // Associated values may themselves project through another trait. Discover
-                    // that trait before lowering so every referenced associated-type datum exists.
-                    if let Some(impl_data) = crate_items.items().impl_data(impl_ref)? {
-                        for item in &impl_data.items {
-                            let AssocItemId::TypeAlias(id) = item else {
-                                continue;
-                            };
-                            let alias = TypeAliasRef {
-                                origin: impl_ref.origin,
-                                id: *id,
-                            };
-                            if let Some(ty) =
-                                SemanticSignatureQuery::type_alias_ty_from(item_paths, alias)?
-                            {
-                                scope.definitions.collect_ty(item_paths, &ty, None)?;
-                            }
+                // Crate-origin traits use the visibility-scoped index that was already built for
+                // this use site. Body-origin traits are intentionally absent from that index, so
+                // keep their lookup inside the owning body store.
+                if trait_ref.origin.as_crate_ref().is_some() {
+                    if let Some(impls) = lookup_index.trait_impls_for_trait(trait_ref) {
+                        for trait_impl in impls {
+                            scope.discover_impl(
+                                item_paths,
+                                crate_items,
+                                session,
+                                trait_impl.impl_ref,
+                            )?;
                         }
                     }
-                    scope.impl_headers.insert(impl_ref, header);
+                } else {
+                    for impl_ref in crate_items.impls_for_trait(trait_ref)? {
+                        scope.discover_impl(item_paths, crate_items, session, impl_ref)?;
+                    }
                 }
             }
 
@@ -363,5 +344,57 @@ impl ChalkProgramScope {
             );
         }
         Ok(scope)
+    }
+
+    /// Add one impl and every semantic definition reachable from its header and values.
+    fn discover_impl<'query, D, I>(
+        &mut self,
+        item_paths: &ItemPathQuery<'query, D, I>,
+        crate_items: &CrateItemQuery<'query, D, I>,
+        session: &TraitSelectionSession,
+        impl_ref: rg_ir_model::ImplRef,
+    ) -> Result<(), I::Error>
+    where
+        D: DefMapSource<Error = I::Error>,
+        I: ItemStoreSource<'query>,
+    {
+        // Each semantic impl has one resolved trait, and the trait queue visits every identity
+        // once. Keeping this invariant avoids a quadratic ordered-set check for large programs.
+        #[cfg(debug_assertions)]
+        assert!(
+            self.discovered_impls.insert(impl_ref),
+            "a Chalk scope must discover each impl through exactly one trait"
+        );
+        self.impls.push(impl_ref);
+
+        let Some(header) = session.impl_header_with(item_paths, item_paths, impl_ref)? else {
+            return Ok(());
+        };
+        self.definitions
+            .collect_ty(item_paths, &header.self_ty, None)?;
+        if let Some(trait_ref) = &header.trait_ref {
+            self.definitions.collect_trait_ref(item_paths, trait_ref)?;
+        }
+        self.definitions
+            .collect_clauses(item_paths, &header.clauses, None)?;
+
+        // Associated values may themselves project through another trait. Discover that trait
+        // before lowering so every referenced associated-type datum exists.
+        if let Some(impl_data) = crate_items.items().impl_data(impl_ref)? {
+            for item in &impl_data.items {
+                let AssocItemId::TypeAlias(id) = item else {
+                    continue;
+                };
+                let alias = TypeAliasRef {
+                    origin: impl_ref.origin,
+                    id: *id,
+                };
+                if let Some(ty) = SemanticSignatureQuery::type_alias_ty_from(item_paths, alias)? {
+                    self.definitions.collect_ty(item_paths, &ty, None)?;
+                }
+            }
+        }
+        self.impl_headers.insert(impl_ref, header);
+        Ok(())
     }
 }

--- a/crates/engine/ty/src/trait_selection/chalk/solver.rs
+++ b/crates/engine/ty/src/trait_selection/chalk/solver.rs
@@ -13,6 +13,7 @@
 //! opaque bounds, and other cases that need the complete program.
 
 use std::cell::Cell;
+use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -42,6 +43,7 @@ const INTER: RgChalkInterner = RgChalkInterner;
 const SOLVER_MAX_SIZE: usize = 32;
 const SETTLED_GOAL_QUANTUM_BUDGET: usize = 4_096;
 const SPECULATIVE_GOAL_QUANTUM_BUDGET: usize = 256;
+const UNRESOLVED_PROJECTION_GOAL_QUANTUM_BUDGET: usize = 256;
 // Program construction is not resumable like solver search. Avoid admitting a live inference goal
 // with a large receiver-compatible root set while it is likely to become more precise later.
 const SPECULATIVE_ROOT_IMPL_BUDGET: usize = 64;
@@ -121,6 +123,14 @@ pub(crate) struct ChalkTraitSolver {
 /// closures and inference slots, then drops the forests when the body finishes.
 pub(crate) struct ChalkInferenceCache {
     forests: Mutex<ChalkSolverForests>,
+    declined_proofs: Mutex<HashMap<Vec<Clause>, DeclinedProof>>,
+}
+
+/// A bounded adapter result that cannot become more precise without different input clauses.
+#[derive(Clone, Copy)]
+enum DeclinedProof {
+    Unsupported,
+    Exhausted,
 }
 
 /// Mutable crate program together with answers safe to reuse across bodies.
@@ -143,7 +153,29 @@ impl ChalkInferenceCache {
     pub(crate) fn new() -> Self {
         Self {
             forests: Mutex::new(ChalkSolverForests::new()),
+            declined_proofs: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Reuse only declines from this body's exact canonical clauses.
+    ///
+    /// Solver forests may resume incomplete search, but body inference should not spend another
+    /// full allowance on an unchanged obligation merely because an unrelated expression made the
+    /// outer fixed point run again. A changed inference solution produces different canonical
+    /// clauses and therefore gets a fresh attempt.
+    fn declined_proof(&self, clauses: &[Clause]) -> Option<DeclinedProof> {
+        self.declined_proofs
+            .lock()
+            .expect("Chalk declined-proof cache lock should not be poisoned")
+            .get(clauses)
+            .copied()
+    }
+
+    fn remember_declined_proof(&self, clauses: &[Clause], declined: DeclinedProof) {
+        self.declined_proofs
+            .lock()
+            .expect("Chalk declined-proof cache lock should not be poisoned")
+            .insert(clauses.to_vec(), declined);
     }
 }
 
@@ -170,6 +202,14 @@ impl ChalkTraitSolver {
         D: DefMapSource<Error = I::Error>,
         I: ItemStoreSource<'query>,
     {
+        if let Some(declined) = inference_cache.declined_proof(clauses) {
+            crate::profile::metric::DECLINED_GOAL_REUSES.inc();
+            return Ok(match declined {
+                DeclinedProof::Unsupported => ChalkOutcome::Unsupported,
+                DeclinedProof::Exhausted => ChalkOutcome::Exhausted,
+            });
+        }
+
         // Trait selection is allowed to refine arguments after `Self` has a selectable head; it
         // must not infer an unconstrained `Self` by enumerating every visible impl. Apart from
         // being an unbounded search in a large crate, choosing from today's impl set would be the
@@ -203,6 +243,7 @@ impl ChalkTraitSolver {
             }
         });
         if has_unknown {
+            inference_cache.remember_declined_proof(clauses, DeclinedProof::Unsupported);
             return Ok(ChalkOutcome::Unsupported);
         }
 
@@ -231,6 +272,7 @@ impl ChalkTraitSolver {
                         table,
                     )?);
                 if root_impl_count > SPECULATIVE_ROOT_IMPL_BUDGET {
+                    inference_cache.remember_declined_proof(clauses, DeclinedProof::Exhausted);
                     return Ok(ChalkOutcome::Exhausted);
                 }
             }
@@ -258,6 +300,7 @@ impl ChalkTraitSolver {
             );
         }
         if !supported {
+            inference_cache.remember_declined_proof(clauses, DeclinedProof::Unsupported);
             return Ok(ChalkOutcome::Unsupported);
         }
         let outcome = state.prove_clauses(clauses, table, inference_cache);
@@ -270,6 +313,15 @@ impl ChalkTraitSolver {
                 ChalkOutcome::Exhausted => "exhausted",
             };
             tracing::debug!(solver_outcome, "slow prepared Chalk proof finished");
+        }
+        match &outcome {
+            ChalkOutcome::Unsupported => {
+                inference_cache.remember_declined_proof(clauses, DeclinedProof::Unsupported);
+            }
+            ChalkOutcome::Exhausted => {
+                inference_cache.remember_declined_proof(clauses, DeclinedProof::Exhausted);
+            }
+            ChalkOutcome::Proven(_) | ChalkOutcome::Ambiguous(_) | ChalkOutcome::NoSolution => {}
         }
         Ok(outcome)
     }
@@ -448,9 +500,20 @@ impl ChalkSolverState {
                 alias.args.iter().any(|arg| arg.has_var()) || ty.has_var()
             }
         });
+        let has_unresolved_projection = clauses.iter().any(|clause| match clause {
+            Clause::Implemented(application) => {
+                application.args.iter().any(|arg| arg.has_projection())
+            }
+            Clause::AliasEq { .. } => true,
+        });
         let quantum_budget = if has_live_inference {
+            crate::profile::metric::SOLVER_GOAL_SHAPES.inc("impl_bounds.live_inference");
             SPECULATIVE_GOAL_QUANTUM_BUDGET
+        } else if has_unresolved_projection {
+            crate::profile::metric::SOLVER_GOAL_SHAPES.inc("impl_bounds.unresolved_projection");
+            UNRESOLVED_PROJECTION_GOAL_QUANTUM_BUDGET
         } else {
+            crate::profile::metric::SOLVER_GOAL_SHAPES.inc("impl_bounds.settled");
             SETTLED_GOAL_QUANTUM_BUDGET
         };
         let budget = SolverBudget::new(quantum_budget);
@@ -507,33 +570,54 @@ impl ChalkSolverState {
                 clause_count = clauses.len(),
                 quantum_budget,
                 has_live_inference,
+                has_unresolved_projection,
                 cache_scope = if cache_stable { "crate" } else { "body" },
                 "slow Chalk solver goal"
             );
         }
-        if budget.exhausted() {
-            return ChalkOutcome::Exhausted;
-        }
-        let Some(solution) = solution else {
-            return ChalkOutcome::NoSolution;
-        };
-        if solution.is_ambig() {
-            crate::profile::metric::SOLVER_AMBIGUOUS_GOALS.inc();
-        }
+        let outcome = 'outcome: {
+            if budget.exhausted() {
+                break 'outcome ChalkOutcome::Exhausted;
+            }
+            let Some(solution) = solution else {
+                break 'outcome ChalkOutcome::NoSolution;
+            };
+            if solution.is_ambig() {
+                crate::profile::metric::SOLVER_AMBIGUOUS_GOALS.inc();
+            }
 
-        let Some(subst) = solution.definite_subst(INTER) else {
-            return if solution.is_ambig() {
-                ChalkOutcome::Ambiguous(None)
-            } else {
-                ChalkOutcome::Proven(table.clone())
+            let Some(subst) = solution.definite_subst(INTER) else {
+                break 'outcome if solution.is_ambig() {
+                    ChalkOutcome::Ambiguous(None)
+                } else {
+                    ChalkOutcome::Proven(table.clone())
+                };
+            };
+            break 'outcome match Self::table_from_subst(&lowering.variables, &subst, table) {
+                Ok(table) if solution.is_ambig() => ChalkOutcome::Ambiguous(Some(table)),
+                Ok(table) => ChalkOutcome::Proven(table),
+                Err(AnswerFailure::Unsupported) => ChalkOutcome::Unsupported,
+                Err(AnswerFailure::Conflicting) => ChalkOutcome::NoSolution,
             };
         };
-        match Self::table_from_subst(&lowering.variables, &subst, table) {
-            Ok(table) if solution.is_ambig() => ChalkOutcome::Ambiguous(Some(table)),
-            Ok(table) => ChalkOutcome::Proven(table),
-            Err(AnswerFailure::Unsupported) => ChalkOutcome::Unsupported,
-            Err(AnswerFailure::Conflicting) => ChalkOutcome::NoSolution,
+        match &outcome {
+            ChalkOutcome::Proven(_) => {
+                crate::profile::metric::SOLVER_GOAL_OUTCOMES.inc("impl_bounds.proven");
+            }
+            ChalkOutcome::Ambiguous(_) => {
+                crate::profile::metric::SOLVER_GOAL_OUTCOMES.inc("impl_bounds.ambiguous");
+            }
+            ChalkOutcome::NoSolution => {
+                crate::profile::metric::SOLVER_GOAL_OUTCOMES.inc("impl_bounds.no_solution");
+            }
+            ChalkOutcome::Unsupported => {
+                crate::profile::metric::SOLVER_GOAL_OUTCOMES.inc("impl_bounds.unsupported");
+            }
+            ChalkOutcome::Exhausted => {
+                crate::profile::metric::SOLVER_GOAL_OUTCOMES.inc("impl_bounds.exhausted");
+            }
         }
+        outcome
     }
 
     fn normalize_assoc_type(
@@ -621,6 +705,13 @@ impl ChalkSolverState {
 
         let canonical_goal = chalk_goal.into_peeled_goal(INTER);
         crate::profile::metric::SOLVER_GOALS.inc();
+        if selected_impl.is_some() {
+            crate::profile::metric::SOLVER_GOAL_SHAPES.inc("assoc_projection.selected_impl");
+        } else if has_live_inference {
+            crate::profile::metric::SOLVER_GOAL_SHAPES.inc("assoc_projection.live_inference");
+        } else {
+            crate::profile::metric::SOLVER_GOAL_SHAPES.inc("assoc_projection.settled");
+        }
         let started = Instant::now();
         let budget = SolverBudget::new(quantum_budget);
         // Projection answers containing body-owned identities have the same lifetime as the
@@ -666,36 +757,56 @@ impl ChalkSolverState {
                 "slow Chalk solver goal"
             );
         }
-        if budget.exhausted() {
-            return ChalkOutcome::Exhausted;
-        }
-        let Some(solution) = solution else {
-            return ChalkOutcome::NoSolution;
-        };
-        if solution.is_ambig() {
-            crate::profile::metric::SOLVER_AMBIGUOUS_GOALS.inc();
-        }
-
-        let applicability = if solution.is_ambig() {
-            TraitApplicability::Maybe
-        } else {
-            TraitApplicability::Yes
-        };
-        if let Some(subst) = solution.definite_subst(INTER) {
-            return match Self::projection_result_from_subst(
-                &projection,
-                &subst,
-                table,
-                applicability,
-            ) {
-                Ok(result) if solution.is_ambig() => ChalkOutcome::Ambiguous(Some(result)),
-                Ok(result) => ChalkOutcome::Proven(result),
-                Err(AnswerFailure::Unsupported) => ChalkOutcome::Unsupported,
-                Err(AnswerFailure::Conflicting) => ChalkOutcome::NoSolution,
+        let outcome = 'outcome: {
+            if budget.exhausted() {
+                break 'outcome ChalkOutcome::Exhausted;
+            }
+            let Some(solution) = solution else {
+                break 'outcome ChalkOutcome::NoSolution;
             };
-        }
+            if solution.is_ambig() {
+                crate::profile::metric::SOLVER_AMBIGUOUS_GOALS.inc();
+            }
 
-        ChalkOutcome::Ambiguous(None)
+            let applicability = if solution.is_ambig() {
+                TraitApplicability::Maybe
+            } else {
+                TraitApplicability::Yes
+            };
+            if let Some(subst) = solution.definite_subst(INTER) {
+                break 'outcome match Self::projection_result_from_subst(
+                    &projection,
+                    &subst,
+                    table,
+                    applicability,
+                ) {
+                    Ok(result) if solution.is_ambig() => ChalkOutcome::Ambiguous(Some(result)),
+                    Ok(result) => ChalkOutcome::Proven(result),
+                    Err(AnswerFailure::Unsupported) => ChalkOutcome::Unsupported,
+                    Err(AnswerFailure::Conflicting) => ChalkOutcome::NoSolution,
+                };
+            }
+
+            break 'outcome ChalkOutcome::Ambiguous(None);
+        };
+        match &outcome {
+            ChalkOutcome::Proven(_) => {
+                crate::profile::metric::SOLVER_GOAL_OUTCOMES.inc("assoc_projection.proven");
+            }
+            ChalkOutcome::Ambiguous(_) => {
+                crate::profile::metric::SOLVER_GOAL_OUTCOMES.inc("assoc_projection.ambiguous");
+            }
+            ChalkOutcome::NoSolution => {
+                crate::profile::metric::SOLVER_GOAL_OUTCOMES.inc("assoc_projection.no_solution");
+            }
+            ChalkOutcome::Unsupported => {
+                crate::profile::metric::SOLVER_GOAL_OUTCOMES.inc("assoc_projection.unsupported");
+            }
+            ChalkOutcome::Exhausted => {
+                crate::profile::metric::SOLVER_GOAL_OUTCOMES.inc("assoc_projection.exhausted");
+            }
+        }
+        outcome
     }
 
     /// Decode one substitution produced for the projection existential and its input variables.

--- a/crates/engine/ty/src/trait_selection/declaration_cache.rs
+++ b/crates/engine/ty/src/trait_selection/declaration_cache.rs
@@ -1,0 +1,292 @@
+//! Snapshot-scoped canonical crate declarations shared by independent solver sessions.
+//!
+//! A crate declaration is lowered from its own semantic origin, so the result does not depend on
+//! the crate that later asks whether one of its impls is visible. Body IR resolves many use-site
+//! crates in parallel; sharing these owned summaries avoids lowering the same dependency
+//! declaration for every crate while each session keeps its own visible impl set and Chalk forests.
+
+use std::{
+    collections::HashMap,
+    hash::Hash,
+    sync::{
+        Arc, Mutex, OnceLock, RwLock,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use rg_ir_model::{FunctionRef, GenericDefRef, ImplRef, TraitDefRef, TypeAliasRef};
+
+use crate::signature::TraitHeader;
+use crate::{CallableSignature, ImplHeader, OpaqueTy, TraitRefLowering, Ty};
+
+/// Opaque identities declared by one owner together with each identity's lowered bounds.
+pub(super) type OpaqueBounds = Vec<(OpaqueTy, Vec<TraitRefLowering>)>;
+
+/// One cache entry whose loader can fail without poisoning later requests.
+///
+/// The `OnceLock` stores both a found declaration and a stable absence. The small mutex only
+/// serializes the first successful load for this key; initialized reads do not take it.
+struct DeclarationSlot<V> {
+    value: OnceLock<Option<Arc<V>>>,
+    load: Mutex<()>,
+}
+
+impl<V> Default for DeclarationSlot<V> {
+    fn default() -> Self {
+        Self {
+            value: OnceLock::new(),
+            load: Mutex::new(()),
+        }
+    }
+}
+
+/// Canonical crate declarations shared while one immutable semantic snapshot is being analyzed.
+///
+/// The cache contains no visibility decisions, inference values, or solver answers. Its owner
+/// creates it at a semantic-snapshot boundary and clones the handle into every use-site session
+/// built from that snapshot. Body-origin declarations do not enter this cache because their path
+/// resolver may expose request-local items. A later snapshot must get a new cache.
+#[derive(Clone, Default)]
+pub struct TraitSelectionDeclarationCache {
+    shared: Arc<TraitSelectionDeclarations>,
+}
+
+/// Shared storage released after the last build or query owner drops its cache handle.
+#[derive(Default)]
+struct TraitSelectionDeclarations {
+    impl_headers: DeclarationMap<ImplRef, ImplHeader>,
+    trait_headers: DeclarationMap<TraitDefRef, TraitHeader>,
+    type_alias_tys: DeclarationMap<TypeAliasRef, Ty>,
+    function_signatures: DeclarationMap<FunctionRef, CallableSignature>,
+    opaque_bounds: DeclarationMap<GenericDefRef, OpaqueBounds>,
+}
+
+impl Drop for TraitSelectionDeclarations {
+    fn drop(&mut self) {
+        // Recording every lookup through the shared profiler would make profiling itself contend
+        // on hot declarations. Fold relaxed atomic counters into the profile once the snapshot
+        // cache dies.
+        self.impl_headers
+            .report("impl_header.hit", "impl_header.miss");
+        self.trait_headers
+            .report("trait_header.hit", "trait_header.miss");
+        self.type_alias_tys
+            .report("type_alias_ty.hit", "type_alias_ty.miss");
+        self.function_signatures
+            .report("function_signature.hit", "function_signature.miss");
+        self.opaque_bounds
+            .report("opaque_bounds.hit", "opaque_bounds.miss");
+    }
+}
+
+/// Concurrent declaration table with a separate initialization slot for each identity.
+///
+/// The map lock protects only identity-to-slot lookup. Declaration lowering happens after that
+/// lock is released, so unrelated missing declarations can be loaded in parallel.
+struct DeclarationMap<K, V> {
+    entries: RwLock<HashMap<K, Arc<DeclarationSlot<V>>>>,
+    hits: AtomicU64,
+    misses: AtomicU64,
+}
+
+impl<K, V> Default for DeclarationMap<K, V> {
+    fn default() -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+        }
+    }
+}
+
+/// Whether this request published a declaration result or reused an initialized slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeclarationCacheAccess {
+    Hit,
+    Miss,
+}
+
+impl TraitSelectionDeclarationCache {
+    /// Start an empty declaration cache for one semantic snapshot.
+    ///
+    /// Cloning the returned handle shares its entries; calling `new` again starts an independent
+    /// cache for another snapshot or standalone session.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(super) fn impl_header<E>(
+        &self,
+        impl_ref: ImplRef,
+        load: impl FnOnce() -> Result<Option<ImplHeader>, E>,
+    ) -> Result<Option<Arc<ImplHeader>>, E> {
+        let (header, _) = self.shared.impl_headers.get_or_try_init(impl_ref, load)?;
+        Ok(header)
+    }
+
+    pub(super) fn trait_header<E>(
+        &self,
+        trait_ref: TraitDefRef,
+        load: impl FnOnce() -> Result<Option<TraitHeader>, E>,
+    ) -> Result<Option<Arc<TraitHeader>>, E> {
+        let (header, _) = self.shared.trait_headers.get_or_try_init(trait_ref, load)?;
+        Ok(header)
+    }
+
+    pub(super) fn type_alias_ty<E>(
+        &self,
+        alias: TypeAliasRef,
+        load: impl FnOnce() -> Result<Option<Ty>, E>,
+    ) -> Result<Option<Arc<Ty>>, E> {
+        let (ty, _) = self.shared.type_alias_tys.get_or_try_init(alias, load)?;
+        Ok(ty)
+    }
+
+    pub(super) fn function_signature<E>(
+        &self,
+        function: FunctionRef,
+        load: impl FnOnce() -> Result<Option<CallableSignature>, E>,
+    ) -> Result<Option<Arc<CallableSignature>>, E> {
+        let (signature, _) = self
+            .shared
+            .function_signatures
+            .get_or_try_init(function, load)?;
+        Ok(signature)
+    }
+
+    pub(super) fn opaque_bounds<E>(
+        &self,
+        owner: GenericDefRef,
+        load: impl FnOnce() -> Result<OpaqueBounds, E>,
+    ) -> Result<Arc<OpaqueBounds>, E> {
+        let (bounds, _) = self
+            .shared
+            .opaque_bounds
+            .get_or_try_init(owner, || load().map(Some))?;
+        Ok(bounds.expect("opaque-bounds cache loader always stores a value"))
+    }
+}
+
+impl<K, V> DeclarationMap<K, V>
+where
+    K: Eq + Hash,
+{
+    /// Load one declaration while holding only its per-key initialization lock.
+    ///
+    /// Initialized entries use a concurrent map read and a lock-free `OnceLock` read. Contenders
+    /// for the same missing declaration wait for the first loader; errors leave the slot empty so a
+    /// later request can retry rather than turning a transient package-load failure into cached
+    /// semantic absence.
+    fn get_or_try_init<E>(
+        &self,
+        key: K,
+        load: impl FnOnce() -> Result<Option<V>, E>,
+    ) -> Result<(Option<Arc<V>>, DeclarationCacheAccess), E> {
+        // Find or create a stable per-key slot, then release the table lock before doing semantic
+        // work. The write-side `entry` handles two unrelated readers racing to create the slot.
+        let existing = {
+            let entries = self
+                .entries
+                .read()
+                .expect("declaration-cache map read lock should not be poisoned");
+            entries.get(&key).cloned()
+        };
+        let slot = if let Some(slot) = existing {
+            slot
+        } else {
+            self.entries
+                .write()
+                .expect("declaration-cache map write lock should not be poisoned")
+                .entry(key)
+                .or_insert_with(|| Arc::new(DeclarationSlot::default()))
+                .clone()
+        };
+
+        // Initialized declarations, including a cached `None`, never take the per-key load lock.
+        if let Some(value) = slot.value.get() {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            return Ok((value.clone(), DeclarationCacheAccess::Hit));
+        }
+
+        // Exactly one contender loads this key. Recheck after locking because another contender
+        // may have initialized the slot while this request was waiting.
+        let _load = slot
+            .load
+            .lock()
+            .expect("declaration-cache entry load lock should not be poisoned");
+        if let Some(value) = slot.value.get() {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            return Ok((value.clone(), DeclarationCacheAccess::Hit));
+        }
+
+        // Publish either the declaration or its stable absence. An error returns before `set`, so
+        // a later request can retry the same key against a healthy package source.
+        let value = load()?.map(Arc::new);
+        assert!(
+            slot.value.set(value.clone()).is_ok(),
+            "declaration-cache entry should only initialize under its load lock"
+        );
+        self.misses.fetch_add(1, Ordering::Relaxed);
+        Ok((value, DeclarationCacheAccess::Miss))
+    }
+
+    /// Fold low-contention hit and miss counters into the ordinary profile report.
+    fn report(&self, hit_key: &'static str, miss_key: &'static str) {
+        let hits = self.hits.load(Ordering::Relaxed);
+        let misses = self.misses.load(Ordering::Relaxed);
+        if hits != 0 {
+            crate::profile::metric::DECLARATION_CACHE_ACCESSES.add(hit_key, hits);
+        }
+        if misses != 0 {
+            crate::profile::metric::DECLARATION_CACHE_ACCESSES.add(miss_key, misses);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[test]
+    fn concurrent_requests_lower_one_declaration_once() {
+        let declarations = DeclarationMap::<u8, u8>::default();
+        let load_count = AtomicUsize::new(0);
+
+        std::thread::scope(|scope| {
+            let requests = (0..8)
+                .map(|_| {
+                    scope.spawn(|| {
+                        declarations.get_or_try_init(7, || {
+                            load_count.fetch_add(1, Ordering::Relaxed);
+                            Ok::<_, Infallible>(Some(42))
+                        })
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            let mut accesses = requests
+                .into_iter()
+                .map(|request| {
+                    let (value, access) = request
+                        .join()
+                        .expect("declaration-cache test worker should not panic")
+                        .expect("infallible declaration load should succeed");
+                    assert_eq!(value.as_deref(), Some(&42));
+                    access
+                })
+                .collect::<Vec<_>>();
+            accesses.sort_by_key(|access| matches!(access, DeclarationCacheAccess::Hit));
+
+            assert_eq!(accesses[0], DeclarationCacheAccess::Miss);
+            assert!(
+                accesses[1..]
+                    .iter()
+                    .all(|access| *access == DeclarationCacheAccess::Hit)
+            );
+        });
+        assert_eq!(load_count.load(Ordering::Relaxed), 1);
+    }
+}

--- a/crates/engine/ty/src/trait_selection/mod.rs
+++ b/crates/engine/ty/src/trait_selection/mod.rs
@@ -200,38 +200,40 @@ where
         subst: &InferenceSubstitution,
         table: &InferenceTable,
     ) -> Result<TraitProof, I::Error> {
-        self.prove_clauses_with_candidate_evidence(clauses, subst, table, CandidateEvidence::Probe)
+        self.prove_clauses_with_candidate_evidence(clauses, subst, table, CandidateEvidence::ROOT)
     }
 
-    /// Prove predicates belonging to a native candidate without selecting that candidate again.
+    /// Prove predicates belonging to a native candidate without recursively selecting an impl
+    /// already on the same proof path.
     ///
-    /// Candidate selection may recursively encounter projections in the candidate's own bounds.
-    /// Chalk's forest owns cycle handling there; native projection probes are reserved for callers
-    /// that enter through the outer semantic-query boundary.
+    /// A candidate's predicates may project through an unrelated predicate-free impl. That direct
+    /// declaration is useful native evidence; candidates that need another proof remain together
+    /// in the outer Chalk goal.
     fn prove_candidate_clauses(
         &self,
         clauses: &[Clause],
         subst: &InferenceSubstitution,
         table: &InferenceTable,
+        active_impls: &[ImplRef],
     ) -> Result<TraitProof, I::Error> {
         self.prove_clauses_with_candidate_evidence(
             clauses,
             subst,
             table,
-            CandidateEvidence::SolverOnly,
+            CandidateEvidence::within(active_impls),
         )
     }
 
     /// Normalize declaration predicates, try the native proof forms, then fall back to Chalk.
     ///
-    /// `candidate_evidence` controls only recursive associated-type normalization. Candidate proof
-    /// must not reselect the same impl while normalizing one of that impl's own predicates.
+    /// `candidate_evidence` controls only recursive associated-type normalization. Its active path
+    /// enables cheap declaration projection without recursively building a second trait engine.
     fn prove_clauses_with_candidate_evidence(
         &self,
         clauses: &[Clause],
         subst: &InferenceSubstitution,
         table: &InferenceTable,
-        candidate_evidence: CandidateEvidence,
+        candidate_evidence: CandidateEvidence<'_>,
     ) -> Result<TraitProof, I::Error> {
         if clauses.is_empty() {
             return Ok(TraitProof::Proven(table.clone()));
@@ -262,7 +264,7 @@ where
                         args.push(arg);
                     }
                     application.args = args.into();
-                    Clause::Implemented(application)
+                    Some(Clause::Implemented(application))
                 }
                 Clause::AliasEq { mut alias, ty } => {
                     let mut args = Vec::with_capacity(alias.args.len());
@@ -285,10 +287,40 @@ where
                     let (ty, next_table) =
                         self.normalize_ty_with_candidate_evidence(&ty, &table, candidate_evidence)?;
                     table = next_table;
-                    Clause::AliasEq { alias, ty }
+
+                    // A declaration-owned associated equality is itself a projection proof, not
+                    // merely a type containing projections. Resolve an exact selected value here
+                    // so the native impl-chain prover can consume the remaining ordinary bounds.
+                    // Ambiguous guidance may refine the table but keeps the equality for Chalk.
+                    let projection = self.normalize_projection_once(
+                        &alias,
+                        &table,
+                        candidate_evidence.native_only(),
+                    )?;
+                    if let Some(projection) = projection {
+                        let (projected_ty, applicability, projected_table) =
+                            projection.into_parts();
+                        table = projected_table;
+                        if table.try_unify(&projected_ty, &ty).is_err() {
+                            return Ok(TraitProof::NoSolution);
+                        }
+                        if applicability == TraitApplicability::Yes && !ty.has_unknown() {
+                            None
+                        } else {
+                            Some(Clause::AliasEq { alias, ty })
+                        }
+                    } else {
+                        Some(Clause::AliasEq { alias, ty })
+                    }
                 }
             };
-            normalized_clauses.push(table.canonicalize_clause(&clause));
+            if let Some(clause) = clause {
+                normalized_clauses.push(table.canonicalize_clause(&clause));
+            }
+        }
+
+        if normalized_clauses.is_empty() {
+            return Ok(TraitProof::Proven(table));
         }
 
         if let Some(proof) = NativeProofQuery::new(self).prove(&normalized_clauses, &table)? {
@@ -337,10 +369,23 @@ where
         goal: &TraitGoal,
         table: &InferenceTable,
     ) -> Result<(ExpectedUnique<TraitSelection>, bool), I::Error> {
+        self.probe_with_completeness_avoiding(goal, table, CandidateEvidence::ROOT)
+    }
+
+    /// Probe candidates while reserving active impls for the outer Chalk goal.
+    fn probe_with_completeness_avoiding(
+        &self,
+        goal: &TraitGoal,
+        table: &InferenceTable,
+        candidate_evidence: CandidateEvidence<'_>,
+    ) -> Result<(ExpectedUnique<TraitSelection>, bool), I::Error> {
+        let active_impls = candidate_evidence.active_impls();
         // A goal that carries live inference or closure identity must be re-evaluated with its
         // owning table. Fully stable semantic goals cannot change the caller's table, so cache only
-        // the selected impl/substitution and attach the caller's current table on a hit.
-        let cacheable = goal.is_cache_stable();
+        // the selected impl/substitution and attach the caller's current table on a hit. Recursive
+        // candidate proof cannot use this cache because a cached answer may itself be on the active
+        // path.
+        let cacheable = active_impls.is_empty() && goal.is_cache_stable();
         if cacheable
             && let Some(selection) = self.context.trait_selection().strict_selection(goal, table)
         {
@@ -360,7 +405,14 @@ where
         let mut maybe_selections = ExpectedUnique::new();
         let mut fully_evaluated = true;
         for candidate in candidates {
-            let selection = match self.select_candidate(goal, candidate)? {
+            if active_impls.contains(&candidate.trait_impl.impl_ref) {
+                // Returning an ordinary empty result here would incorrectly prove absence for a
+                // nominal receiver. Mark the probe incomplete so projection normalization enters
+                // Chalk, whose forest owns recursive semantic goals.
+                crate::profile::metric::NATIVE_CANDIDATE_CYCLES.inc();
+                return Ok((ExpectedUnique::new(), false));
+            }
+            let selection = match self.select_candidate(goal, candidate, candidate_evidence)? {
                 SemanticOutcome::Available(selection) => selection,
                 SemanticOutcome::Rejected => continue,
                 SemanticOutcome::Unavailable => {
@@ -450,7 +502,8 @@ where
         // cannot classify it. The trial starts from the caller's live inference state, so any
         // body-owned variables keep their original identities.
         let unavailable = candidate.clone();
-        let outcome = self.select_candidate_with_header(&goal, candidate, header)?;
+        let outcome =
+            self.select_candidate_with_header(&goal, candidate, header, CandidateEvidence::ROOT)?;
         let selection = match outcome {
             SemanticOutcome::Available(selection) => {
                 self.context
@@ -487,6 +540,7 @@ where
         &self,
         goal: &TraitGoal,
         candidate: TraitCandidate,
+        candidate_evidence: CandidateEvidence<'_>,
     ) -> Result<SemanticOutcome<TraitSelection>, I::Error> {
         let Some(header) = self.context.trait_selection().impl_header_with(
             self.context.item_paths(),
@@ -496,7 +550,7 @@ where
         else {
             return Ok(SemanticOutcome::Unavailable);
         };
-        self.select_candidate_with_header(goal, candidate, &header)
+        self.select_candidate_with_header(goal, candidate, &header, candidate_evidence)
     }
 
     /// Prove a candidate whose canonical header is already available to the caller.
@@ -505,6 +559,7 @@ where
         goal: &TraitGoal,
         candidate: TraitCandidate,
         header: &crate::ImplHeader,
+        candidate_evidence: CandidateEvidence<'_>,
     ) -> Result<SemanticOutcome<TraitSelection>, I::Error> {
         let TraitCandidate {
             trait_impl,
@@ -512,6 +567,16 @@ where
             mut applicability,
             mut table,
         } = candidate;
+
+        // Candidate-aware projection is a declaration shortcut, not recursive trait solving.
+        // A predicate-free impl can provide its associated value immediately. If this impl has
+        // conditions of its own, keep the original projection equality in the caller's combined
+        // Chalk goal; proving it here would branch candidate trees and materialize one program per
+        // leaf.
+        if !candidate_evidence.allows_solver_fallback() && !header.clauses.is_empty() {
+            crate::profile::metric::NATIVE_CANDIDATE_PREDICATE_DECLINES.inc();
+            return Ok(SemanticOutcome::Unavailable);
+        }
 
         let generics = self
             .context
@@ -523,8 +588,12 @@ where
         if header.clauses.is_empty() {
             crate::profile::metric::PREDICATE_FREE_CANDIDATES.inc();
         } else {
+            let active_impls = candidate_evidence.active_impls();
+            let mut candidate_path = Vec::with_capacity(active_impls.len() + 1);
+            candidate_path.extend_from_slice(active_impls);
+            candidate_path.push(trait_impl.impl_ref);
             let predicate_applicability =
-                self.prove_candidate_clauses(&header.clauses, &subst, &table)?;
+                self.prove_candidate_clauses(&header.clauses, &subst, &table, &candidate_path)?;
             match predicate_applicability {
                 TraitProof::Proven(proven_table) => table = proven_table,
                 TraitProof::Ambiguous(guided_table) => {

--- a/crates/engine/ty/src/trait_selection/mod.rs
+++ b/crates/engine/ty/src/trait_selection/mod.rs
@@ -5,9 +5,15 @@
 //! the remaining predicates and associated-type equalities. Keeping discovery, native proof, and
 //! solver fallback as different types prevents exploratory editor candidates from being mistaken
 //! for established semantic facts.
+//!
+//! Canonical crate declarations have a wider reuse boundary than solver state. Their lowered types
+//! can be shared by sessions over the same semantic snapshot, while visible impl indexes, Chalk
+//! forests, body declarations, and inference answers remain owned by the use-site session that
+//! produced them.
 
 mod candidate;
 mod chalk;
+mod declaration_cache;
 mod matcher;
 mod native_proof;
 mod projection;
@@ -20,6 +26,7 @@ use rg_std::ExpectedUnique;
 
 use self::candidate::TraitCandidate;
 use self::chalk::ChalkOutcome;
+pub use self::declaration_cache::TraitSelectionDeclarationCache;
 use self::native_proof::NativeProofQuery;
 pub use self::projection::AssocProjectionResult;
 use self::projection::CandidateEvidence;

--- a/crates/engine/ty/src/trait_selection/projection.rs
+++ b/crates/engine/ty/src/trait_selection/projection.rs
@@ -17,7 +17,7 @@ use super::{ChalkOutcome, TraitGoal, TraitSelection, TraitSelectionQuery};
 use crate::inference::InferenceTable;
 use crate::{
     AdtTy, AliasTy, ClosureTy, FnDefTy, GenericArg, GenericArgs, OpaqueTy, ProjectionTy,
-    SemanticSignatureQuery, Substitution, TraitApplication, Ty,
+    Substitution, TraitApplication, Ty,
 };
 
 /// Result of normalizing one selected associated type projection.
@@ -295,8 +295,10 @@ where
         if !can_project_directly(alias_data) {
             return Ok(None);
         }
-        let Some(selected_value) =
-            SemanticSignatureQuery::type_alias_ty_from(self.context.item_paths(), alias)?
+        let Some(selected_value) = self
+            .context
+            .trait_selection()
+            .type_alias_ty_with(self.context.item_paths(), alias)?
         else {
             return Ok(None);
         };

--- a/crates/engine/ty/src/trait_selection/projection.rs
+++ b/crates/engine/ty/src/trait_selection/projection.rs
@@ -334,7 +334,12 @@ where
                     associated_ty: alias.associated_ty,
                     args: self.normalize_args(&alias.args, table, active, candidate_evidence)?,
                 };
-                if active.contains(&alias) {
+                // Solver retries can reproduce one projection with freshly allocated inference
+                // slots. Their numeric IDs differ, but they still describe the same obligation.
+                if active
+                    .iter()
+                    .any(|active_alias| active_alias.equivalent_modulo_inference_ids(&alias))
+                {
                     return Ok(Ty::Alias(AliasTy::Projection(alias)));
                 }
 

--- a/crates/engine/ty/src/trait_selection/projection.rs
+++ b/crates/engine/ty/src/trait_selection/projection.rs
@@ -6,10 +6,13 @@
 //! bounded boundary so nested aliases use the same evidence and inference table.
 
 use rg_def_map::DefMapSource;
-use rg_ir_model::{GenericDefRef, ItemOwner, TraitApplicability, TraitDefRef, TypeAliasRef};
+use rg_ir_model::{
+    GenericDefRef, ImplRef, ItemOwner, TraitApplicability, TraitDefRef, TypeAliasRef,
+};
 use rg_semantic_ir::ItemStoreSource;
 use rg_std::ExpectedUnique;
 
+use super::matcher::TraitSelfHead;
 use super::{ChalkOutcome, TraitGoal, TraitSelection, TraitSelectionQuery};
 use crate::inference::InferenceTable;
 use crate::{
@@ -28,17 +31,47 @@ pub struct AssocProjectionResult {
     pub table: InferenceTable,
 }
 
-/// Whether recursive normalization may use native candidate selection as extra evidence.
+/// Native impls already being proved while recursively normalizing associated projections.
 ///
-/// An outer query starts in `Probe` mode. Once candidate predicates are being proved, recursively
-/// probing the same candidate would re-enter native selection; `SolverOnly` leaves that cycle to
-/// Chalk's own forest instead.
+/// Candidate predicates often mention an associated type supplied by a different predicate-free
+/// impl. That declaration is cheap native evidence and should not force the entire predicate into
+/// Chalk. The path also tells normalization to preserve solver-shaped projections for the outer
+/// combined goal instead of solving each one independently.
 #[derive(Clone, Copy)]
-pub(super) enum CandidateEvidence {
-    /// Use native selection to instantiate an already-proved impl value before solver search.
-    Probe,
-    /// Stay inside Chalk while normalizing a predicate that native selection is proving.
-    SolverOnly,
+pub(super) struct CandidateEvidence<'path> {
+    active_impls: &'path [ImplRef],
+    native_declarations_only: bool,
+}
+
+impl CandidateEvidence<'static> {
+    pub(super) const ROOT: Self = Self {
+        active_impls: &[],
+        native_declarations_only: false,
+    };
+}
+
+impl<'path> CandidateEvidence<'path> {
+    pub(super) fn within(active_impls: &'path [ImplRef]) -> Self {
+        Self {
+            active_impls,
+            native_declarations_only: true,
+        }
+    }
+
+    pub(super) fn active_impls(self) -> &'path [ImplRef] {
+        self.active_impls
+    }
+
+    pub(super) fn native_only(self) -> Self {
+        Self {
+            native_declarations_only: true,
+            ..self
+        }
+    }
+
+    pub(super) fn allows_solver_fallback(self) -> bool {
+        !self.native_declarations_only
+    }
 }
 
 impl AssocProjectionResult {
@@ -67,7 +100,7 @@ where
             return Ok(None);
         };
         let Some(mut projection) =
-            self.normalize_assoc_type_once(goal, associated_ty, table, CandidateEvidence::Probe)?
+            self.normalize_assoc_type_once(goal, associated_ty, table, CandidateEvidence::ROOT)?
         else {
             return Ok(None);
         };
@@ -76,7 +109,7 @@ where
             &projection.ty,
             &mut table,
             &mut Vec::new(),
-            CandidateEvidence::Probe,
+            CandidateEvidence::ROOT,
         )?;
         projection.table = table;
         Ok(Some(projection))
@@ -88,29 +121,43 @@ where
         goal: &TraitGoal,
         associated_ty: TypeAliasRef,
         table: &InferenceTable,
-        candidate_evidence: CandidateEvidence,
+        candidate_evidence: CandidateEvidence<'_>,
     ) -> Result<Option<AssocProjectionResult>, I::Error> {
-        let selection = match candidate_evidence {
-            CandidateEvidence::Probe => {
-                let (selection, fully_evaluated) = self.probe_with_completeness(goal, table)?;
-                match selection {
-                    ExpectedUnique::One(selection) => Some(selection),
-                    // Native matching indexes every ordinary impl by the concrete ADT head. Once
-                    // all matching candidates were classified, Chalk has no additional source of
-                    // evidence for that nominal type. Opaque, generic, and callable types still
-                    // fall through because their bounds or built-in clauses can prove a goal with
-                    // no ordinary impl identity.
-                    ExpectedUnique::Empty
-                        if fully_evaluated
-                            && matches!(table.resolve_root_var(goal.self_ty()), Ty::Adt(_)) =>
-                    {
-                        return Ok(None);
-                    }
-                    ExpectedUnique::Empty | ExpectedUnique::Ambiguous => None,
-                }
+        if !candidate_evidence.allows_solver_fallback() {
+            let self_ty = table.resolve_root_var(goal.self_ty());
+            let is_stable_headed_goal = goal.is_cache_stable()
+                && !goal.application.args.iter().any(GenericArg::has_unknown)
+                && TraitSelfHead::from_ty(&self_ty).is_some();
+            if !is_stable_headed_goal {
+                crate::profile::metric::NATIVE_CANDIDATE_UNSTABLE_DECLINES.inc();
+                return Ok(None);
             }
-            CandidateEvidence::SolverOnly => None,
+        }
+
+        let (selection, fully_evaluated) =
+            self.probe_with_completeness_avoiding(goal, table, candidate_evidence)?;
+        if !candidate_evidence.allows_solver_fallback() && !fully_evaluated {
+            // A predicate-bearing or recursive competing candidate can change the associated
+            // value. Keep the equality for Chalk unless native discovery classified the complete
+            // matching set.
+            return Ok(None);
+        }
+        let selection = match selection {
+            ExpectedUnique::One(selection) => Some(selection),
+            // Native matching indexes every ordinary impl by the concrete ADT head. Once all
+            // matching candidates were classified, Chalk has no additional source of evidence
+            // for that nominal type. Opaque, generic, and callable types still fall through
+            // because their bounds or built-in clauses can prove a goal with no ordinary impl
+            // identity.
+            ExpectedUnique::Empty
+                if fully_evaluated
+                    && matches!(table.resolve_root_var(goal.self_ty()), Ty::Adt(_)) =>
+            {
+                return Ok(None);
+            }
+            ExpectedUnique::Empty | ExpectedUnique::Ambiguous => None,
         };
+
         let selection_table = selection
             .as_ref()
             .map(|selection| &selection.table)
@@ -122,7 +169,15 @@ where
         if let Some(selection) = &selection
             && let Some(projection) = self.project_selected_impl(goal, associated_ty, selection)?
         {
+            crate::profile::metric::NATIVE_ASSOC_PROJECTIONS.inc();
             return Ok(Some(projection));
+        }
+
+        // Native-only normalization is performed while preparing a larger predicate conjunction.
+        // Preserve anything that is not a direct declaration so the caller submits one combined
+        // Chalk goal instead of materializing a transitive program for each equality separately.
+        if !candidate_evidence.allows_solver_fallback() {
+            return Ok(None);
         }
 
         let projection = self.context.trait_selection().normalize_assoc_type(
@@ -151,6 +206,41 @@ where
             projection.applicability = selection.applicability.and(projection.applicability);
         }
         Ok(Some(projection))
+    }
+
+    /// Normalize one already-resolved projection identity through the same candidate path as a
+    /// type-tree projection.
+    ///
+    /// Alias-equality predicates use this entry point before native proof. A definite selected
+    /// value can discharge the equality without asking Chalk to rediscover the same impl.
+    pub(super) fn normalize_projection_once(
+        &self,
+        alias: &ProjectionTy,
+        table: &InferenceTable,
+        candidate_evidence: CandidateEvidence<'_>,
+    ) -> Result<Option<AssocProjectionResult>, I::Error> {
+        let Some(data) = self
+            .context
+            .item_paths()
+            .items()
+            .type_alias_data(alias.associated_ty)?
+        else {
+            return Ok(None);
+        };
+        let ItemOwner::Trait(trait_id) = data.owner else {
+            return Ok(None);
+        };
+        let goal = TraitGoal {
+            application: TraitApplication {
+                def: TraitDefRef {
+                    origin: alias.associated_ty.origin,
+                    id: trait_id,
+                },
+                args: alias.args.clone(),
+            },
+            associated_types: Vec::new(),
+        };
+        self.normalize_assoc_type_once(&goal, alias.associated_ty, table, candidate_evidence)
     }
 
     /// Instantiate a plain associated value from an already-proved nominal impl.
@@ -236,14 +326,14 @@ where
         ty: &Ty,
         table: &InferenceTable,
     ) -> Result<(Ty, InferenceTable), I::Error> {
-        self.normalize_ty_with_candidate_evidence(ty, table, CandidateEvidence::Probe)
+        self.normalize_ty_with_candidate_evidence(ty, table, CandidateEvidence::ROOT)
     }
 
     pub(super) fn normalize_ty_with_candidate_evidence(
         &self,
         ty: &Ty,
         table: &InferenceTable,
-        candidate_evidence: CandidateEvidence,
+        candidate_evidence: CandidateEvidence<'_>,
     ) -> Result<(Ty, InferenceTable), I::Error> {
         let mut table = table.clone();
         let ty =
@@ -256,7 +346,7 @@ where
         ty: &Ty,
         table: &mut InferenceTable,
         active: &mut Vec<ProjectionTy>,
-        candidate_evidence: CandidateEvidence,
+        candidate_evidence: CandidateEvidence<'_>,
     ) -> Result<Ty, I::Error> {
         Ok(match ty {
             Ty::Tuple(fields) => Ty::tuple(
@@ -343,37 +433,11 @@ where
                     return Ok(Ty::Alias(AliasTy::Projection(alias)));
                 }
 
-                let Some(data) = self
-                    .context
-                    .item_paths()
-                    .items()
-                    .type_alias_data(alias.associated_ty)?
-                else {
-                    return Ok(Ty::Alias(AliasTy::Projection(alias)));
-                };
-                let ItemOwner::Trait(trait_id) = data.owner else {
-                    return Ok(Ty::Alias(AliasTy::Projection(alias)));
-                };
-                let goal = TraitGoal {
-                    application: TraitApplication {
-                        def: TraitDefRef {
-                            origin: alias.associated_ty.origin,
-                            id: trait_id,
-                        },
-                        args: alias.args.clone(),
-                    },
-                    associated_types: Vec::new(),
-                };
-
                 // Associated values can form cycles across multiple aliases. Stop at the first
                 // repeated semantic projection and keep that alias visible to the caller.
                 active.push(alias.clone());
-                let normalized = self.normalize_assoc_type_once(
-                    &goal,
-                    alias.associated_ty,
-                    table,
-                    candidate_evidence,
-                )?;
+                let normalized =
+                    self.normalize_projection_once(&alias, table, candidate_evidence)?;
                 let ty = if let Some(normalized) = normalized {
                     let (ty, _applicability, normalized_table) = normalized.into_parts();
                     *table = normalized_table;
@@ -410,7 +474,7 @@ where
         args: &GenericArgs,
         table: &mut InferenceTable,
         active: &mut Vec<ProjectionTy>,
-        candidate_evidence: CandidateEvidence,
+        candidate_evidence: CandidateEvidence<'_>,
     ) -> Result<GenericArgs, I::Error> {
         args.iter()
             .map(|arg| {

--- a/crates/engine/ty/src/trait_selection/session.rs
+++ b/crates/engine/ty/src/trait_selection/session.rs
@@ -1,11 +1,18 @@
-//! Ownership and cache lifetimes for one trait-selection use-site crate.
+//! Ownership and cache lifetimes for trait selection.
 //!
-//! Crate-semantic state is shared by every query for the use-site. A session adds one inference
-//! cache whose answers may contain body-owned variables and closure identities.
+//! Trait selection reuses work at three different boundaries:
 //!
-//! `TraitSelectionSession::new` starts both layers. `fresh_inference_scope` and `for_body` keep the
-//! crate layer and replace only the inference layer. Cloning any session shares all of the state it
-//! already owns; a clone does not accidentally start another solver program or inference cache.
+//! 1. `TraitSelectionDeclarationCache` belongs to one immutable semantic snapshot. Sessions for
+//!    different use-site crates may share it because canonical crate declaration types do not
+//!    contain visibility decisions or solver answers.
+//! 2. `TraitSelectionShared` belongs to one use-site crate. It owns that crate's visible candidate
+//!    indexes, growing Chalk program, stable solver forests, and body-origin impl headers.
+//! 3. `TraitSelectionSession` adds an inference cache. That cache may contain live variables and
+//!    closure identities, so `fresh_inference_scope` and `for_body` replace only this layer.
+//!
+//! Cloning a session shares every layer already attached to it. `new` creates a standalone
+//! declaration layer; `new_with_declaration_cache` joins the snapshot layer supplied by a project
+//! build or query owner.
 
 use std::{
     collections::HashMap,
@@ -14,16 +21,22 @@ use std::{
 };
 
 use rg_def_map::DefMapSource;
-use rg_ir_model::{CrateRef, ImplRef, TraitApplicability, TraitDefRef, TraitImplRef, TypeAliasRef};
+use rg_ir_model::{
+    CrateRef, FunctionRef, GenericDefRef, ImplRef, TraitApplicability, TraitDefRef, TraitImplRef,
+    TypeAliasRef,
+};
 use rg_semantic_ir::{CrateItemQuery, ItemLookupIndex, ItemStoreSource};
 use rg_std::{ExpectedUnique, UniqueVec};
 
 use super::chalk::{ChalkInferenceCache, ChalkOutcome, ChalkTraitSolver};
+use super::declaration_cache::{OpaqueBounds, TraitSelectionDeclarationCache};
 use super::matcher::{TraitImplCandidateIndex, TraitSelfHead};
 use super::{AssocProjectionResult, TraitGoal, TraitSelection};
 use crate::inference::{InferenceSubstitution, InferenceTable};
-use crate::signature::impl_header_with;
-use crate::{Clause, ItemPathQuery, TypePathResolver};
+use crate::signature::impl_header_with as lower_impl_header;
+use crate::{
+    CallableSignature, Clause, ItemPathQuery, SemanticSignatureQuery, Ty, TypePathResolver,
+};
 
 /// Cross-body part of a cached selection.
 ///
@@ -60,17 +73,20 @@ type TraitImplCandidateIndexes = Mutex<HashMap<TraitDefRef, SharedTraitImplCandi
 type ExactCandidateApplicabilities =
     Mutex<HashMap<TraitImplRef, HashMap<TraitGoal, TraitApplicability>>>;
 
-/// Crate-semantic solver state shared by every session for one use-site crate.
+/// Crate-semantic solver state shared by one use-site session and its inference scopes.
 ///
-/// Everything here is safe to keep after a body finishes. The separate inference cache on
-/// `TraitSelectionSession` is the only place allowed to retain answers containing body variables
-/// or closure identities.
+/// Everything here is safe to keep for the rest of the snapshot after one body finishes. The
+/// separate inference cache on `TraitSelectionSession` is the only place allowed to retain answers
+/// containing body variables or closure identities.
 struct TraitSelectionShared {
     use_site: CrateRef,
+    /// Use-site-independent crate declarations shared across sessions over the same snapshot.
+    declarations: TraitSelectionDeclarationCache,
     /// Growing Chalk program plus solver forests for body-independent goals.
     solver: ChalkTraitSolver,
-    /// Canonical headers lowered once and reused by candidate indexing and proof.
-    impl_headers: Mutex<HashMap<ImplRef, Option<crate::ImplHeader>>>,
+    /// Body-origin headers cannot enter the snapshot declaration cache because lexical views may
+    /// differ between requests. Keep them within the session that owns their body source.
+    body_impl_headers: Mutex<HashMap<ImplRef, Option<Arc<crate::ImplHeader>>>>,
     /// Per-trait indexes that narrow visible impls by the outer shape of `Self`.
     trait_impl_candidates: TraitImplCandidateIndexes,
     /// Unique whole-goal selections whose inputs contain no body-owned identity.
@@ -80,11 +96,12 @@ struct TraitSelectionShared {
 }
 
 impl TraitSelectionShared {
-    fn new(use_site: CrateRef) -> Self {
+    fn new(use_site: CrateRef, declarations: TraitSelectionDeclarationCache) -> Self {
         Self {
             use_site,
+            declarations,
             solver: ChalkTraitSolver::new(),
-            impl_headers: Mutex::new(HashMap::new()),
+            body_impl_headers: Mutex::new(HashMap::new()),
             trait_impl_candidates: Mutex::new(HashMap::new()),
             strict_selections: Mutex::new(HashMap::new()),
             exact_candidate_applicabilities: Mutex::new(HashMap::new()),
@@ -115,9 +132,25 @@ impl fmt::Debug for TraitSelectionSession {
 }
 
 impl TraitSelectionSession {
+    /// Start a standalone use-site session with its own declaration cache.
+    ///
+    /// Use [`Self::new_with_declaration_cache`] when several use-site crates are analyzed from the
+    /// same semantic snapshot and should share canonical crate declaration lowering.
     pub fn new(use_site: CrateRef) -> Self {
+        Self::new_with_declaration_cache(use_site, TraitSelectionDeclarationCache::new())
+    }
+
+    /// Start one use-site solver while reusing canonical crate declarations from the same snapshot.
+    ///
+    /// Another use-site session given the same `declarations` handle shares only declaration-owned
+    /// types. Visibility indexes, solver forests, stable answers, and inference caches start fresh
+    /// for this use-site crate; clones of this returned session then share those layers normally.
+    pub fn new_with_declaration_cache(
+        use_site: CrateRef,
+        declarations: TraitSelectionDeclarationCache,
+    ) -> Self {
         Self {
-            shared: Arc::new(TraitSelectionShared::new(use_site)),
+            shared: Arc::new(TraitSelectionShared::new(use_site, declarations)),
             inference_cache: Arc::new(ChalkInferenceCache::new()),
         }
     }
@@ -128,10 +161,10 @@ impl TraitSelectionSession {
 
     /// Keep crate-semantic solver state while starting an independent inference scope.
     ///
-    /// This is the safe handoff between separate build or query operations. Chalk's program,
-    /// canonical impl headers, candidate indexes, and stable answers remain shared, while answers
-    /// containing inference variables or body identities stay with the operation that created
-    /// them.
+    /// This is the safe handoff between independent inference operations over the same snapshot.
+    /// Snapshot crate declarations, Chalk's program, candidate indexes, and stable answers remain
+    /// shared, while answers containing inference variables or body identities stay with the
+    /// operation that created them.
     pub fn fresh_inference_scope(&self) -> Self {
         Self {
             shared: self.shared.clone(),
@@ -211,40 +244,51 @@ impl TraitSelectionSession {
         )
     }
 
-    /// Lower each canonical impl header once for this visible crate context.
+    /// Reuse an impl header without crossing the resolver boundary that produced it.
+    ///
+    /// A crate-origin impl has one canonical header for the semantic snapshot, so all use-site
+    /// sessions may share its lowering. A body-origin impl can resolve through request-local items;
+    /// its header therefore stays in the use-site session that owns that body source.
     pub(crate) fn impl_header_with<'query, D, I, R>(
         &self,
         item_paths: &ItemPathQuery<'query, D, I>,
         resolver: &R,
         impl_ref: ImplRef,
-    ) -> Result<Option<crate::ImplHeader>, I::Error>
+    ) -> Result<Option<Arc<crate::ImplHeader>>, I::Error>
     where
         D: DefMapSource<Error = I::Error>,
         I: ItemStoreSource<'query>,
         R: TypePathResolver<Error = I::Error>,
     {
+        if impl_ref.origin.as_crate_ref().is_some() {
+            return self.shared.declarations.impl_header(impl_ref, || {
+                lower_impl_header(item_paths, resolver, impl_ref)
+            });
+        }
+
         if let Some(header) = self
             .shared
-            .impl_headers
+            .body_impl_headers
             .lock()
-            .expect("trait selection impl-header cache lock should not be poisoned")
+            .expect("body impl-header cache lock should not be poisoned")
             .get(&impl_ref)
             .cloned()
         {
             return Ok(header);
         }
 
-        let header = impl_header_with(item_paths, resolver, impl_ref)?;
-        self.remember_impl_header(impl_ref, header.clone());
+        let header = lower_impl_header(item_paths, resolver, impl_ref)?.map(Arc::new);
+        self.remember_body_impl_header(impl_ref, header.clone());
         Ok(header)
     }
 
-    fn remember_impl_header(&self, impl_ref: ImplRef, header: Option<crate::ImplHeader>) {
+    /// Publish a body header without letting a later conservative miss erase a successful load.
+    fn remember_body_impl_header(&self, impl_ref: ImplRef, header: Option<Arc<crate::ImplHeader>>) {
         let mut headers = self
             .shared
-            .impl_headers
+            .body_impl_headers
             .lock()
-            .expect("trait selection impl-header cache lock should not be poisoned");
+            .expect("body impl-header cache lock should not be poisoned");
         // Parallel misses can finish out of order. A successfully lowered header may replace a
         // conservative miss, while a late miss must not erase a header another worker found.
         if header.is_some() {
@@ -252,6 +296,93 @@ impl TraitSelectionSession {
         } else {
             headers.entry(impl_ref).or_insert(None);
         }
+    }
+
+    /// Lower a trait's canonical `Self` and predicates at the lifetime allowed by its origin.
+    ///
+    /// Crate traits use the snapshot declaration cache. Body traits are lowered from the caller's
+    /// body-aware item view and are not placed in that cross-use-site cache.
+    pub(crate) fn trait_header_with<'query, D, I>(
+        &self,
+        item_paths: &ItemPathQuery<'query, D, I>,
+        trait_ref: TraitDefRef,
+    ) -> Result<Option<Arc<crate::signature::TraitHeader>>, I::Error>
+    where
+        D: DefMapSource<Error = I::Error>,
+        I: ItemStoreSource<'query>,
+    {
+        if trait_ref.origin.as_crate_ref().is_some() {
+            return self.shared.declarations.trait_header(trait_ref, || {
+                SemanticSignatureQuery::trait_header_from(item_paths, trait_ref)
+            });
+        }
+        Ok(SemanticSignatureQuery::trait_header_from(item_paths, trait_ref)?.map(Arc::new))
+    }
+
+    /// Lower the value behind a declaration such as `type Item = Vec<T>`.
+    ///
+    /// Crate aliases use the snapshot declaration cache. A body alias may name local items, so it
+    /// is lowered from the caller's item view instead of being shared across use-site sessions.
+    pub(crate) fn type_alias_ty_with<'query, D, I>(
+        &self,
+        item_paths: &ItemPathQuery<'query, D, I>,
+        alias: TypeAliasRef,
+    ) -> Result<Option<Arc<Ty>>, I::Error>
+    where
+        D: DefMapSource<Error = I::Error>,
+        I: ItemStoreSource<'query>,
+    {
+        if alias.origin.as_crate_ref().is_some() {
+            return self.shared.declarations.type_alias_ty(alias, || {
+                SemanticSignatureQuery::type_alias_ty_from(item_paths, alias)
+            });
+        }
+        Ok(SemanticSignatureQuery::type_alias_ty_from(item_paths, alias)?.map(Arc::new))
+    }
+
+    /// Lower a function's canonical params, return type, and clauses.
+    ///
+    /// Crate functions use the snapshot declaration cache. Body functions are lowered through the
+    /// body-aware item view instead of being shared across use-site sessions.
+    pub(crate) fn function_signature_with<'query, D, I>(
+        &self,
+        item_paths: &ItemPathQuery<'query, D, I>,
+        function: FunctionRef,
+    ) -> Result<Option<Arc<CallableSignature>>, I::Error>
+    where
+        D: DefMapSource<Error = I::Error>,
+        I: ItemStoreSource<'query>,
+    {
+        if function.origin.as_crate_ref().is_some() {
+            return self.shared.declarations.function_signature(function, || {
+                SemanticSignatureQuery::function_from(item_paths, function)
+            });
+        }
+        Ok(SemanticSignatureQuery::function_from(item_paths, function)?.map(Arc::new))
+    }
+
+    /// Lower every opaque identity and bound declared by one generic owner.
+    ///
+    /// For `fn items<T>() -> impl Iterator<Item = T>`, this keeps the opaque return identity beside
+    /// its lowered `Iterator` bound. Crate owners use the snapshot cache; body owners are lowered
+    /// from their local item view.
+    pub(crate) fn opaque_bounds_for_owner_with<'query, D, I>(
+        &self,
+        item_paths: &ItemPathQuery<'query, D, I>,
+        owner: GenericDefRef,
+    ) -> Result<Arc<OpaqueBounds>, I::Error>
+    where
+        D: DefMapSource<Error = I::Error>,
+        I: ItemStoreSource<'query>,
+    {
+        if owner.origin().as_crate_ref().is_some() {
+            return self.shared.declarations.opaque_bounds(owner, || {
+                SemanticSignatureQuery::opaque_bounds_for_owner_from(item_paths, owner)
+            });
+        }
+        Ok(Arc::new(
+            SemanticSignatureQuery::opaque_bounds_for_owner_from(item_paths, owner)?,
+        ))
     }
 
     /// Narrow one trait's visible impls to headers with this outer `Self` shape.

--- a/crates/engine/ty/src/trait_selection/session.rs
+++ b/crates/engine/ty/src/trait_selection/session.rs
@@ -393,7 +393,7 @@ impl TraitSelectionSession {
         &self,
         item_paths: &ItemPathQuery<'query, D, I>,
         trait_ref: TraitDefRef,
-        visible_impls: &UniqueVec<TraitImplRef>,
+        visible_impls: impl IntoIterator<Item = TraitImplRef>,
         self_head: TraitSelfHead,
     ) -> Result<UniqueVec<TraitImplRef>, I::Error>
     where
@@ -419,7 +419,7 @@ impl TraitSelectionSession {
         // from its semantic `Self` fingerprint. The per-trait lock makes initialization
         // single-flight without serializing indexes for unrelated traits.
         let mut built = TraitImplCandidateIndex::default();
-        for &trait_impl in visible_impls {
+        for trait_impl in visible_impls {
             let Some(header) =
                 self.impl_header_with(item_paths, item_paths, trait_impl.impl_ref)?
             else {

--- a/crates/engine/ty/src/trait_selection/tests/mod.rs
+++ b/crates/engine/ty/src/trait_selection/tests/mod.rs
@@ -185,7 +185,11 @@ fn probe_checks_custom_trait_associated_type_equality_constraints() {
 }
 
 #[test]
-fn chalk_proves_impl_predicate_associated_type_equality_constraints() {
+fn native_proof_resolves_impl_predicate_associated_type_equality_constraints() {
+    let profile = rg_profile::test_support::ProfileTest::start(
+        crate::profile_descriptors(),
+        "ty.trait_selection.chalk",
+    );
     check_trait_selection_queries(
         r#"
             traits
@@ -226,6 +230,15 @@ fn chalk_proves_impl_predicate_associated_type_equality_constraints() {
               goal: Adapter<Iter<Other>>: AcceptsUserIterator
               result: empty
         "#]],
+    );
+    let profile = profile.finish();
+    profile.assert_counter(crate::profile::metric::NATIVE_ASSOC_PROJECTIONS, 2);
+    assert_eq!(
+        profile
+            .inner()
+            .counter(crate::profile::metric::PROGRAM_BUILDS.path()),
+        None,
+        "exact associated equalities should not construct a Chalk program",
     );
 }
 

--- a/crates/engine/ty/src/trait_selection/tests/mod.rs
+++ b/crates/engine/ty/src/trait_selection/tests/mod.rs
@@ -1,8 +1,41 @@
 mod utils;
 
 use expect_test::expect;
+use rg_ir_model::{TypeAliasId, TypeAliasRef};
 
 use self::utils::*;
+use crate::inference::InferenceTable;
+use crate::{GenericArg, ProjectionTy};
+
+#[test]
+fn projection_cycle_identity_ignores_fresh_inference_slots() {
+    let mut table = InferenceTable::new();
+    let first_slot = table.new_type_var();
+    let fresh_slot = table.new_type_var();
+    let associated_ty = TypeAliasRef {
+        origin: origin(),
+        id: TypeAliasId(0),
+    };
+    let first = ProjectionTy {
+        associated_ty,
+        args: vec![GenericArg::Type(Box::new(first_slot))].into(),
+    };
+    let repeated = ProjectionTy {
+        associated_ty,
+        args: vec![GenericArg::Type(Box::new(fresh_slot))].into(),
+    };
+    let unrelated = ProjectionTy {
+        associated_ty: TypeAliasRef {
+            origin: origin(),
+            id: TypeAliasId(1),
+        },
+        args: repeated.args.clone(),
+    };
+
+    assert_ne!(first, repeated);
+    assert!(first.equivalent_modulo_inference_ids(&repeated));
+    assert!(!first.equivalent_modulo_inference_ids(&unrelated));
+}
 
 #[test]
 fn probe_selects_direct_from_iterator_impl_and_solves_destination_arg() {

--- a/crates/engine/ty/src/ty.rs
+++ b/crates/engine/ty/src/ty.rs
@@ -144,6 +144,14 @@ pub struct ProjectionTy {
     pub args: GenericArgs,
 }
 
+impl ProjectionTy {
+    /// Compare projections after bijectively renaming transient inference-variable IDs.
+    pub(crate) fn equivalent_modulo_inference_ids(&self, other: &Self) -> bool {
+        self.associated_ty == other.associated_ty
+            && self.args.equivalent_modulo_inference_ids(&other.args)
+    }
+}
+
 /// One opaque `impl Trait` occurrence instantiated with its owner's generic arguments.
 ///
 /// In `fn make<T>() -> impl Iterator<Item = T>`, `opaque` identifies this particular `impl Trait`

--- a/crates/lsp/engine/src/engine/command.rs
+++ b/crates/lsp/engine/src/engine/command.rs
@@ -100,6 +100,17 @@ pub(crate) enum EngineCommand {
     ReindexWorkspace {
         respond_to: EngineResponder<()>,
     },
+    /// Update the editor-derived package priority used by deferred background indexing.
+    SetDeferredIndexingPriority {
+        path: PathBuf,
+        prioritized: bool,
+        respond_to: EngineResponder<()>,
+    },
+    /// Publish a priority package while the same detached build continues in the background.
+    DeferredIndexingPriorityPackageFinished {
+        generation: u64,
+        finished: Box<rg_project::FinishedSplitIndexing>,
+    },
     /// Re-enters a background result onto the lane that owns the saved project.
     DeferredIndexingFinished {
         generation: u64,

--- a/crates/lsp/engine/src/engine/dispatcher.rs
+++ b/crates/lsp/engine/src/engine/dispatcher.rs
@@ -311,6 +311,31 @@ impl EngineDispatcher {
                     tracing::trace!("engine command started: reindex_workspace");
                     let _ = respond_to.send(self.project.reindex_workspace());
                 }
+                EngineCommand::SetDeferredIndexingPriority {
+                    path,
+                    prioritized,
+                    respond_to,
+                } => {
+                    tracing::trace!(
+                        path = %path.display(),
+                        prioritized,
+                        "engine command started: set_deferred_indexing_priority"
+                    );
+                    self.project
+                        .set_deferred_indexing_priority(path, prioritized);
+                    let _ = respond_to.send(Ok(()));
+                }
+                EngineCommand::DeferredIndexingPriorityPackageFinished {
+                    generation,
+                    finished,
+                } => {
+                    tracing::trace!(
+                        generation,
+                        "engine command started: deferred_indexing_priority_package_finished"
+                    );
+                    self.project
+                        .deferred_indexing_priority_package_finished(generation, *finished);
+                }
                 EngineCommand::DeferredIndexingFinished { generation, result } => {
                     tracing::trace!(
                         generation,

--- a/crates/lsp/engine/src/engine/project/deferred.rs
+++ b/crates/lsp/engine/src/engine/project/deferred.rs
@@ -1,19 +1,23 @@
 //! Deferred-indexing reconciliation for the saved project generation.
 //!
-//! Early-start indexing leaves some expensive payloads for a detached project clone to finish.
-//! The saved project remains queryable in parallel and may even materialize the same packages on
-//! demand. This module keeps at most one clone in flight, sends its result back through the engine
-//! queue, and merges only package-wise improvements that still belong to the saved generation.
+//! Early-start indexing leaves expensive Body IR for one detached project clone to finish. The
+//! saved project remains queryable in parallel and may materialize the same package on demand.
+//! Open-document packages are scheduled first inside the detached build and copied back as soon as
+//! their resolution finishes; the same build continues through every ordinary package.
 //!
-//! If source changes while a clone is running, the old clone is allowed to return before a new one
-//! starts. That avoids holding two full detached projects at once.
-//!
-//! Example: a clone for generation 4 is running when a saved file publishes generation 5. The
-//! generation-4 result is discarded when it returns, and only then is a generation-5 clone
-//! started.
+//! All publication still re-enters the serialized engine queue. A source generation change makes
+//! later copies stale, and the old clone must return before a replacement is detached. There is
+//! therefore never more than one full background clone or a concurrent saved-project writer.
 
-use std::{sync::mpsc::Sender, thread, time::Instant};
+use std::{
+    collections::BTreeSet,
+    path::PathBuf,
+    sync::{Arc, Mutex, mpsc::Sender},
+    thread,
+    time::Instant,
+};
 
+use rg_def_map::PackageSlot;
 use rg_project::DetachedSplitIndexing;
 
 use crate::engine::{
@@ -24,14 +28,15 @@ use crate::engine::{
 
 /// Tracks the one detached indexing finish allowed to run beside the engine lane.
 ///
-/// The sender is owned here because background completion is this subsystem's only external
-/// capability. It cannot mutate project state directly; it can only enqueue a result for the
-/// coordinator to inspect.
+/// The background worker cannot mutate saved state. Its only external capabilities are receiving
+/// best-effort path priorities and enqueueing package copies for generation-checked publication.
 #[derive(Debug)]
 pub(super) struct DeferredIndexingFinish {
     sender: Sender<QueuedEngineCommand>,
     in_flight_generation: Option<u64>,
+    worker_priority: Option<Arc<Mutex<Vec<PackageSlot>>>>,
     restart_after_in_flight: bool,
+    priority_paths: BTreeSet<PathBuf>,
 }
 
 impl DeferredIndexingFinish {
@@ -39,16 +44,13 @@ impl DeferredIndexingFinish {
         Self {
             sender,
             in_flight_generation: None,
+            worker_priority: None,
             restart_after_in_flight: false,
+            priority_paths: BTreeSet::new(),
         }
     }
 
     /// Start deferred indexing for the freshly saved project.
-    ///
-    /// This is called after the coordinator replaces the saved project during initialization. At
-    /// that point there cannot be an older finish for the same engine, so the clone built by the
-    /// initial index can be handed directly to the background thread. The return value tells the
-    /// coordinator whether it should publish a deferred-started notification.
     pub(super) fn start_initial(
         &mut self,
         generation: u64,
@@ -59,10 +61,8 @@ impl DeferredIndexingFinish {
 
     /// Ensure the current saved project will eventually finish deferred indexing.
     ///
-    /// Saved-source mutations invalidate any detached clone that is already running. Starting
-    /// another clone immediately would double peak memory, so this state records that one restart
-    /// is needed and lets the old clone return first. Returning `true` means the active generation
-    /// now has deferred work running or queued behind that older clone.
+    /// Starting another clone immediately would double peak memory. Record one restart and let the
+    /// old build return first; its generation-tagged publications are harmless in the meantime.
     pub(super) fn saved_project_changed(&mut self, project: &ProjectState) -> bool {
         if self.in_flight_generation.is_some() {
             self.restart_after_in_flight = true;
@@ -71,18 +71,70 @@ impl DeferredIndexingFinish {
         self.start_current(project)
     }
 
-    /// Reconcile one returned clone and decide whether the editor may see indexing as finished.
+    /// Record whether an editor path should be scheduled ahead of ordinary background packages.
     ///
-    /// An unknown result is ignored. A known result is merged only if its generation still matches
-    /// saved source, then any restart requested by an intervening source change is launched. The
-    /// return value is `true` only for a finish belonging to the active generation.
+    /// The set survives source generations so an open document stays prioritized after a save.
+    /// Workers consume complete package-priority snapshots between resolution jobs. Work already
+    /// executing is never preempted, but a late didOpen still moves pending work to the front.
+    pub(super) fn set_priority(
+        &mut self,
+        project: &ProjectState,
+        path: PathBuf,
+        prioritized: bool,
+    ) {
+        let changed = if prioritized {
+            self.priority_paths.insert(path.clone())
+        } else {
+            self.priority_paths.remove(&path)
+        };
+        if !changed {
+            return;
+        }
+
+        if self.in_flight_generation != Some(project.generation()) {
+            return;
+        }
+        if let Some(worker_priority) = &self.worker_priority {
+            let priorities = Self::package_priorities_for_paths(&self.priority_paths, |path| {
+                project.package_slots_for_path(path)
+            });
+            tracing::debug!(
+                generation = project.generation(),
+                priority_package_count = priorities.len(),
+                "deferred indexing package priority updated"
+            );
+            *worker_priority
+                .lock()
+                .expect("deferred indexing package priorities should not be poisoned") = priorities;
+        }
+    }
+
+    /// Merge one priority package without ending the deferred-indexing lifecycle.
+    pub(super) fn priority_package_returned(
+        &mut self,
+        project: &mut ProjectState,
+        generation: u64,
+        finished: rg_project::FinishedSplitIndexing,
+    ) {
+        if self.in_flight_generation != Some(generation) {
+            tracing::info!(
+                generation,
+                current_in_flight_generation = ?self.in_flight_generation,
+                "discarding unknown deferred indexing priority package"
+            );
+            return;
+        }
+
+        Self::apply_finished_if_current(project, generation, finished, "priority package");
+    }
+
+    /// Reconcile the final background result and decide whether indexing is finished for the client.
     pub(super) fn finish_returned(
         &mut self,
         project: &mut ProjectState,
         generation: u64,
         result: DeferredIndexingResult,
     ) -> bool {
-        // Only the clone recorded as in flight is allowed to change this controller's state.
         if self.in_flight_generation != Some(generation) {
             tracing::info!(
                 generation,
@@ -92,12 +144,11 @@ impl DeferredIndexingFinish {
             return false;
         }
         self.in_flight_generation = None;
+        self.worker_priority = None;
 
-        // The clone is no longer live even if its generation became stale while it ran.
         let is_current_generation = Self::apply_finish_if_current(project, generation, result);
         let should_restart = self.restart_after_in_flight || !is_current_generation;
         self.restart_after_in_flight = false;
-        // Wait until after the old clone returns before allocating its replacement.
         if should_restart {
             self.start_current(project);
         }
@@ -105,7 +156,6 @@ impl DeferredIndexingFinish {
         is_current_generation
     }
 
-    /// Detach the latest saved state when no other background clone is live.
     fn start_current(&mut self, project: &ProjectState) -> bool {
         let (generation, detached) = match project.detach_saved_split_indexing() {
             Ok(detached) => detached,
@@ -121,13 +171,14 @@ impl DeferredIndexingFinish {
         self.spawn_finish(generation, detached)
     }
 
-    /// Finish deferred indexing on a detached project clone.
-    ///
-    /// The saved project is already usable when this runs. The background result is sent back to
-    /// the command loop instead of mutating saved state directly, so the command loop can keep all
-    /// project generation checks in one place.
+    /// Finish deferred indexing on one detached project clone.
     fn spawn_finish(&mut self, generation: u64, detached: DetachedSplitIndexing) -> bool {
         let sender = self.sender.clone();
+        let priority_packages = Self::package_priorities_for_paths(&self.priority_paths, |path| {
+            detached.package_slots_for_path(path)
+        });
+        let worker_priority = Arc::new(Mutex::new(priority_packages));
+        let background_priority = Arc::clone(&worker_priority);
 
         let spawn_result = thread::Builder::new()
             .name("rg-deferred-indexing".to_string())
@@ -135,9 +186,13 @@ impl DeferredIndexingFinish {
                 let started = Instant::now();
                 tracing::info!(generation, "deferred indexing background finish started");
 
-                // Finish against the clone. The result still owns that clone, which lets the saved
-                // project later merge only package-wise improvements.
-                let result = detached.finish().map(Box::new);
+                let result = Self::finish_with_priorities(
+                    &sender,
+                    generation,
+                    detached,
+                    background_priority,
+                    started,
+                );
                 let elapsed_ms = started.elapsed().as_millis();
                 match &result {
                     Ok(_) => {
@@ -165,6 +220,7 @@ impl DeferredIndexingFinish {
         match spawn_result {
             Ok(_) => {
                 self.in_flight_generation = Some(generation);
+                self.worker_priority = Some(worker_priority);
                 true
             }
             Err(error) => {
@@ -178,11 +234,72 @@ impl DeferredIndexingFinish {
         }
     }
 
-    /// Merge a background finish if it still matches the saved-project generation.
-    ///
-    /// Returning `true` means that the background finish belongs to the current saved project, even
-    /// if there was nothing left to merge. The client-side status indicator cares about that
-    /// lifecycle fact: deferred indexing is no longer pending once this command has been handled.
+    /// Run one Body IR build whose package queue keeps accepting editor priorities.
+    fn finish_with_priorities(
+        sender: &Sender<QueuedEngineCommand>,
+        generation: u64,
+        detached: DetachedSplitIndexing,
+        priority_packages: Arc<Mutex<Vec<PackageSlot>>>,
+        started: Instant,
+    ) -> DeferredIndexingResult {
+        let unfinished = detached.unfinished_packages();
+        let priority_package_count = priority_packages
+            .lock()
+            .expect("deferred indexing package priorities should not be poisoned")
+            .len();
+        tracing::debug!(
+            generation,
+            pending_package_count = unfinished.len(),
+            priority_package_count,
+            "deferred indexing package schedule prepared"
+        );
+
+        detached
+            .finish_with_package_priority(
+                || {
+                    priority_packages
+                        .lock()
+                        .expect("deferred indexing package priorities should not be poisoned")
+                        .clone()
+                },
+                |finished| {
+                    tracing::debug!(
+                        generation,
+                        elapsed_ms = started.elapsed().as_millis(),
+                        "deferred indexing priority package resolved"
+                    );
+                    let _ = sender.send(QueuedEngineCommand::new(
+                        EngineCommand::DeferredIndexingPriorityPackageFinished {
+                            generation,
+                            finished: Box::new(finished),
+                        },
+                    ));
+                },
+            )
+            .map(Box::new)
+    }
+
+    fn package_priorities_for_paths(
+        paths: &BTreeSet<PathBuf>,
+        mut packages_for_path: impl FnMut(&std::path::Path) -> anyhow::Result<Vec<PackageSlot>>,
+    ) -> Vec<PackageSlot> {
+        let mut packages = BTreeSet::new();
+        for path in paths {
+            match packages_for_path(path) {
+                Ok(path_packages) => packages.extend(path_packages),
+                Err(error) => {
+                    tracing::trace!(
+                        path = %path.display(),
+                        error = %format!("{error:#}"),
+                        "deferred indexing priority path is not in the saved source inventory"
+                    );
+                }
+            }
+        }
+        packages.into_iter().collect()
+    }
+
+    /// Merge the final result if it still matches the saved-project generation.
     fn apply_finish_if_current(
         project: &mut ProjectState,
         generation: u64,
@@ -197,35 +314,55 @@ impl DeferredIndexingFinish {
             return false;
         }
 
-        let updated = match result {
-            // The merge itself is monotonic: packages finished by query-time materialization win
-            // over an equal or older package from the background clone.
-            Ok(finished) => project
-                .mutate_saved_preserving_generation(|saved| {
-                    saved.split_indexing().merge_finished(*finished)
-                })
-                .unwrap_or_else(|error| {
-                    tracing::warn!(
-                        generation,
-                        error = %format!("{error:#}"),
-                        "deferred indexing finish could not merge into saved project"
-                    );
-                    false
-                }),
+        match result {
+            Ok(finished) => {
+                Self::apply_finished_if_current(project, generation, *finished, "finish");
+            }
             Err(error) => {
                 tracing::warn!(
                     generation,
                     error = %format!("{error:#}"),
                     "deferred indexing finish did not update project"
                 );
-                false
             }
-        };
+        }
+        true
+    }
 
+    fn apply_finished_if_current(
+        project: &mut ProjectState,
+        generation: u64,
+        finished: rg_project::FinishedSplitIndexing,
+        label: &'static str,
+    ) -> bool {
+        if project.generation() != generation {
+            tracing::info!(
+                generation,
+                current_generation = project.generation(),
+                label,
+                "discarding stale deferred indexing publication"
+            );
+            return false;
+        }
+
+        let updated = project
+            .mutate_saved_preserving_generation(|saved| {
+                saved.split_indexing().merge_finished(finished)
+            })
+            .unwrap_or_else(|error| {
+                tracing::warn!(
+                    generation,
+                    label,
+                    error = %format!("{error:#}"),
+                    "deferred indexing publication could not merge into saved project"
+                );
+                false
+            });
         if !updated {
             tracing::trace!(
                 generation,
-                "deferred indexing finish completed without saved project changes"
+                label,
+                "deferred indexing publication completed without saved project changes"
             );
         }
         true

--- a/crates/lsp/engine/src/engine/project/mod.rs
+++ b/crates/lsp/engine/src/engine/project/mod.rs
@@ -389,6 +389,25 @@ impl ProjectCoordinator {
         }
     }
 
+    /// Publish one resolved priority package without ending the lifecycle.
+    pub(super) fn deferred_indexing_priority_package_finished(
+        &mut self,
+        generation: u64,
+        finished: rg_project::FinishedSplitIndexing,
+    ) {
+        self.deferred_indexing_finish.priority_package_returned(
+            &mut self.project,
+            generation,
+            finished,
+        );
+    }
+
+    /// Update package scheduling priority from an editor open/close hint.
+    pub(super) fn set_deferred_indexing_priority(&mut self, path: PathBuf, prioritized: bool) {
+        self.deferred_indexing_finish
+            .set_priority(&self.project, path, prioritized);
+    }
+
     pub(super) fn saved_snapshot(&self) -> anyhow::Result<ProjectSnapshot<'_>> {
         self.project
             .saved_snapshot()

--- a/crates/lsp/engine/src/engine/project/state.rs
+++ b/crates/lsp/engine/src/engine/project/state.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 
 use anyhow::Context as _;
+use rg_def_map::PackageSlot;
 use rg_project::{AnalysisSurface, DetachedSplitIndexing, Project, ProjectSnapshot};
 
 /// Owns the one saved project used by all analysis queries in this engine.
@@ -89,6 +90,16 @@ impl ProjectState {
             .as_ref()
             .map(Project::snapshot)
             .context("saved project is not initialized")
+    }
+
+    pub(super) fn package_slots_for_path(
+        &self,
+        path: &std::path::Path,
+    ) -> anyhow::Result<Vec<PackageSlot>> {
+        self.saved
+            .as_ref()
+            .context("saved project is not initialized")?
+            .package_slots_for_path(path)
     }
 
     /// Load deferred analysis data needed by a query without changing the source generation.

--- a/crates/lsp/engine/src/engine/project/tests/mod.rs
+++ b/crates/lsp/engine/src/engine/project/tests/mod.rs
@@ -231,6 +231,107 @@ fn deferred_lifecycle_tracks_published_generations_not_foreground_activity() {
 }
 
 #[test]
+fn open_document_package_is_published_before_full_deferred_result() {
+    let fixture = fixture_crate(
+        r#"
+            //- /Cargo.toml
+            [workspace]
+            members = ["app", "helper"]
+            resolver = "2"
+
+            //- /app/Cargo.toml
+            [package]
+            name = "deferred_priority_app"
+            version = "0.1.0"
+            edition = "2024"
+
+            //- /app/src/lib.rs
+            pub fn app() -> usize { 1 }
+
+            //- /helper/Cargo.toml
+            [package]
+            name = "deferred_priority_helper"
+            version = "0.1.0"
+            edition = "2024"
+
+            //- /helper/src/lib.rs
+            pub fn first() -> usize { 1 }
+            pub fn second() -> usize { 2 }
+            pub fn third() -> usize { 3 }
+            "#,
+    );
+    let (sender, receiver) = mpsc::channel();
+    let memory_control: Arc<dyn MemoryControl> = Arc::new(());
+    let recorded = RecordingNotifications::default();
+    let notifications = ServiceNotificationsSink::from_publisher(recorded.clone());
+    let mut project = ProjectCoordinator::new(sender, memory_control, notifications);
+    project
+        .initialize(
+            fixture.path(""),
+            ProjectConfiguration::from(AnalysisConfig {
+                package_residency_policy: PackageResidencyPolicy::AllResident,
+                sysroot_discovery: SysrootDiscovery::Disabled,
+                ..AnalysisConfig::default()
+            }),
+        )
+        .expect("fixture project should initialize");
+    assert!(matches!(
+        recorded.take().as_slice(),
+        [ServiceNotification::DeferredIndexingStarted { .. }]
+    ));
+
+    // The worker is already live when this didOpen-derived hint reaches its package queue.
+    project.set_deferred_indexing_priority(fixture.path("helper/src/lib.rs"), true);
+    let first = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("the prioritized package should return");
+    let EngineCommand::DeferredIndexingPriorityPackageFinished {
+        generation,
+        finished,
+    } = first.command
+    else {
+        panic!("the open-document package should publish before the final background result");
+    };
+    project.deferred_indexing_priority_package_finished(generation, *finished);
+
+    let first_stats = project
+        .saved_snapshot()
+        .expect("partially finished saved project should be available")
+        .stats()
+        .body_ir;
+    assert_eq!(first_stats.complete_crate_count, 1);
+    assert_eq!(
+        first_stats.body_count, 3,
+        "the three-body open-document package should be the first publication",
+    );
+    assert!(
+        recorded.take().is_empty(),
+        "an intermediate package publication must not end deferred indexing",
+    );
+
+    let final_command = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("the remaining background package should return");
+    let EngineCommand::DeferredIndexingFinished { generation, result } = final_command.command
+    else {
+        panic!("the final package result should complete deferred indexing");
+    };
+    project.deferred_indexing_finished(generation, result);
+
+    let finished_stats = project
+        .saved_snapshot()
+        .expect("finished saved project should be available")
+        .stats()
+        .body_ir;
+    assert_eq!(finished_stats.complete_crate_count, 2);
+    assert_eq!(finished_stats.body_count, 4);
+    assert!(matches!(
+        recorded.take().as_slice(),
+        [ServiceNotification::DeferredIndexingFinished { .. }]
+    ));
+}
+
+#[test]
 fn saved_project_change_retries_source_races_but_preserves_a_finite_lane_budget() {
     let fixture = fixture_crate(
         r#"

--- a/crates/lsp/engine/src/service/mod.rs
+++ b/crates/lsp/engine/src/service/mod.rs
@@ -80,6 +80,22 @@ impl EngineService for Service {
         Ok(())
     }
 
+    async fn set_deferred_indexing_priority(
+        self,
+        _: context::Context,
+        path: PathBuf,
+        prioritized: bool,
+    ) -> EngineResult<()> {
+        self.engine
+            .request(|respond_to| EngineCommand::SetDeferredIndexingPriority {
+                path,
+                prioritized,
+                respond_to,
+            })
+            .await
+            .map_err(EngineError::from)
+    }
+
     async fn did_save(self, _: context::Context, proposal: SaveProposal) -> EngineResult<u64> {
         let client_version = proposal.client_version();
         let (target, text) = proposal.into_parts();

--- a/crates/lsp/proto/src/service.rs
+++ b/crates/lsp/proto/src/service.rs
@@ -1,9 +1,10 @@
 //! RPC vocabulary between the editor-facing server and one analysis engine.
 //!
-//! Document methods carry complete immutable snapshots; there is no open/change/close document
-//! protocol on this boundary. Saved-project mutations are separate and either carry exact source
-//! text or explicitly ask the project layer to interpret a filesystem path. Responses preserve
-//! operational failures instead of folding them into feature-specific empty values.
+//! Document methods carry complete immutable snapshots; there is no second document-text lifecycle
+//! on this boundary. A lightweight open-path hint may affect only deferred package scheduling.
+//! Saved-project mutations are separate and either carry exact source text or explicitly ask the
+//! project layer to interpret a filesystem path. Responses preserve operational failures instead
+//! of folding them into feature-specific empty values.
 
 use std::path::PathBuf;
 
@@ -25,6 +26,9 @@ pub trait EngineService {
     async fn initialize(root: PathBuf, config: EngineConfig) -> EngineResult<()>;
 
     async fn initialized() -> EngineResult<()>;
+
+    /// Move the package containing an open editor path ahead of ordinary deferred work.
+    async fn set_deferred_indexing_priority(path: PathBuf, prioritized: bool) -> EngineResult<()>;
 
     async fn did_save(proposal: SaveProposal) -> EngineResult<u64>;
 

--- a/crates/lsp/server/src/ingress/state/lifecycle.rs
+++ b/crates/lsp/server/src/ingress/state/lifecycle.rs
@@ -41,8 +41,8 @@ pub(crate) enum LifecycleEvent {
         proposal: SaveProposal,
         route: SessionRoute,
     },
-    /// Remove the registry route after earlier async work for this path has finished.
-    Close { path: PathBuf },
+    /// Remove the registry route and its deferred-indexing priority after earlier work finishes.
+    Close { path: PathBuf, route: SessionRoute },
 }
 
 /// One async lifecycle step together with the earlier step it must wait for.

--- a/crates/lsp/server/src/ingress/state/mod.rs
+++ b/crates/lsp/server/src/ingress/state/mod.rs
@@ -680,6 +680,7 @@ impl EditorState {
             entry.tail.clone(),
             LifecycleEvent::Close {
                 path: path.to_path_buf(),
+                route: open.route,
             },
             Some(cleanup),
         );

--- a/crates/lsp/server/src/methods/text_document/completion/tests.rs
+++ b/crates/lsp/server/src/methods/text_document/completion/tests.rs
@@ -637,6 +637,16 @@ impl EngineService for GatedCompletionEngine {
         panic!("test engine only supports completion")
     }
 
+    async fn set_deferred_indexing_priority(
+        self,
+        _: context::Context,
+        _: PathBuf,
+        _: bool,
+    ) -> EngineResult<()> {
+        // Raw didOpen/didClose in these tests may carry the ordinary best-effort scheduler hint.
+        Ok(())
+    }
+
     async fn did_save(self, _: context::Context, _: SaveProposal) -> EngineResult<u64> {
         panic!("test engine only supports completion")
     }

--- a/crates/lsp/server/src/methods/text_document/did_close.rs
+++ b/crates/lsp/server/src/methods/text_document/did_close.rs
@@ -5,12 +5,13 @@ use crate::{
     ingress::{self, LifecycleEvent},
 };
 
-/// Remove the engine-registry route for a session already marked closed in editor state.
+/// Remove the engine-registry route and background-indexing priority for a closed session.
 ///
 /// Earlier open/save work for the same path has finished before `lifecycle_event` returns. The
-/// engine itself stores no open-document lifecycle state, so it needs no close request.
+/// engine receives only a scheduling hint; synchronized text and session identity remain owned by
+/// editor ingress.
 pub(crate) async fn did_close(registry: Result<&EngineRegistry>) {
-    let Some(LifecycleEvent::Close { path }) = ingress::lifecycle_event().await else {
+    let Some(LifecycleEvent::Close { path, route }) = ingress::lifecycle_event().await else {
         tracing::error!("didClose bypassed ordered LSP ingress");
         return;
     };
@@ -18,5 +19,17 @@ pub(crate) async fn did_close(registry: Result<&EngineRegistry>) {
     // Remove the old route before a later reopen for this path can store its new route.
     if let Ok(registry) = registry {
         registry.close_document(&path).await;
+    }
+    if let Ok(engine_client) = route.engine_client() {
+        engine_client
+            .notify(
+                "set_deferred_indexing_priority",
+                move |engine_client, request_context| async move {
+                    engine_client
+                        .set_deferred_indexing_priority(request_context, path, false)
+                        .await
+                },
+            )
+            .await;
     }
 }

--- a/crates/lsp/server/src/methods/text_document/did_open.rs
+++ b/crates/lsp/server/src/methods/text_document/did_open.rs
@@ -19,11 +19,26 @@ pub(crate) async fn did_open(registry: Result<&EngineRegistry>) {
         Err(error) => Err(anyhow::anyhow!(error.message.into_owned())),
     };
     route.publish(routed);
-    if route.engine_client().is_err() {
-        tracing::debug!(
-            path = %document.path().display(),
-            session = document.session().get(),
-            "retained opened editor document without a ready engine route"
-        );
+    match route.engine_client() {
+        Ok(engine_client) => {
+            let path = document.path().to_path_buf();
+            engine_client
+                .notify(
+                    "set_deferred_indexing_priority",
+                    move |engine_client, request_context| async move {
+                        engine_client
+                            .set_deferred_indexing_priority(request_context, path, true)
+                            .await
+                    },
+                )
+                .await;
+        }
+        Err(_) => {
+            tracing::debug!(
+                path = %document.path().display(),
+                session = document.session().get(),
+                "retained opened editor document without a ready engine route"
+            );
+        }
     }
 }

--- a/crates/vendor/macro-expand/src/lib.rs
+++ b/crates/vendor/macro-expand/src/lib.rs
@@ -306,6 +306,53 @@ make_fields!(id, age);
     }
 
     #[test]
+    fn matcher_error_does_not_transcribe_partial_repetition() {
+        let file = ast::SourceFile::parse(
+            r#"
+macro_rules! expand_params {
+    (
+        $($code:literal),+,
+        $(param: $param:expr,)?
+    ) => {{
+        let _ = expand_params!(@param $($param)*);
+    }};
+    (@param) => { () };
+    (@param $param:expr) => { $param };
+}
+
+expand_params!("RAND", param: value.clone());
+"#,
+            Edition::CURRENT,
+        )
+        .ok()
+        .expect("test source should parse");
+        let macro_rules = file
+            .syntax()
+            .descendants()
+            .find_map(ast::MacroRules::cast)
+            .expect("test source should contain macro_rules");
+        let call = file
+            .syntax()
+            .descendants()
+            .filter_map(ast::MacroCall::cast)
+            .last()
+            .expect("test source should contain a macro call");
+
+        let macro_rules = stored_macro_rules_body(&macro_rules);
+        let (args, call_site) = stored_call_args(&call);
+        let mac = DeclarativeMacro::from_macro_rules_tokens(&macro_rules, Edition::CURRENT)
+            .expect("macro should compile");
+        let error = mac
+            .expand_call_tokens(&args, call_site, ExpansionParseKind::Expr)
+            .expect_err("invalid macro input should fail to expand");
+
+        assert!(
+            error.to_string().contains("expected literal"),
+            "unexpected expansion error: {error:#}",
+        );
+    }
+
+    #[test]
     fn renders_joint_path_punctuation() {
         check_expansion(
             r#"

--- a/crates/vendor/macro-expand/src/mbe/expander.rs
+++ b/crates/vendor/macro-expand/src/mbe/expander.rs
@@ -56,14 +56,33 @@ pub(crate) fn expand_rules(
         }
     }
     if let Some((match_, rule, idx)) = match_ {
-        // if we got here, there was no match without errors
+        // If every arm failed to match, the public expansion API returns the matcher error and
+        // discards generated syntax. Do not transcribe the matcher's partial bindings: repetitions
+        // can otherwise keep replaying an incomplete binding until the 65,536-iteration safety
+        // limit, only for the generated token tree to be discarded with the error.
+        let matcher::Match {
+            bindings,
+            err: match_err,
+            ..
+        } = match_;
+        if let Some(error) = match_err {
+            return ExpandResult::new(
+                (
+                    tt::TopSubtree::empty(tt::DelimSpan::from_single(call_site)),
+                    idx.try_into().ok(),
+                ),
+                error,
+            );
+        }
+
+        // If we got here, one arm matched but its transcriber reported an error.
         let ExpandResult {
             value,
             err: transcribe_err,
-        } = transcriber::transcribe(&rule.rhs, &match_.bindings, marker, call_site);
+        } = transcriber::transcribe(&rule.rhs, &bindings, marker, call_site);
         ExpandResult {
             value: (value, idx.try_into().ok()),
-            err: match_.err.or(transcribe_err),
+            err: transcribe_err,
         }
     } else {
         ExpandResult::new(

--- a/docs/src/intro/INTRO.md
+++ b/docs/src/intro/INTRO.md
@@ -26,7 +26,12 @@ It does not come for free, though:
   less precise than one of saved buffer. Indexing happens only on save, so when you're typing we're
   performing a "shallow" analysis. It's better covered in [limitations](../usage/LIMITATIONS.md).
 
-And obviously Rust Glancer is a much younger project than rust-analyzer, so it's less complete:
+Another important property is that workspaces are handled by dedicated handlers and are lazy:
+indexing doesn't start until you open a project. Similarly, if something goes wrong with one
+of the projects (rust workspace) in vs code workspace (multiple projects), other engines are
+not affected.
+
+Now, obviously Rust Glancer is a much younger project than rust-analyzer, so it's less complete:
 - Type inference doesn't work in some cases
 - There are bugs here and there
 - Advanced features like proc macros are not supported.

--- a/docs/src/usage/CONFIGURE.md
+++ b/docs/src/usage/CONFIGURE.md
@@ -48,13 +48,16 @@ For example:
 }
 ```
 
+Another (maybe) important configuration is `Indexing: Performance Preference`:
+`lower-peak-memory` makes the indexer use less concurrency, making it slower, but also reducing peak
+allocations during indexing. Exact reduction can vary by machine/os/project, so if the default
+(faster builds) does not work for you and you are affected by high peak RAM, you can try changing
+this option.
+
 ## Tweaking options
 
 Following settings _can_ be changed, but probably shouldn't.
 
-- `Indexing: Performance Preference`: `lower-peak-memory` makes the indexer use less concurrency,
-  making it slower, but also reducing peak allocations during indexing. Exact reduction can vary
-  by machine/os/project, but based on anecdotal measurements I've had, it's <20% from peak burst.
 - `Cache: Package Residency`: you can make it so that not everything is offloaded to the filesystem.
   In theory, it can make Rust Glancer faster. In practice, if you don't care about memory usage,
   `rust-analyzer` will probably work better for you.


### PR DESCRIPTION
During pre-release testing I've discovered that in some cases rust glancer behaves worse than I expected:
- 14gb RAM consumed during indexing (huh)
- crash during type infering (huhhuh)
- 500mb of RAM occupied after indexing (huhhuhhuh)
- indexing taking ~90 seconds on m4 max (dam)

It turned out to be a bunch of mostly unrelated small issues -- cycle detection issue in type infering, lack of some caches in chalk, lack of some performance optimizations here and there, and lack of some memory optimizations.

Each commit should be somewhat readable on its own, but all in all on the project that had been indexing for 90 seconds with 14gb ram peak and 500mb post indexing, we now have 30 seconds indexing (lsp usable at ~15 seconds), 5gb peak ram, 70mb after indexing.

5gb is not great, rust analyzer uses 3.7gb, but it does less work, and it only needs to be done once, so it should be fine.
But also I've done some improvements to the low memory mode which makes indexing lower but takes ~1gb from peak ram on that project (by reducing parallelism during body resolution). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deferred indexing now prioritizes packages for open editor files and publishes their results as soon as they are ready.
  - Added support for updating indexing priority when documents open or close.
  - Added configurable indexing worker limits for lower peak memory usage.

- **Bug Fixes**
  - Improved macro expansion errors by preventing partial output when matching fails.
  - Prevented completed offloaded packages from being unnecessarily restored during indexing updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->