### PR TITLE
fix: Fix release please and extension name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,8 @@ jobs:
         id: release
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT so release PRs trigger their normal pull-request workflows.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .github/release-please/config.json
           manifest-file: .github/release-please/manifest.json
 

--- a/editors/code/.vscode-test.mjs
+++ b/editors/code/.vscode-test.mjs
@@ -5,8 +5,8 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const extensionRoot = dirname(fileURLToPath(import.meta.url));
-const userDataDir = mkdtempSync(resolve(tmpdir(), "rust-glancer-code-user-data-"));
-const extensionsDir = mkdtempSync(resolve(tmpdir(), "rust-glancer-code-extensions-"));
+const userDataDir = mkdtempSync(resolve(tmpdir(), "rust-glancer-user-data-"));
+const extensionsDir = mkdtempSync(resolve(tmpdir(), "rust-glancer-extensions-"));
 
 export default defineConfig({
   files: "out/test/**/*.test.js",

--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "rust-glancer-code",
+  "name": "rust-glancer",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rust-glancer-code",
+      "name": "rust-glancer",
       "version": "0.1.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rust-glancer-code",
+  "name": "rust-glancer",
   "displayName": "Rust Glancer",
   "description": "VS Code client for the rust-glancer language server.",
   "version": "0.1.0",

--- a/editors/code/test/extension.test.ts
+++ b/editors/code/test/extension.test.ts
@@ -9,7 +9,7 @@ import { EXTENSION_COMMANDS } from "../src/commands";
 import { CompletionScenario } from "./completion-scenario";
 import { readySession, waitForClientState, waitForOutput } from "./extension-harness";
 
-const EXTENSION_ID = "rust-glancer.rust-glancer-code";
+const EXTENSION_ID = "rust-glancer.rust-glancer";
 
 suite("Rust Glancer extension", () => {
   test("starts one real server and routes multiple Rust workspaces", async () => {


### PR DESCRIPTION
subj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the VS Code extension package and test identifiers to use the streamlined `rust-glancer` name.
  * Improved release automation by using the dedicated release token.
  * Updated temporary test directory naming to match the new extension name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->