### PR TITLE
fix: Last minute fixes (type inference)

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -7,6 +7,7 @@
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "extra-files": [
     "crates/lsp/server/src/methods/mod.rs",
     {

--- a/crates/engine/body-ir/src/lib.rs
+++ b/crates/engine/body-ir/src/lib.rs
@@ -1,6 +1,7 @@
 use rg_std::MemorySize;
 mod build;
 mod ir;
+mod profile;
 mod resolution;
 mod store;
 #[doc(hidden)]
@@ -9,6 +10,7 @@ pub mod testonly;
 use rg_def_map::PackageSlot;
 use rg_parse::FileId;
 
+pub use self::profile::profile_descriptors;
 pub use rg_ir_model::FieldKey;
 
 pub use self::build::{

--- a/crates/engine/body-ir/src/profile.rs
+++ b/crates/engine/body-ir/src/profile.rs
@@ -1,0 +1,16 @@
+//! Profile descriptors for body inference and resolution.
+
+use rg_profile::{ProfileDescriptor, declare_metrics};
+
+declare_metrics! {
+    pub(crate) mod metric {
+        scope "body_ir.resolution" {
+            /// Bodies that retained semantic progress until the fixed-point safety limit.
+            counter FIXED_POINT_EXHAUSTIONS = "fixed_point_exhaustions";
+        }
+    }
+}
+
+pub fn profile_descriptors() -> &'static [ProfileDescriptor] {
+    metric::descriptors()
+}

--- a/crates/engine/body-ir/src/resolution/infer/call.rs
+++ b/crates/engine/body-ir/src/resolution/infer/call.rs
@@ -42,10 +42,14 @@ pub(super) struct CallInferenceState {
 
 impl CallInferenceState {
     /// Collapse the call-owned inference substitution into its persistent semantic form.
-    pub(super) fn finalize(&self, table: &InferenceTable) -> CallFacts {
-        let generic_args = self
-            .subst
-            .finalize_args(table, self.generic_params.iter().copied());
+    pub(super) fn finalize(&self, table: &InferenceTable, inference_complete: bool) -> CallFacts {
+        let params = self.generic_params.iter().copied();
+        let generic_args = if inference_complete {
+            self.subst.finalize_args(table, params)
+        } else {
+            self.subst
+                .finalize_args_without_numeric_defaults(table, params)
+        };
         CallFacts::new(self.function, generic_args)
     }
 }

--- a/crates/engine/body-ir/src/resolution/infer/context.rs
+++ b/crates/engine/body-ir/src/resolution/infer/context.rs
@@ -619,7 +619,7 @@ impl BodyInferenceCtx {
             .map(|ty| GenericArg::Type(Box::new(self.table.canonicalize(ty))))
             .collect::<GenericArgs>();
         BodyInferenceProgress {
-            calls: self.finalize_calls(),
+            calls: self.finalize_calls(true),
             inference_facts,
         }
     }
@@ -631,43 +631,61 @@ impl BodyInferenceCtx {
     /// Consume live inference state into the persisted body sidecar.
     ///
     /// This is the only boundary that writes expression and binding types into `BodyFacts`.
-    /// Unsolved numeric variables receive their language defaults; other unresolved or cyclic
-    /// slots become unknown, and selected calls retain only finalized full-arity arguments.
-    pub(crate) fn finish(self, mut facts: BodyFacts) -> BodyFacts {
+    /// After convergence, unsolved numeric variables receive their language defaults. An
+    /// incomplete fixed point instead keeps every unresolved slot unknown because later evidence
+    /// could still choose a non-default numeric type. Selected calls retain only finalized
+    /// full-arity arguments under the same policy.
+    pub(crate) fn finish(self, mut facts: BodyFacts, inference_complete: bool) -> BodyFacts {
         debug_assert_eq!(facts.exprs.len(), self.expr_tys.as_slice().len());
         debug_assert_eq!(facts.bindings.len(), self.binding_tys.as_slice().len());
 
         for expr_idx in 0..self.expr_tys.as_slice().len() {
             let expr = ExprId(expr_idx);
-            facts.set_expr_ty(expr, self.finalize_expr_ty(expr));
+            let ty = self.finalize_ty(self.expr_tys.get_ref(expr), inference_complete);
+            facts.set_expr_ty(expr, ty);
         }
         for binding_idx in 0..self.binding_tys.as_slice().len() {
             let binding = BindingId(binding_idx);
-            facts.set_binding_ty(binding, self.finalize_binding_ty(binding));
+            let ty = self.finalize_ty(self.binding_tys.get_ref(binding), inference_complete);
+            facts.set_binding_ty(binding, ty);
         }
-        facts.set_calls(self.finalize_calls());
+        facts.set_calls(self.finalize_calls(inference_complete));
         facts
     }
 
+    #[cfg(test)]
     pub(crate) fn finalize_expr_ty(&self, expr: ExprId) -> Ty {
         self.expr_tys.finalize(&self.table, expr)
     }
 
+    #[cfg(test)]
     pub(crate) fn finalize_binding_ty(&self, binding: BindingId) -> Ty {
         self.binding_tys.finalize(&self.table, binding)
     }
 
     /// Finalize only expressions for which call lookup selected one semantic function.
-    fn finalize_calls(&self) -> Vec<(ExprId, CallFacts)> {
+    fn finalize_calls(&self, inference_complete: bool) -> Vec<(ExprId, CallFacts)> {
         self.call_inference
             .iter()
             .enumerate()
             .filter_map(|(index, state)| {
-                state
-                    .as_ref()
-                    .map(|state| (ExprId(index), state.finalize(&self.table)))
+                state.as_ref().map(|state| {
+                    (
+                        ExprId(index),
+                        state.finalize(&self.table, inference_complete),
+                    )
+                })
             })
             .collect()
+    }
+
+    /// Erase live variables under the policy chosen by the outer fixed-point boundary.
+    fn finalize_ty(&self, ty: &Ty, inference_complete: bool) -> Ty {
+        if inference_complete {
+            self.table.finalize(ty)
+        } else {
+            self.table.finalize_without_numeric_defaults(ty)
+        }
     }
 
     /// Return whether a fact still points into the inference table.

--- a/crates/engine/body-ir/src/resolution/infer/context.rs
+++ b/crates/engine/body-ir/src/resolution/infer/context.rs
@@ -211,16 +211,31 @@ impl BodyInferenceCtx {
             return false;
         }
 
+        // A fixed-point revisit often presents the same weak producer shape again, for example
+        // `Vec<unknown>` after this expression already owns `Vec<?T>`. The existing structure can
+        // absorb any new concrete evidence directly; allocating another `?T` would only grow an
+        // alias chain that is invisible to convergence.
+        let existing_ty = self.root_resolved_expr_ty(expr);
+        if !matches!(existing_ty, Ty::Unknown | Ty::InferVar { .. }) && !existing_ty.has_unknown() {
+            return self.set_expr_infer_ty(expr, ty.clone());
+        }
+
         let (infer_ty, used_vars) = {
             let mut builder = UnknownTypeInstantiationBuilder::new(&mut self.table);
             let infer_ty = builder.ty_from_ty(ty);
             (infer_ty, builder.used_type_vars())
         };
 
-        if used_vars {
-            self.set_expr_infer_ty(expr, infer_ty);
+        if !used_vars {
+            return false;
         }
-        used_vars
+
+        // A partially known fact may contain both live variables and raw `Unknown` children.
+        // Unification links its existing variables, while refinement installs slots for the raw
+        // children so the next pass sees a complete stable structure.
+        self.set_expr_infer_ty(expr, infer_ty.clone());
+        self.refine_expr_fact(expr, infer_ty);
+        true
     }
 
     pub(crate) fn set_expr_integer_var(&mut self, expr: ExprId) {
@@ -564,6 +579,15 @@ impl BodyInferenceCtx {
     }
 
     pub(crate) fn constrain_expr_ty(&mut self, expr: ExprId, expected_ty: &Ty) -> bool {
+        // A diverging expression can inhabit every expected value type, but its own type remains
+        // `!`. Treating this as equality would solve a destination slot to `!`; later evidence for
+        // the real destination type would then conflict instead of refining that slot.
+        if matches!(self.root_resolved_expr_ty(expr), Ty::Never)
+            && !matches!(self.table.resolve_root_var(expected_ty), Ty::Never)
+        {
+            return false;
+        }
+
         // `Unknown` means that no producer fact has arrived yet. Expected types are still real
         // evidence, so retain their shape now; a later producer will unify with or refine it.
         self.set_expr_infer_ty(expr, expected_ty.clone())

--- a/crates/engine/body-ir/src/resolution/infer/facts.rs
+++ b/crates/engine/body-ir/src/resolution/infer/facts.rs
@@ -89,6 +89,7 @@ impl<Id: InferenceFactId> InferenceFacts<Id> {
         self.refine(table, id, ty)
     }
 
+    #[cfg(test)]
     pub(super) fn finalize(&self, table: &InferenceTable, id: Id) -> Ty {
         table.finalize(self.get_ref(id))
     }

--- a/crates/engine/body-ir/src/resolution/infer/tests.rs
+++ b/crates/engine/body-ir/src/resolution/infer/tests.rs
@@ -119,6 +119,33 @@ fn expected_type_seeds_an_expression_without_producer_evidence() {
 }
 
 #[test]
+fn repeated_nested_unknown_instantiation_reuses_expression_slots() {
+    let mut context = BodyInferenceCtx::new(1, 0, 0);
+    let return_ty = vec_ty(Ty::Unknown);
+
+    assert!(context.instantiate_expr_nested_unknown_ty(ExprId(0), &return_ty));
+    let first_inference_ty = context.expr_ty(ExprId(0));
+    let before = context.progress();
+
+    assert!(!context.instantiate_expr_nested_unknown_ty(ExprId(0), &return_ty));
+    assert_eq!(context.expr_ty(ExprId(0)), first_inference_ty);
+    assert!(!context.has_progressed_since(&before));
+}
+
+#[test]
+fn never_expression_does_not_solve_its_expected_type_slot() {
+    let mut context = BodyInferenceCtx::new(1, 0, 0);
+    context.set_expr_infer_ty(ExprId(0), Ty::Never);
+    let expected = context.table.new_type_var();
+
+    assert!(!context.constrain_expr_ty(ExprId(0), &expected));
+    assert!(context.table.unify(&expected, &user_ty()));
+
+    assert_eq!(context.finalize_expr_ty(ExprId(0)), Ty::Never);
+    assert_eq!(context.table.finalize(&expected), user_ty());
+}
+
+#[test]
 fn binding_path_equality_carries_early_expected_type_back_to_the_binding() {
     let mut context = BodyInferenceCtx::new(1, 1, 0);
     context.constrain_expr_ty(ExprId(0), &vec_ty(user_ty()));

--- a/crates/engine/body-ir/src/resolution/pass/body.rs
+++ b/crates/engine/body-ir/src/resolution/pass/body.rs
@@ -153,7 +153,7 @@ where
             );
         }
 
-        Ok(self.inference.finish(self.facts))
+        Ok(self.inference.finish(self.facts, converged))
     }
 
     fn transfer_expressions_and_patterns(&mut self) -> Result<bool, PackageStoreError> {

--- a/crates/engine/body-ir/src/resolution/pass/body.rs
+++ b/crates/engine/body-ir/src/resolution/pass/body.rs
@@ -27,6 +27,11 @@ use super::{
     pattern::PatternInferenceTransfer,
 };
 
+// Most bodies settle after a handful of rounds, but a single slot may legitimately gain several
+// layers of evidence. Keep the emergency ceiling independent of body size: slot count is not a
+// sound convergence bound, while a fixed high limit still prevents an endless rescan.
+const MAX_BODY_INFERENCE_PASSES: usize = 128;
+
 /// Shared state for the body-resolution fixed-point pass.
 ///
 /// The structural body is borrowed and never mutated. Name resolution accumulates directly in the
@@ -118,15 +123,34 @@ where
         // Expressions, patterns, calls, and expected types all exchange evidence through the same
         // inference context. Revisit the transfer rules while that context or declaration
         // resolution changes; there is no ordinary-fact pass to refresh afterward.
-        let max_passes = self.body.exprs().len() + self.body.bindings().len() + 1;
-        for _ in 0..max_passes {
+        let mut converged = false;
+        let mut final_resolution_changed = false;
+        let mut final_inference_changed = false;
+        for _ in 0..MAX_BODY_INFERENCE_PASSES {
             let before = self.inference.progress();
             let resolution_changed = self.transfer_expressions_and_patterns()?;
             InferenceTransferPass::new(&mut self).apply_once()?;
+            let inference_changed = self.inference.has_progressed_since(&before);
 
-            if !resolution_changed && !self.inference.has_progressed_since(&before) {
+            if !resolution_changed && !inference_changed {
+                converged = true;
                 break;
             }
+            final_resolution_changed = resolution_changed;
+            final_inference_changed = inference_changed;
+        }
+
+        if !converged {
+            crate::profile::metric::FIXED_POINT_EXHAUSTIONS.inc();
+            tracing::warn!(
+                body = ?self.env.body_ref(),
+                max_passes = MAX_BODY_INFERENCE_PASSES,
+                expression_count = self.body.exprs().len(),
+                binding_count = self.body.bindings().len(),
+                final_resolution_changed,
+                final_inference_changed,
+                "body inference stopped at the fixed-point pass limit; unresolved facts remain unknown"
+            );
         }
 
         Ok(self.inference.finish(self.facts))

--- a/crates/engine/body-ir/src/tests/closures.rs
+++ b/crates/engine/body-ir/src/tests/closures.rs
@@ -543,3 +543,70 @@ pub fn forward<R>(callback: fn(User) -> R) -> R {
         "#]],
     );
 }
+
+#[test]
+fn never_closure_satisfies_generic_callable_output() {
+    check_project_body_ir_with_fake_sysroot(
+        r#"
+//- /Cargo.toml
+[package]
+name = "body_never_closure_callable_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub struct User;
+pub struct Error;
+pub struct ReportedError;
+
+pub trait BuildFrom<T> {}
+
+pub trait Convert<T> {
+    fn convert(self) -> T;
+}
+
+impl<T, U> Convert<U> for T
+where
+    U: BuildFrom<T>,
+{
+    fn convert(self) -> U {
+        loop {}
+    }
+}
+
+impl BuildFrom<Error> for ReportedError {}
+
+pub enum Outcome<T, E> {
+    Ok(T),
+    Err(E),
+}
+
+impl<T, E> Outcome<T, E> {
+    pub fn unwrap_or_else<F>(self, fallback: F) -> T
+    where
+        F: FnOnce(E) -> T,
+    {
+        loop {}
+    }
+}
+
+pub fn source() -> Outcome<User, Error> {
+    loop {}
+}
+
+pub fn abort() -> ! {
+    loop {}
+}
+
+pub fn report(_: &ReportedError) {}
+
+pub fn use_it() -> User {
+    source().unwrap_or_else(|error| {
+        report(&error.convert());
+        abort()
+    })
+}
+"#,
+        expect![[r#""#]],
+    );
+}

--- a/crates/engine/body-ir/src/tests/closures.rs
+++ b/crates/engine/body-ir/src/tests/closures.rs
@@ -607,6 +607,128 @@ pub fn use_it() -> User {
     })
 }
 "#,
-        expect![[r#""#]],
+        expect![[r#"
+            package alloc
+
+            alloc [lib]
+            skipped
+
+            package body_never_closure_callable_fixture
+
+            body_never_closure_callable_fixture [lib]
+            body b0 fn body_never_closure_callable_fixture[lib]::crate::source @ 36:1-38:2
+            scopes
+            - s0 parent <none>: <none>
+            - s1 parent s0: <none>
+            - s2 parent s1: <none>
+            bindings
+            body
+            expr e2 block s1 => nominal enum body_never_closure_callable_fixture[lib]::crate::Outcome<nominal struct body_never_closure_callable_fixture[lib]::crate::User, nominal struct body_never_closure_callable_fixture[lib]::crate::Error> @ 36:41-38:2
+              tail
+                expr e1 loop => nominal enum body_never_closure_callable_fixture[lib]::crate::Outcome<nominal struct body_never_closure_callable_fixture[lib]::crate::User, nominal struct body_never_closure_callable_fixture[lib]::crate::Error> @ 37:5-37:12
+                  body
+                    expr e0 block s2 => () @ 37:10-37:12
+
+
+            body b1 fn body_never_closure_callable_fixture[lib]::crate::abort @ 40:1-42:2
+            scopes
+            - s0 parent <none>: <none>
+            - s1 parent s0: <none>
+            - s2 parent s1: <none>
+            bindings
+            body
+            expr e2 block s1 => ! @ 40:21-42:2
+              tail
+                expr e1 loop => ! @ 41:5-41:12
+                  body
+                    expr e0 block s2 => () @ 41:10-41:12
+
+
+            body b2 fn body_never_closure_callable_fixture[lib]::crate::report @ 44:1-44:36
+            scopes
+            - s0 parent <none>: <none>
+            - s1 parent s0: <none>
+            bindings
+            body
+            expr e0 block s1 => () @ 44:34-44:36
+
+
+            body b3 fn body_never_closure_callable_fixture[lib]::crate::use_it @ 46:1-51:2
+            scopes
+            - s0 parent <none>: <none>
+            - s1 parent s0: <none>
+            - s2 parent s1: v0
+            - s3 parent s2: <none>
+            bindings
+            - v0 param error `error` => nominal struct body_never_closure_callable_fixture[lib]::crate::Error @ 47:30-47:35
+            body
+            expr e12 block s1 => nominal struct body_never_closure_callable_fixture[lib]::crate::User @ 46:25-51:2
+              tail
+                expr e11 method_call unwrap_or_else -> fn impl Outcome<T, E>::unwrap_or_else => nominal struct body_never_closure_callable_fixture[lib]::crate::User @ 47:5-50:7
+                  receiver
+                    expr e1 call => nominal enum body_never_closure_callable_fixture[lib]::crate::Outcome<nominal struct body_never_closure_callable_fixture[lib]::crate::User, nominal struct body_never_closure_callable_fixture[lib]::crate::Error> @ 47:5-47:13
+                      callee
+                        expr e0 path source -> fn body_never_closure_callable_fixture[lib]::crate::source => function item fn body_never_closure_callable_fixture[lib]::crate::source @ 47:5-47:11
+                  arg
+                    expr e10 closure s2 (v0) => closure #10 @ 47:29-50:6
+                      body
+                        expr e9 block s3 => nominal struct body_never_closure_callable_fixture[lib]::crate::User @ 47:37-50:6
+                          stmt s0 expr; @ 48:9-48:34
+                            expr e6 call => () @ 48:9-48:33
+                              callee
+                                expr e2 path report -> fn body_never_closure_callable_fixture[lib]::crate::report => function item fn body_never_closure_callable_fixture[lib]::crate::report @ 48:9-48:15
+                              arg
+                                expr e5 wrapper ref => &nominal struct body_never_closure_callable_fixture[lib]::crate::ReportedError @ 48:16-48:32
+                                  inner
+                                    expr e4 method_call convert => nominal struct body_never_closure_callable_fixture[lib]::crate::ReportedError @ 48:17-48:32
+                                      receiver
+                                        expr e3 path error -> local v0 => nominal struct body_never_closure_callable_fixture[lib]::crate::Error @ 48:17-48:22
+                          tail
+                            expr e8 call => ! @ 49:9-49:16
+                              callee
+                                expr e7 path abort -> fn body_never_closure_callable_fixture[lib]::crate::abort => function item fn body_never_closure_callable_fixture[lib]::crate::abort @ 49:9-49:14
+
+
+            body b4 fn impl Convert<U> for T::convert @ 15:5-17:6
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: <none>
+            - s2 parent s1: <none>
+            bindings
+            - v0 self_param self `self` => param T @ 15:16-15:20
+            body
+            expr e2 block s1 => param U @ 15:27-17:6
+              tail
+                expr e1 loop => param U @ 16:9-16:16
+                  body
+                    expr e0 block s2 => () @ 16:14-16:16
+
+
+            body b5 fn impl Outcome<T, E>::unwrap_or_else @ 28:5-33:6
+            scopes
+            - s0 parent <none>: v0, v1
+            - s1 parent s0: <none>
+            - s2 parent s1: <none>
+            bindings
+            - v0 self_param self `self` => nominal enum body_never_closure_callable_fixture[lib]::crate::Outcome<param T, param E> @ 28:30-28:34
+            - v1 param fallback `fallback`: F => param F @ 28:36-28:44
+            body
+            expr e2 block s1 => param T @ 31:5-33:6
+              tail
+                expr e1 loop => param T @ 32:9-32:16
+                  body
+                    expr e0 block s2 => () @ 32:14-32:16
+
+
+            package core
+
+            core [lib]
+            skipped
+
+            package std
+
+            std [lib]
+            skipped
+        "#]],
     );
 }

--- a/crates/engine/body-ir/src/tests/type_propagation.rs
+++ b/crates/engine/body-ir/src/tests/type_propagation.rs
@@ -149,3 +149,42 @@ where
         "#]],
     );
 }
+
+#[test]
+fn recursive_supertrait_projection_stops_at_unknown_argument() {
+    check_project_body_ir(
+        r#"
+//- /Cargo.toml
+[package]
+name = "body_recursive_supertrait_projection_fixture"
+version = "0.1.0"
+edition = "2024"
+
+//- /src/lib.rs
+pub trait Base<T> {
+    type Item;
+}
+
+pub trait Derived: Base<Self::Item> {}
+
+pub fn use_it<T: Derived>(value: T::Item) {
+    value;
+}
+"#,
+        expect![[r#"
+            package body_recursive_supertrait_projection_fixture
+
+            body_recursive_supertrait_projection_fixture [lib]
+            body b0 fn body_recursive_supertrait_projection_fixture[lib]::crate::use_it @ 7:1-9:2
+            scopes
+            - s0 parent <none>: v0
+            - s1 parent s0: <none>
+            bindings
+            - v0 param value `value`: T::Item => projection type trait body_recursive_supertrait_projection_fixture[lib]::crate::Base::Item<param T, <unknown>> @ 7:27-7:32
+            body
+            expr e1 block s1 => () @ 7:43-9:2
+              stmt s0 expr; @ 8:5-8:11
+                expr e0 path value -> local v0 => projection type trait body_recursive_supertrait_projection_fixture[lib]::crate::Base::Item<param T, <unknown>> @ 8:5-8:10
+        "#]],
+    );
+}

--- a/crates/engine/project/src/cache/codec/body.rs
+++ b/crates/engine/project/src/cache/codec/body.rs
@@ -32,7 +32,7 @@ use rg_semantic_ir::ItemLookupIndex;
 use wincode::{SchemaRead, SchemaWrite};
 
 use super::{
-    PACKAGE_CACHE_SECTION_LIMIT_BYTES, PackageCacheCodec, PackageCacheProbe,
+    PACKAGE_CACHE_DECODE_LIMIT_BYTES, PackageCacheCodec, PackageCacheProbe,
     PackageCacheSectionRange,
 };
 
@@ -190,16 +190,17 @@ impl PackageCacheCodec {
         let manifest = wincode::config::serialize(&manifest, Self::wincode_config())
             .map_err(|error| anyhow::anyhow!("{error}"))
             .context("while attempting to serialize package cache Body IR manifest")?;
+        anyhow::ensure!(
+            manifest.len() <= PACKAGE_CACHE_DECODE_LIMIT_BYTES,
+            "package cache Body IR manifest has {} bytes, limit is {PACKAGE_CACHE_DECODE_LIMIT_BYTES}",
+            manifest.len(),
+        );
         let manifest_len = u64::try_from(manifest.len())
             .context("package cache Body IR manifest length does not fit u64")?;
         let total_len = BODY_CACHE_CONTAINER_PREFIX_BYTES
             .checked_add(manifest.len())
             .and_then(|len| len.checked_add(payload.len()))
             .context("package cache Body IR section length overflows usize")?;
-        anyhow::ensure!(
-            total_len <= PACKAGE_CACHE_SECTION_LIMIT_BYTES,
-            "package cache Body IR section has {total_len} bytes, limit is {PACKAGE_CACHE_SECTION_LIMIT_BYTES}",
-        );
 
         // 4. Keep the three final fragments separate. The package writer can emit them in this
         // order without allocating and copying another complete Body IR buffer.
@@ -219,6 +220,10 @@ impl PackageCacheCodec {
         let len = end
             .checked_sub(start)
             .context("Body IR payload end precedes its start")?;
+        anyhow::ensure!(
+            len <= PACKAGE_CACHE_DECODE_LIMIT_BYTES,
+            "package cache Body IR payload has {len} bytes, limit is {PACKAGE_CACHE_DECODE_LIMIT_BYTES}",
+        );
         Ok(PackageCacheSectionRange {
             offset: u64::try_from(start).context("Body IR payload offset does not fit u64")?,
             len: u64::try_from(len).context("Body IR payload length does not fit u64")?,
@@ -248,8 +253,8 @@ impl PackageCacheCodec {
         let manifest_len = usize::try_from(manifest_len)
             .context("package cache Body IR manifest length does not fit usize")?;
         anyhow::ensure!(
-            manifest_len <= PACKAGE_CACHE_SECTION_LIMIT_BYTES,
-            "package cache Body IR manifest has {manifest_len} bytes, limit is {PACKAGE_CACHE_SECTION_LIMIT_BYTES}",
+            manifest_len <= PACKAGE_CACHE_DECODE_LIMIT_BYTES,
+            "package cache Body IR manifest has {manifest_len} bytes, limit is {PACKAGE_CACHE_DECODE_LIMIT_BYTES}",
         );
         Ok(manifest_len)
     }
@@ -381,8 +386,8 @@ impl PackageCacheCodec {
                     range.offset,
                 );
                 anyhow::ensure!(
-                    range.len <= PACKAGE_CACHE_SECTION_LIMIT_BYTES as u64,
-                    "package cache Body IR payload has {} bytes, limit is {PACKAGE_CACHE_SECTION_LIMIT_BYTES}",
+                    range.len <= PACKAGE_CACHE_DECODE_LIMIT_BYTES as u64,
+                    "package cache Body IR payload has {} bytes, limit is {PACKAGE_CACHE_DECODE_LIMIT_BYTES}",
                     range.len,
                 );
                 next_offset = next_offset

--- a/crates/engine/project/src/cache/codec/mod.rs
+++ b/crates/engine/project/src/cache/codec/mod.rs
@@ -16,7 +16,7 @@
 //! Wincode is the representation inside each section, not a long-lived compatibility promise.
 //! Schema compatibility comes from the version in the probe header. Every decoder also validates
 //! structural relationships against the probe, exact section consumption, declared ranges, and
-//! allocation limits before returning engine data.
+//! per-decode allocation limits before returning engine data.
 //!
 //! The codec only deals with bytes and engine values. It does not open files or decide whether a
 //! cache miss should trigger a rebuild; those responsibilities belong to the cache store and the
@@ -41,12 +41,13 @@ const PACKAGE_CACHE_CONTAINER_MAGIC: [u8; 8] = *b"RGPKG\0\0\x01";
 /// Bytes needed to discover every outer section without decoding wincode data.
 pub(crate) const PACKAGE_CACHE_CONTAINER_PREFIX_BYTES: usize = 8 + 4 * size_of::<u64>();
 
-// Protect section decoding from corrupted lengths while leaving ample room for realistic large
-// package phases. The complete container may exceed this because each phase is bounded separately.
-const PACKAGE_CACHE_SECTION_LIMIT_BYTES: usize = 256 * 1024 * 1024;
+// Protect one decoded allocation from corrupted lengths while leaving ample room for realistic
+// phase payloads. Body IR is a nested lazy container, so its aggregate section may exceed this;
+// its manifest and every independently decoded lookup index or file shard remain bounded.
+const PACKAGE_CACHE_DECODE_LIMIT_BYTES: usize = 256 * 1024 * 1024;
 
 type PackageCacheWincodeConfig =
-    wincode::config::Configuration<true, PACKAGE_CACHE_SECTION_LIMIT_BYTES>;
+    wincode::config::Configuration<true, PACKAGE_CACHE_DECODE_LIMIT_BYTES>;
 
 /// Absolute byte range in the outer file, or relative range in a nested payload.
 ///
@@ -109,9 +110,9 @@ impl EncodedPackageCacheArtifact {
 impl PackageCacheLayout {
     /// Turn the fixed prefix into trusted file ranges.
     ///
-    /// Besides checking magic and individual size limits, this requires the four ranges to end
-    /// exactly at `file_len`. A truncated file and a file with unexplained trailing bytes are both
-    /// rejected before any wincode decoder sees their contents.
+    /// Besides checking magic and eagerly decoded section limits, this requires the four ranges to
+    /// end exactly at `file_len`. A truncated file and a file with unexplained trailing bytes are
+    /// both rejected before any wincode decoder sees their contents.
     pub(crate) fn decode_prefix(prefix: &[u8], file_len: u64) -> anyhow::Result<Self> {
         // 1. The caller should have read exactly the fixed directory. Validate that assumption and
         // reject unrelated files before interpreting their next bytes as lengths.
@@ -139,15 +140,26 @@ impl PackageCacheLayout {
             cursor = end;
         }
 
-        // 3. Convert lengths into contiguous absolute ranges. The checked cursor prevents a
+        // 3. Probe, DefMap, and Semantic IR are each read and decoded as one allocation. Body IR is
+        // different: its outer section is only a directory over independently bounded payloads,
+        // so limiting their package-wide sum would reject large packages without reducing the
+        // size of any read or decode.
+        for (section, len) in [
+            ("probe", lengths[0]),
+            ("DefMap", lengths[1]),
+            ("Semantic IR", lengths[2]),
+        ] {
+            anyhow::ensure!(
+                len <= PACKAGE_CACHE_DECODE_LIMIT_BYTES as u64,
+                "package cache {section} section has {len} bytes, limit is {PACKAGE_CACHE_DECODE_LIMIT_BYTES}",
+            );
+        }
+
+        // 4. Convert lengths into contiguous absolute ranges. The checked cursor prevents a
         // corrupted length from wrapping around to an earlier part of the file.
         let mut next_offset = u64::try_from(PACKAGE_CACHE_CONTAINER_PREFIX_BYTES)
             .expect("package cache prefix length should fit into u64");
         let mut next_range = |len: u64| -> anyhow::Result<PackageCacheSectionRange> {
-            anyhow::ensure!(
-                len <= PACKAGE_CACHE_SECTION_LIMIT_BYTES as u64,
-                "package cache section has {len} bytes, limit is {PACKAGE_CACHE_SECTION_LIMIT_BYTES}",
-            );
             let range = PackageCacheSectionRange {
                 offset: next_offset,
                 len,
@@ -164,7 +176,7 @@ impl PackageCacheLayout {
             semantic_ir: next_range(lengths[2])?,
             body_ir: next_range(lengths[3])?,
         };
-        // 4. All declared sections together must account for the complete artifact.
+        // 5. All declared sections together must account for the complete artifact.
         anyhow::ensure!(
             next_offset == file_len,
             "package cache sections end at byte {next_offset}, file has {file_len} bytes",
@@ -176,15 +188,24 @@ impl PackageCacheLayout {
     fn encode_prefix(
         section_lengths: [usize; 4],
     ) -> anyhow::Result<[u8; PACKAGE_CACHE_CONTAINER_PREFIX_BYTES]> {
+        // Body IR is written as one contiguous outer section, but later reads only allocate its
+        // bounded manifest or one bounded nested payload. Keep the aggregate out of this check.
+        for (section, length) in [
+            ("probe", section_lengths[0]),
+            ("DefMap", section_lengths[1]),
+            ("Semantic IR", section_lengths[2]),
+        ] {
+            anyhow::ensure!(
+                length <= PACKAGE_CACHE_DECODE_LIMIT_BYTES,
+                "package cache {section} section has {length} bytes, limit is {PACKAGE_CACHE_DECODE_LIMIT_BYTES}",
+            );
+        }
+
         let mut prefix = [0_u8; PACKAGE_CACHE_CONTAINER_PREFIX_BYTES];
         prefix[..PACKAGE_CACHE_CONTAINER_MAGIC.len()]
             .copy_from_slice(&PACKAGE_CACHE_CONTAINER_MAGIC);
         let mut cursor = PACKAGE_CACHE_CONTAINER_MAGIC.len();
         for length in section_lengths {
-            anyhow::ensure!(
-                length <= PACKAGE_CACHE_SECTION_LIMIT_BYTES,
-                "package cache section has {length} bytes, limit is {PACKAGE_CACHE_SECTION_LIMIT_BYTES}",
-            );
             let end = cursor + size_of::<u64>();
             prefix[cursor..end].copy_from_slice(
                 &u64::try_from(length)
@@ -281,10 +302,10 @@ impl PackageCacheCodec {
     /// Use one bounded wincode configuration for every independently decoded storage unit.
     ///
     /// The preallocation limit is defensive against malformed cache lengths. It is not a total
-    /// artifact limit: the outer file can contain several separately bounded sections.
+    /// artifact limit: Body IR can contain many independently bounded storage units.
     fn wincode_config() -> PackageCacheWincodeConfig {
         wincode::config::Configuration::default()
-            .with_preallocation_size_limit::<PACKAGE_CACHE_SECTION_LIMIT_BYTES>()
+            .with_preallocation_size_limit::<PACKAGE_CACHE_DECODE_LIMIT_BYTES>()
     }
 
     fn validate_header(header: &PackageCacheHeader) -> anyhow::Result<()> {
@@ -375,5 +396,30 @@ impl PackageCacheCodec {
         Self::validate_def_map(input.def_map, probe)?;
         Self::validate_semantic_ir(input.semantic_ir, probe)?;
         Self::validate_body_ir(input.body_ir, probe)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn package_layout_allows_body_ir_larger_than_one_decode_unit() {
+        // No allocation follows this declared length: opening Body IR reads its small directory,
+        // then one independently bounded payload. Exercise both prefix writing and validation.
+        let body_ir_len = PACKAGE_CACHE_DECODE_LIMIT_BYTES + 1;
+        let prefix = PackageCacheLayout::encode_prefix([0, 0, 0, body_ir_len])
+            .expect("aggregate Body IR should not use the per-decode limit");
+        let body_ir_len =
+            u64::try_from(body_ir_len).expect("fixture Body IR section length should fit u64");
+        let file_len = u64::try_from(PACKAGE_CACHE_CONTAINER_PREFIX_BYTES)
+            .expect("package cache prefix length should fit u64")
+            .checked_add(body_ir_len)
+            .expect("fixture package cache length should fit u64");
+
+        let layout = PackageCacheLayout::decode_prefix(&prefix, file_len)
+            .expect("aggregate Body IR layout should validate");
+
+        assert_eq!(layout.body_ir.len, body_ir_len);
     }
 }

--- a/crates/engine/project/src/lib.rs
+++ b/crates/engine/project/src/lib.rs
@@ -56,6 +56,7 @@ pub fn profile_descriptors() -> &'static [rg_profile::ProfileDescriptor] {
         .get_or_init(|| {
             let mut descriptors = Vec::new();
             descriptors.extend_from_slice(profile::profile_descriptors());
+            descriptors.extend_from_slice(rg_body_ir::profile_descriptors());
             descriptors.extend_from_slice(rg_def_map::profile_descriptors());
             descriptors.extend_from_slice(rg_ty::profile_descriptors());
             descriptors

--- a/crates/engine/ty/src/inference/subst.rs
+++ b/crates/engine/ty/src/inference/subst.rs
@@ -113,6 +113,16 @@ impl InferenceSubstitution {
         table.finalize_generic_args(&args)
     }
 
+    /// Finalize durable arguments when the owning inference operation stopped incomplete.
+    pub fn finalize_args_without_numeric_defaults(
+        &self,
+        table: &InferenceTable,
+        params: impl IntoIterator<Item = GenericParamRef>,
+    ) -> GenericArgs {
+        let args = self.0.args_for_params(params);
+        table.finalize_generic_args_without_numeric_defaults(&args)
+    }
+
     /// Give the function's own type parameters fresh variables, shadowing only by identity.
     pub fn shadow_type_params(&mut self, table: &mut InferenceTable, generics: &Generics<'_>) {
         for param in generics.iter_self() {

--- a/crates/engine/ty/src/inference/table.rs
+++ b/crates/engine/ty/src/inference/table.rs
@@ -1,5 +1,5 @@
 use super::{
-    traversal::{InferenceTyFolder, same_generic_arg_shape, same_ty_shape, ty_contains_var},
+    traversal::{InferenceTyFolder, same_generic_arg_shape, same_ty_shape},
     var::{InferVarId, InferVarKind},
 };
 use crate::{
@@ -379,9 +379,10 @@ impl InferenceTable {
             return UnifyResult::compatible();
         }
 
-        // Avoid recursive solutions such as `?T = Vec<?T>`. The check uses root evidence so
-        // variable links like `?U = ?T` do not later allow the reverse `?T = ?U` cycle.
-        if ty_contains_var(&evidence, id) {
+        // Avoid recursive solutions such as `?T = Vec<?T>`. Solved variables nested inside the
+        // evidence must be followed as well: `?A = Vec<?B>` and `?B = ?T` make `?T = ?A`
+        // recursive even though `?T` is not present in the stored `Vec<?B>` syntax.
+        if self.ty_contains_var_or_cycle(&evidence, id, &mut Vec::new()) {
             let result = if Self::shallow_infer_var(&evidence).is_some_and(|(_, var)| var == id) {
                 UnifyResult::compatible()
             } else {
@@ -412,8 +413,120 @@ impl InferenceTable {
         }
     }
 
+    /// Follow solved slots while checking whether evidence would make a variable recursive.
+    ///
+    /// The active stack also rejects evidence that already contains a recursive slot graph. Such
+    /// a graph should not be constructible through this table, but accepting it as new evidence
+    /// would spread the invalid state and make later type traversal unsafe.
+    fn ty_contains_var_or_cycle(
+        &self,
+        ty: &Ty,
+        needle: InferVarId,
+        active_vars: &mut Vec<InferVarId>,
+    ) -> bool {
+        match ty {
+            Ty::InferVar { kind, id } => {
+                if *id == needle || active_vars.contains(id) {
+                    return true;
+                }
+
+                let Some(slot) = self.slots.get(id.index()) else {
+                    return false;
+                };
+                if slot.kind != *kind {
+                    return false;
+                }
+                let InferVarValue::Solved(solution) = &slot.value else {
+                    return false;
+                };
+
+                active_vars.push(*id);
+                let contains = self.ty_contains_var_or_cycle(solution, needle, active_vars);
+                active_vars.pop();
+                contains
+            }
+            Ty::Tuple(fields) => fields
+                .iter()
+                .any(|field| self.ty_contains_var_or_cycle(field, needle, active_vars)),
+            Ty::Array { inner, .. }
+            | Ty::Slice(inner)
+            | Ty::Reference { inner, .. }
+            | Ty::RawPointer { inner, .. } => {
+                self.ty_contains_var_or_cycle(inner, needle, active_vars)
+            }
+            Ty::FnPointer { params, ret } => {
+                params
+                    .iter()
+                    .any(|param| self.ty_contains_var_or_cycle(param, needle, active_vars))
+                    || self.ty_contains_var_or_cycle(ret, needle, active_vars)
+            }
+            Ty::Adt(ty) => ty
+                .args
+                .iter()
+                .any(|arg| self.generic_arg_contains_var_or_cycle(arg, needle, active_vars)),
+            Ty::Alias(alias) => alias
+                .args()
+                .iter()
+                .any(|arg| self.generic_arg_contains_var_or_cycle(arg, needle, active_vars)),
+            Ty::FnDef(function) => function
+                .args
+                .iter()
+                .any(|arg| self.generic_arg_contains_var_or_cycle(arg, needle, active_vars)),
+            Ty::Closure(closure) => {
+                closure
+                    .params
+                    .iter()
+                    .any(|param| self.ty_contains_var_or_cycle(param, needle, active_vars))
+                    || self.ty_contains_var_or_cycle(&closure.ret, needle, active_vars)
+            }
+            Ty::Unit | Ty::Never | Ty::Primitive(_) | Ty::Param(_) | Ty::Unknown => false,
+        }
+    }
+
+    fn generic_arg_contains_var_or_cycle(
+        &self,
+        arg: &GenericArg,
+        needle: InferVarId,
+        active_vars: &mut Vec<InferVarId>,
+    ) -> bool {
+        match arg {
+            GenericArg::Type(ty) => self.ty_contains_var_or_cycle(ty, needle, active_vars),
+            GenericArg::Lifetime(_) | GenericArg::Const(_) => false,
+        }
+    }
+
     fn solve_unsolved_var(&mut self, id: InferVarId, evidence: &Ty) -> UnifyResult {
         let kind = self.slots[id.index()].kind;
+        // Equality between same-kind variables is symmetric, so keep the oldest slot as the
+        // representative. Directional links based on call order build chains such as
+        // `?0 -> ?1 -> ?2`; every later canonicalization then recursively walks that chain.
+        // Stable representatives instead make later variables point back into the body-owned
+        // slots that existed before them.
+        if let Some((evidence_kind, evidence_id)) = Self::shallow_infer_var(evidence)
+            && evidence_kind == kind
+        {
+            let (representative, alias) = if id.index() <= evidence_id.index() {
+                (id, evidence_id)
+            } else {
+                (evidence_id, id)
+            };
+            if representative == alias {
+                return UnifyResult::compatible();
+            }
+
+            debug_assert!(matches!(
+                self.slots[representative.index()].value,
+                InferVarValue::Unsolved
+            ));
+            debug_assert!(matches!(
+                self.slots[alias.index()].value,
+                InferVarValue::Unsolved
+            ));
+            self.slots[alias.index()].value =
+                InferVarValue::Solved(Ty::var_for_kind(kind, representative));
+            return UnifyResult::changed();
+        }
+
         // Numeric variables may be unified with an ordinary type variable. Link through the type
         // variable so a later or already-known primitive solution is shared by both slots.
         if let Some((var_kind, var)) = Self::shallow_infer_var(evidence)

--- a/crates/engine/ty/src/inference/table.rs
+++ b/crates/engine/ty/src/inference/table.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use super::{
     traversal::{InferenceTyFolder, same_generic_arg_shape, same_ty_shape},
     var::{InferVarId, InferVarKind},
@@ -19,6 +21,13 @@ enum InferVarValue {
     Solved(Ty),
     /// The variable saw incompatible evidence and must finalize conservatively.
     Conflict,
+}
+
+/// Fallback used when a numeric inference slot has no semantic evidence.
+#[derive(Clone, Copy)]
+enum NumericFallback {
+    LanguageDefault,
+    Unknown,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -145,12 +154,32 @@ impl InferenceTable {
     }
 
     pub fn finalize(&self, ty: &Ty) -> Ty {
-        TableFinalizer::new(self).fold_ty(ty)
+        TableFinalizer::new(self, NumericFallback::LanguageDefault).fold_ty(ty)
+    }
+
+    /// Finalize inference state that stopped before reaching a fixed point.
+    ///
+    /// Ordinary type variables already become `Unknown`. Numeric variables must do the same here:
+    /// their `i32` / `f64` defaults are language conclusions only after all available constraints
+    /// have propagated.
+    pub fn finalize_without_numeric_defaults(&self, ty: &Ty) -> Ty {
+        TableFinalizer::new(self, NumericFallback::Unknown).fold_ty(ty)
     }
 
     /// Finalize every type-bearing position in a semantic argument list.
     pub(crate) fn finalize_generic_args(&self, args: &GenericArgs) -> GenericArgs {
-        let mut finalizer = TableFinalizer::new(self);
+        let mut finalizer = TableFinalizer::new(self, NumericFallback::LanguageDefault);
+        args.iter()
+            .map(|arg| finalizer.fold_generic_arg(arg))
+            .collect()
+    }
+
+    /// Finalize durable arguments after an incomplete inference operation.
+    pub(crate) fn finalize_generic_args_without_numeric_defaults(
+        &self,
+        args: &GenericArgs,
+    ) -> GenericArgs {
+        let mut finalizer = TableFinalizer::new(self, NumericFallback::Unknown);
         args.iter()
             .map(|arg| finalizer.fold_generic_arg(arg))
             .collect()
@@ -382,11 +411,15 @@ impl InferenceTable {
         // Avoid recursive solutions such as `?T = Vec<?T>`. Solved variables nested inside the
         // evidence must be followed as well: `?A = Vec<?B>` and `?B = ?T` make `?T = ?A`
         // recursive even though `?T` is not present in the stored `Vec<?B>` syntax.
-        if self.ty_contains_var_or_cycle(&evidence, id, &mut Vec::new()) {
+        if self.ty_contains_var_or_cycle(&evidence, id) {
             let result = if Self::shallow_infer_var(&evidence).is_some_and(|(_, var)| var == id) {
                 UnifyResult::compatible()
             } else {
-                self.mark_conflict(id)
+                // Equality aliases share one representative. Poisoning only the spelling that
+                // happened to occur in recursive evidence would detach it from that class and let
+                // the representative accept a later concrete solution.
+                let representative = self.infer_var_representative(id, kind);
+                self.mark_conflict(representative)
             };
             return result;
         }
@@ -418,81 +451,128 @@ impl InferenceTable {
     /// The active stack also rejects evidence that already contains a recursive slot graph. Such
     /// a graph should not be constructible through this table, but accepting it as new evidence
     /// would spread the invalid state and make later type traversal unsafe.
-    fn ty_contains_var_or_cycle(
-        &self,
-        ty: &Ty,
-        needle: InferVarId,
-        active_vars: &mut Vec<InferVarId>,
-    ) -> bool {
-        match ty {
-            Ty::InferVar { kind, id } => {
-                if *id == needle || active_vars.contains(id) {
-                    return true;
-                }
-
-                let Some(slot) = self.slots.get(id.index()) else {
-                    return false;
-                };
-                if slot.kind != *kind {
-                    return false;
-                }
-                let InferVarValue::Solved(solution) = &slot.value else {
-                    return false;
-                };
-
-                active_vars.push(*id);
-                let contains = self.ty_contains_var_or_cycle(solution, needle, active_vars);
-                active_vars.pop();
-                contains
-            }
-            Ty::Tuple(fields) => fields
-                .iter()
-                .any(|field| self.ty_contains_var_or_cycle(field, needle, active_vars)),
-            Ty::Array { inner, .. }
-            | Ty::Slice(inner)
-            | Ty::Reference { inner, .. }
-            | Ty::RawPointer { inner, .. } => {
-                self.ty_contains_var_or_cycle(inner, needle, active_vars)
-            }
-            Ty::FnPointer { params, ret } => {
-                params
-                    .iter()
-                    .any(|param| self.ty_contains_var_or_cycle(param, needle, active_vars))
-                    || self.ty_contains_var_or_cycle(ret, needle, active_vars)
-            }
-            Ty::Adt(ty) => ty
-                .args
-                .iter()
-                .any(|arg| self.generic_arg_contains_var_or_cycle(arg, needle, active_vars)),
-            Ty::Alias(alias) => alias
-                .args()
-                .iter()
-                .any(|arg| self.generic_arg_contains_var_or_cycle(arg, needle, active_vars)),
-            Ty::FnDef(function) => function
-                .args
-                .iter()
-                .any(|arg| self.generic_arg_contains_var_or_cycle(arg, needle, active_vars)),
-            Ty::Closure(closure) => {
-                closure
-                    .params
-                    .iter()
-                    .any(|param| self.ty_contains_var_or_cycle(param, needle, active_vars))
-                    || self.ty_contains_var_or_cycle(&closure.ret, needle, active_vars)
-            }
-            Ty::Unit | Ty::Never | Ty::Primitive(_) | Ty::Param(_) | Ty::Unknown => false,
+    fn ty_contains_var_or_cycle<'a>(&'a self, ty: &'a Ty, needle: InferVarId) -> bool {
+        // A solved structural chain can be much longer than the source type that created each
+        // individual slot. Use an explicit DFS so malformed/generated evidence cannot consume the
+        // thread stack, and retain both visiting/finished sets so shared DAG nodes are not mistaken
+        // for cycles.
+        enum Step<'ty> {
+            Visit(&'ty Ty),
+            FinishVar(InferVarId),
         }
+
+        let mut steps = vec![Step::Visit(ty)];
+        let mut active_vars = HashSet::new();
+        let mut finished_vars = HashSet::new();
+        while let Some(step) = steps.pop() {
+            let ty = match step {
+                Step::Visit(ty) => ty,
+                Step::FinishVar(id) => {
+                    active_vars.remove(&id);
+                    finished_vars.insert(id);
+                    continue;
+                }
+            };
+
+            match ty {
+                Ty::InferVar { kind, id } => {
+                    if *id == needle || active_vars.contains(id) {
+                        return true;
+                    }
+                    if finished_vars.contains(id) {
+                        continue;
+                    }
+
+                    let Some(slot) = self.slots.get(id.index()) else {
+                        continue;
+                    };
+                    if slot.kind != *kind {
+                        continue;
+                    }
+                    let InferVarValue::Solved(solution) = &slot.value else {
+                        continue;
+                    };
+
+                    active_vars.insert(*id);
+                    steps.push(Step::FinishVar(*id));
+                    steps.push(Step::Visit(solution));
+                }
+                Ty::Tuple(fields) => {
+                    steps.extend(fields.iter().map(Step::Visit));
+                }
+                Ty::Array { inner, .. }
+                | Ty::Slice(inner)
+                | Ty::Reference { inner, .. }
+                | Ty::RawPointer { inner, .. } => steps.push(Step::Visit(inner)),
+                Ty::FnPointer { params, ret } => {
+                    steps.push(Step::Visit(ret));
+                    steps.extend(params.iter().map(Step::Visit));
+                }
+                Ty::Adt(ty) => {
+                    steps.extend(
+                        ty.args
+                            .iter()
+                            .filter_map(GenericArg::as_ty)
+                            .map(Step::Visit),
+                    );
+                }
+                Ty::Alias(alias) => {
+                    steps.extend(
+                        alias
+                            .args()
+                            .iter()
+                            .filter_map(GenericArg::as_ty)
+                            .map(Step::Visit),
+                    );
+                }
+                Ty::FnDef(function) => {
+                    steps.extend(
+                        function
+                            .args
+                            .iter()
+                            .filter_map(GenericArg::as_ty)
+                            .map(Step::Visit),
+                    );
+                }
+                Ty::Closure(closure) => {
+                    steps.push(Step::Visit(&closure.ret));
+                    steps.extend(closure.params.iter().map(Step::Visit));
+                }
+                Ty::Unit | Ty::Never | Ty::Primitive(_) | Ty::Param(_) | Ty::Unknown => {}
+            }
+        }
+        false
     }
 
-    fn generic_arg_contains_var_or_cycle(
-        &self,
-        arg: &GenericArg,
-        needle: InferVarId,
-        active_vars: &mut Vec<InferVarId>,
-    ) -> bool {
-        match arg {
-            GenericArg::Type(ty) => self.ty_contains_var_or_cycle(ty, needle, active_vars),
-            GenericArg::Lifetime(_) | GenericArg::Const(_) => false,
+    /// Follow variable-to-variable links to the slot that owns their shared evidence.
+    fn infer_var_representative(&self, id: InferVarId, kind: InferVarKind) -> InferVarId {
+        let mut current_id = id;
+        let mut current_kind = kind;
+        let mut visited = HashSet::new();
+        while visited.insert(current_id) {
+            let Some(slot) = self.slots.get(current_id.index()) else {
+                break;
+            };
+            if slot.kind != current_kind {
+                break;
+            }
+            let InferVarValue::Solved(Ty::InferVar {
+                kind: next_kind,
+                id: next_id,
+            }) = &slot.value
+            else {
+                break;
+            };
+            let Some(next_slot) = self.slots.get(next_id.index()) else {
+                break;
+            };
+            if next_slot.kind != *next_kind {
+                break;
+            }
+            current_id = *next_id;
+            current_kind = *next_kind;
         }
+        current_id
     }
 
     fn solve_unsolved_var(&mut self, id: InferVarId, evidence: &Ty) -> UnifyResult {
@@ -873,13 +953,15 @@ impl InferenceTyFolder for TableCanonicalizer<'_> {
 struct TableFinalizer<'table> {
     table: &'table InferenceTable,
     active_vars: Vec<InferVarId>,
+    numeric_fallback: NumericFallback,
 }
 
 impl<'table> TableFinalizer<'table> {
-    fn new(table: &'table InferenceTable) -> Self {
+    fn new(table: &'table InferenceTable, numeric_fallback: NumericFallback) -> Self {
         Self {
             table,
             active_vars: Vec::new(),
+            numeric_fallback,
         }
     }
 }
@@ -920,10 +1002,17 @@ impl InferenceTyFolder for TableFinalizer<'_> {
         }
 
         match &slot.value {
-            InferVarValue::Unsolved => match kind {
-                InferVarKind::Type => Ty::Unknown,
-                InferVarKind::Integer => Ty::Primitive(PrimitiveTy::DEFAULT_INT),
-                InferVarKind::Float => Ty::Primitive(PrimitiveTy::DEFAULT_FLOAT),
+            InferVarValue::Unsolved => match (kind, self.numeric_fallback) {
+                (InferVarKind::Type, _)
+                | (InferVarKind::Integer | InferVarKind::Float, NumericFallback::Unknown) => {
+                    Ty::Unknown
+                }
+                (InferVarKind::Integer, NumericFallback::LanguageDefault) => {
+                    Ty::Primitive(PrimitiveTy::DEFAULT_INT)
+                }
+                (InferVarKind::Float, NumericFallback::LanguageDefault) => {
+                    Ty::Primitive(PrimitiveTy::DEFAULT_FLOAT)
+                }
             },
             InferVarValue::Solved(ty) => {
                 self.active_vars.push(id);

--- a/crates/engine/ty/src/inference/tests.rs
+++ b/crates/engine/ty/src/inference/tests.rs
@@ -265,14 +265,53 @@ fn indirect_var_links_do_not_create_reverse_cycles() {
     assert!(table.unify(&second, &third));
     assert!(!table.unify(&third, &first));
 
-    assert_eq!(table.resolve_root_var(&first), third);
-    assert_eq!(table.resolve_root_var(&second), third);
+    assert_eq!(table.resolve_root_var(&second), first);
+    assert_eq!(table.resolve_root_var(&third), first);
 
     assert!(table.unify(&third, &fourth));
     assert!(!table.unify(&fourth, &first));
-    assert_eq!(table.resolve_root_var(&first), fourth);
-    assert_eq!(table.resolve_root_var(&second), fourth);
-    assert_eq!(table.resolve_root_var(&third), fourth);
+    assert_eq!(table.resolve_root_var(&second), first);
+    assert_eq!(table.resolve_root_var(&third), first);
+    assert_eq!(table.resolve_root_var(&fourth), first);
+}
+
+#[test]
+fn long_variable_equality_sequence_finalizes_without_recursive_alias_walk() {
+    let mut table = InferenceTable::new();
+    let vars = (0..50_000)
+        .map(|_| table.new_type_var())
+        .collect::<Vec<_>>();
+
+    // Equality is symmetric. A long sequence should share one representative instead of storing
+    // a directional `?0 -> ?1 -> ?2` chain whose later resolution consumes the thread stack.
+    for pair in vars.windows(2) {
+        assert!(table.unify(&pair[0], &pair[1]));
+    }
+    assert!(table.unify(
+        vars.last().expect("the test creates inference variables"),
+        &user_ty()
+    ));
+
+    assert_eq!(table.finalize(&vars[0]), user_ty());
+}
+
+#[test]
+fn nested_var_links_do_not_create_indirect_cycles() {
+    let mut table = InferenceTable::new();
+    let container = table.new_type_var();
+    let element = table.new_type_var();
+    let alias = table.new_type_var();
+
+    assert!(table.unify(&container, &vec_ty(element.clone())));
+    assert!(table.unify(&element, &alias));
+
+    // `container = Vec<element>` and `element = alias` make `alias = container` recursive,
+    // even though the target variable is hidden behind both a type shape and another slot.
+    assert_eq!(
+        table.try_unify(&alias, &container),
+        Err(super::InferenceConflict)
+    );
+    assert_eq!(table.finalize(&container), concrete_vec_ty(Ty::Unknown));
 }
 
 #[test]
@@ -283,8 +322,8 @@ fn canonicalizes_variable_aliases_inside_type_shapes() {
 
     assert!(table.unify(&element, &alias));
 
-    assert_eq!(table.canonicalize(&element), alias);
-    assert_eq!(table.canonicalize(&vec_ty(element)), vec_ty(alias));
+    assert_eq!(table.canonicalize(&alias), element);
+    assert_eq!(table.canonicalize(&vec_ty(alias)), vec_ty(element));
 }
 
 #[test]

--- a/crates/engine/ty/src/inference/tests.rs
+++ b/crates/engine/ty/src/inference/tests.rs
@@ -108,6 +108,22 @@ fn finalizes_unsolved_variables_to_stable_fallbacks() {
 }
 
 #[test]
+fn incomplete_finalization_does_not_default_numeric_variables() {
+    let mut table = InferenceTable::new();
+    let int_var = table.new_integer_var();
+    let float_var = table.new_float_var();
+
+    assert_eq!(
+        table.finalize_without_numeric_defaults(&int_var),
+        Ty::Unknown
+    );
+    assert_eq!(
+        table.finalize_without_numeric_defaults(&float_var),
+        Ty::Unknown
+    );
+}
+
+#[test]
 fn conflicting_variables_finalize_to_unknown() {
     let mut table = InferenceTable::new();
     let var = table.new_type_var();
@@ -312,6 +328,45 @@ fn nested_var_links_do_not_create_indirect_cycles() {
         Err(super::InferenceConflict)
     );
     assert_eq!(table.finalize(&container), concrete_vec_ty(Ty::Unknown));
+}
+
+#[test]
+fn recursive_evidence_through_alias_conflicts_the_representative() {
+    let mut table = InferenceTable::new();
+    let representative = table.new_type_var();
+    let alias = table.new_type_var();
+
+    assert!(table.unify(&representative, &alias));
+    assert_eq!(table.resolve_root_var(&alias), representative);
+
+    // The recursive spelling uses the alias, but both slots describe one equality class. The
+    // representative must become conflicting so it cannot accept an unrelated concrete type.
+    assert!(table.unify(&alias, &vec_ty(alias.clone())));
+    assert!(!table.unify(&representative, &user_ty()));
+    assert_eq!(table.finalize(&representative), Ty::Unknown);
+    assert_eq!(table.finalize(&alias), Ty::Unknown);
+}
+
+#[test]
+fn long_structural_variable_chain_checks_cycles_without_recursing() {
+    let mut table = InferenceTable::new();
+    let vars = (0..50_000)
+        .map(|_| table.new_type_var())
+        .collect::<Vec<_>>();
+
+    // Each slot contributes only one structural layer, but following their solutions creates a
+    // chain deep enough to consume the thread stack if the occurs check uses recursive calls.
+    for pair in vars.windows(2) {
+        assert!(table.unify(&pair[0], &vec_ty(pair[1].clone())));
+    }
+
+    assert_eq!(
+        table.try_unify(
+            vars.last().expect("the test creates inference variables"),
+            &vars[0],
+        ),
+        Err(super::InferenceConflict)
+    );
 }
 
 #[test]

--- a/crates/engine/ty/src/inference/traversal.rs
+++ b/crates/engine/ty/src/inference/traversal.rs
@@ -145,55 +145,6 @@ pub(super) trait InferenceTyFolder {
     }
 }
 
-/// Return whether a type contains a specific inference variable.
-pub(super) fn ty_contains_var(ty: &Ty, needle: InferVarId) -> bool {
-    match ty {
-        Ty::InferVar { id, .. } => *id == needle,
-        Ty::Tuple(fields) => fields.iter().any(|field| ty_contains_var(field, needle)),
-        Ty::Array { inner, .. }
-        | Ty::Slice(inner)
-        | Ty::Reference { inner, .. }
-        | Ty::RawPointer { inner, .. } => ty_contains_var(inner, needle),
-        Ty::FnPointer { params, ret } => {
-            params.iter().any(|param| ty_contains_var(param, needle))
-                || ty_contains_var(ret, needle)
-        }
-        Ty::Adt(ty) => ty
-            .args
-            .iter()
-            .any(|arg| generic_arg_contains_var(arg, needle)),
-        Ty::Alias(alias) => match alias {
-            AliasTy::Projection(alias) => alias
-                .args
-                .iter()
-                .any(|arg| generic_arg_contains_var(arg, needle)),
-            AliasTy::Opaque(alias) => alias
-                .args
-                .iter()
-                .any(|arg| generic_arg_contains_var(arg, needle)),
-        },
-        Ty::FnDef(function) => function
-            .args
-            .iter()
-            .any(|arg| generic_arg_contains_var(arg, needle)),
-        Ty::Closure(closure) => {
-            closure
-                .params
-                .iter()
-                .any(|param| ty_contains_var(param, needle))
-                || ty_contains_var(&closure.ret, needle)
-        }
-        Ty::Unit | Ty::Never | Ty::Primitive(_) | Ty::Param(_) | Ty::Unknown => false,
-    }
-}
-
-fn generic_arg_contains_var(arg: &GenericArg, needle: InferVarId) -> bool {
-    match arg {
-        GenericArg::Type(ty) => ty_contains_var(ty, needle),
-        GenericArg::Lifetime(_) | GenericArg::Const(_) => false,
-    }
-}
-
 /// Return whether two types can use the same inference structural branch.
 pub(super) fn same_ty_shape(lhs: &Ty, rhs: &Ty) -> bool {
     match (lhs, rhs) {

--- a/crates/engine/ty/src/lowering.rs
+++ b/crates/engine/ty/src/lowering.rs
@@ -22,6 +22,10 @@ use crate::{
     TraitRefLowering, Ty,
 };
 
+// Source syntax can be deeply nested even without aliases or projections. This is an emergency
+// boundary for malformed/generated input; ordinary Rust types stay far below it.
+const MAX_TYPE_LOWERING_DEPTH: usize = 128;
+
 /// Name-lookup starting point for paths encountered during type lowering.
 ///
 /// A path written in a body may resolve through its lexical `Scope`, including body-local items.
@@ -135,6 +139,9 @@ where
             subst,
             alias_stack: Vec::new(),
             param_projection_stack: Vec::new(),
+            associated_projection_stack: Vec::new(),
+            type_ref_depth: 0,
+            limit_reported: false,
             opaque_indices: Vec::new(),
             opaque_bounds: Vec::new(),
             argument_impl_trait_indices: Vec::new(),
@@ -149,8 +156,8 @@ where
 /// Mutable state shared while one complete signature is lowered.
 ///
 /// Keeping a session across all parameters is what gives anonymous `impl Trait` occurrences a
-/// stable owner-local order. Alias and parameter-projection stacks keep recursive source types
-/// bounded, while owner and lookup context change only for the duration of nested declarations.
+/// stable owner-local order. Alias and projection stacks keep recursive source types bounded,
+/// while owner and lookup context change only for the duration of nested declarations.
 pub struct TypeLoweringSession<'lower, 'query, D, I, R> {
     query: &'lower TypeLoweringQuery<'lower, 'query, D, I, R>,
     owner: GenericDefRef,
@@ -158,6 +165,9 @@ pub struct TypeLoweringSession<'lower, 'query, D, I, R> {
     subst: Substitution,
     alias_stack: Vec<TypeAliasRef>,
     param_projection_stack: Vec<(TypeParamRef, rg_text::Name)>,
+    associated_projection_stack: Vec<(TraitDefRef, rg_text::Name)>,
+    type_ref_depth: usize,
+    limit_reported: bool,
     opaque_indices: Vec<(GenericDefRef, usize)>,
     opaque_bounds: Vec<(OpaqueTy, Vec<TraitRefLowering>)>,
     argument_impl_trait_indices: Vec<(GenericDefRef, usize)>,
@@ -458,6 +468,23 @@ where
     }
 
     fn lower_type_ref_with_mode(
+        &mut self,
+        ty: &TypeRef,
+        impl_trait_mode: ImplTraitMode,
+        inference: Option<&mut InferenceTable>,
+    ) -> Result<Ty, D::Error> {
+        if self.type_ref_depth >= MAX_TYPE_LOWERING_DEPTH {
+            self.report_limit("type_ref_depth", Some(MAX_TYPE_LOWERING_DEPTH));
+            return Ok(Ty::Unknown);
+        }
+
+        self.type_ref_depth += 1;
+        let result = self.lower_type_ref_with_mode_inner(ty, impl_trait_mode, inference);
+        self.type_ref_depth -= 1;
+        result
+    }
+
+    fn lower_type_ref_with_mode_inner(
         &mut self,
         ty: &TypeRef,
         impl_trait_mode: ImplTraitMode,
@@ -1091,7 +1118,44 @@ where
         application: &TraitApplication,
         name: &rg_text::Name,
     ) -> Result<Option<ProjectionTy>, D::Error> {
-        self.associated_type_projection_inner(application, name, &[])
+        // Supertrait arguments can refer back to the associated item being searched for. The
+        // lineage inside the graph walk cannot see that re-entry because lowering the argument
+        // starts a fresh walk, so retain the semantic request across the complete lowering session.
+        if self
+            .associated_projection_stack
+            .iter()
+            .any(|(trait_ref, candidate)| *trait_ref == application.def && candidate == name)
+        {
+            self.report_limit("associated_projection_cycle", None);
+            return Ok(None);
+        }
+
+        self.associated_projection_stack
+            .push((application.def, name.clone()));
+        let result = self.associated_type_projection_inner(application, name, &[]);
+        let popped = self
+            .associated_projection_stack
+            .pop()
+            .expect("projection request was pushed above");
+        debug_assert_eq!(popped.0, application.def);
+        debug_assert_eq!(popped.1, *name);
+        result
+    }
+
+    /// Make a fail-soft lowering boundary observable without flooding one signature walk.
+    fn report_limit(&mut self, kind: &'static str, limit: Option<usize>) {
+        if self.limit_reported {
+            return;
+        }
+        self.limit_reported = true;
+        crate::profile::metric::TYPE_LOWERING_LIMIT_EXHAUSTIONS.inc(kind);
+        tracing::warn!(
+            owner = ?self.owner,
+            anchor = ?self.anchor,
+            limit_kind = kind,
+            limit,
+            "type lowering stopped at a recursion limit; affected types remain unknown"
+        );
     }
 
     fn associated_type_projection_inner(

--- a/crates/engine/ty/src/profile.rs
+++ b/crates/engine/ty/src/profile.rs
@@ -13,6 +13,10 @@ const BY_DURATION: ProfileReport = ProfileReport {
 
 declare_metrics! {
     pub(crate) mod metric {
+        scope "ty.lowering" {
+            /// Recursive source-type lowering stopped at a semantic cycle or depth boundary.
+            keyed_counter TYPE_LOWERING_LIMIT_EXHAUSTIONS = "limit_exhaustions" [report super::BY_COUNT, title "Type-lowering limit exhaustions"];
+        }
         scope "ty.trait_selection.chalk" {
             /// Impl candidates whose header matched and had no predicates left for Chalk to prove.
             counter PREDICATE_FREE_CANDIDATES = "candidates.predicate_free";
@@ -36,6 +40,8 @@ declare_metrics! {
             keyed_counter SOLVER_GOAL_SHAPES = "solver.goal_shapes" [report super::BY_COUNT, title "Chalk solver goal shapes"];
             /// Repeated body-local goals served from a previous bounded decline.
             counter DECLINED_GOAL_REUSES = "solver.declined_goal_reuses";
+            /// Body-owned aggregate work or recursive normalization stopped at a safety boundary.
+            keyed_counter WORK_LIMIT_EXHAUSTIONS = "work_limit_exhaustions" [report super::BY_COUNT, title "Trait-selection work-limit exhaustions"];
             /// Associated projections instantiated directly from a selected native impl.
             counter NATIVE_ASSOC_PROJECTIONS = "native.assoc_projections";
             /// Candidate projection probes stopped at an actual recursive impl cycle.

--- a/crates/engine/ty/src/trait_selection/candidate.rs
+++ b/crates/engine/ty/src/trait_selection/candidate.rs
@@ -10,11 +10,12 @@
 use rg_def_map::DefMapSource;
 use rg_ir_model::{TraitApplicability, TraitImplRef};
 use rg_semantic_ir::{ItemLookupIndex, ItemStoreSource};
+use rg_std::UniqueVec;
 
 use super::matcher::{CandidateMatcher, TraitSelfHead};
 use super::{TraitGoal, TraitSelectionSession};
-use crate::ItemPathQuery;
 use crate::inference::{InferenceSubstitution, InferenceTable};
+use crate::{ItemPathQuery, Ty};
 
 /// One visible impl whose canonical header is compatible with a trait goal.
 ///
@@ -31,7 +32,89 @@ pub(super) struct TraitCandidate {
 }
 
 impl TraitCandidate {
-    /// Enumerate every compatible header, including speculative candidates.
+    /// Enumerate the cheap impl identities that may have a compatible header.
+    ///
+    /// Matching is deliberately separate: every match owns a cloned trial table, so callers must
+    /// consume one candidate before constructing the next instead of retaining one full table per
+    /// visible impl.
+    pub(super) fn plausible_impls<'query, D, I>(
+        item_paths: &ItemPathQuery<'query, D, I>,
+        lookup_index: &ItemLookupIndex,
+        session: &TraitSelectionSession,
+        goal: &TraitGoal,
+        table: &InferenceTable,
+    ) -> Result<UniqueVec<TraitImplRef>, I::Error>
+    where
+        D: DefMapSource<Error = I::Error>,
+        I: ItemStoreSource<'query>,
+    {
+        // Narrow the visible impl set by the resolved outer shape of `Self`. Parameters and aliases
+        // have no useful head, so those established semantic shapes retain every visible impl.
+        let self_ty = table.resolve_root_var(goal.self_ty());
+        // A trait obligation constrains `Self` after some other inference source gives it a shape;
+        // it is not an inverse lookup over today's impl set. Besides being order-dependent Rust
+        // semantics, probing a bare slot would clone the whole body table once for every concrete
+        // impl before eventually calling the result ambiguous.
+        if matches!(self_ty, Ty::InferVar { .. } | Ty::Unknown) {
+            return Ok(UniqueVec::new());
+        }
+        let trait_ref = goal.trait_ref();
+        let Some(visible_impls) = lookup_index.trait_impls_for_trait(trait_ref) else {
+            return Ok(UniqueVec::new());
+        };
+        Ok(match TraitSelfHead::from_ty(&self_ty) {
+            Some(self_head) => session.indexed_trait_impl_candidates(
+                item_paths,
+                trait_ref,
+                visible_impls,
+                self_head,
+            )?,
+            None => visible_impls.collect(),
+        })
+    }
+
+    /// Match one plausible impl against the goal using an isolated trial table.
+    pub(super) fn probe_impl<'query, D, I>(
+        item_paths: &ItemPathQuery<'query, D, I>,
+        session: &TraitSelectionSession,
+        goal: &TraitGoal,
+        table: &InferenceTable,
+        trait_impl: TraitImplRef,
+    ) -> Result<Option<Self>, I::Error>
+    where
+        D: DefMapSource<Error = I::Error>,
+        I: ItemStoreSource<'query>,
+    {
+        // The candidate index identifies plausible self-type heads. Load the canonical header,
+        // then confirm that its declaration still names the requested trait before matching the
+        // full application and collecting equality evidence.
+        let Some(header) = session.impl_header_with(item_paths, item_paths, trait_impl.impl_ref)?
+        else {
+            return Ok(None);
+        };
+        let Some(impl_data) = item_paths.items().impl_data(trait_impl.impl_ref)? else {
+            return Ok(None);
+        };
+        if !impl_data.resolved_trait_ref.is(&goal.trait_ref()) {
+            return Ok(None);
+        }
+
+        let mut trial_table = table.clone();
+        let mut subst = InferenceSubstitution::new();
+        let Some(applicability) =
+            CandidateMatcher.match_goal(goal, trait_impl, &header, &mut trial_table, &mut subst)
+        else {
+            return Ok(None);
+        };
+        Ok(applicability.is_applicable().then_some(Self {
+            trait_impl,
+            subst,
+            applicability,
+            table: trial_table,
+        }))
+    }
+
+    #[cfg(test)]
     pub(super) fn probe_all<'query, D, I>(
         item_paths: &ItemPathQuery<'query, D, I>,
         lookup_index: &ItemLookupIndex,
@@ -43,58 +126,11 @@ impl TraitCandidate {
         D: DefMapSource<Error = I::Error>,
         I: ItemStoreSource<'query>,
     {
-        // Narrow the visible impl set by the resolved outer shape of `Self`. A parameter, alias,
-        // or inference variable has no useful head, so those goals must inspect every visible impl.
-        let self_ty = table.resolve_root_var(goal.self_ty());
-        let trait_ref = goal.trait_ref();
-        let Some(visible_impls) = lookup_index.trait_impls_for_trait(trait_ref) else {
-            return Ok(Vec::new());
-        };
-        let trait_impls = match TraitSelfHead::from_ty(&self_ty) {
-            Some(self_head) => session.indexed_trait_impl_candidates(
-                item_paths,
-                trait_ref,
-                visible_impls,
-                self_head,
-            )?,
-            None => visible_impls.collect(),
-        };
-
         let mut candidates = Vec::new();
-        for trait_impl in trait_impls {
-            // The candidate index identifies plausible self-type heads. Load the canonical
-            // header, then confirm that its declaration still names the requested trait before
-            // matching the full application and collecting equality evidence.
-            let Some(header) =
-                session.impl_header_with(item_paths, item_paths, trait_impl.impl_ref)?
-            else {
-                continue;
-            };
-            let Some(impl_data) = item_paths.items().impl_data(trait_impl.impl_ref)? else {
-                continue;
-            };
-            if !impl_data.resolved_trait_ref.is(&goal.trait_ref()) {
-                continue;
-            }
-
-            let mut trial_table = table.clone();
-            let mut subst = InferenceSubstitution::new();
-            let Some(applicability) = CandidateMatcher.match_goal(
-                goal,
-                trait_impl,
-                &header,
-                &mut trial_table,
-                &mut subst,
-            ) else {
-                continue;
-            };
-            if applicability.is_applicable() {
-                candidates.push(Self {
-                    trait_impl,
-                    subst,
-                    applicability,
-                    table: trial_table,
-                });
+        for trait_impl in Self::plausible_impls(item_paths, lookup_index, session, goal, table)? {
+            if let Some(candidate) = Self::probe_impl(item_paths, session, goal, table, trait_impl)?
+            {
+                candidates.push(candidate);
             }
         }
         Ok(candidates)

--- a/crates/engine/ty/src/trait_selection/candidate.rs
+++ b/crates/engine/ty/src/trait_selection/candidate.rs
@@ -13,7 +13,7 @@ use rg_semantic_ir::{ItemLookupIndex, ItemStoreSource};
 use rg_std::UniqueVec;
 
 use super::matcher::{CandidateMatcher, TraitSelfHead};
-use super::{TraitGoal, TraitSelectionSession};
+use super::{TraitGoal, TraitSelectionSession, session::TraitWorkKind};
 use crate::inference::{InferenceSubstitution, InferenceTable};
 use crate::{ItemPathQuery, Ty};
 
@@ -43,7 +43,7 @@ impl TraitCandidate {
         session: &TraitSelectionSession,
         goal: &TraitGoal,
         table: &InferenceTable,
-    ) -> Result<UniqueVec<TraitImplRef>, I::Error>
+    ) -> Result<Option<UniqueVec<TraitImplRef>>, I::Error>
     where
         D: DefMapSource<Error = I::Error>,
         I: ItemStoreSource<'query>,
@@ -56,21 +56,27 @@ impl TraitCandidate {
         // semantics, probing a bare slot would clone the whole body table once for every concrete
         // impl before eventually calling the result ambiguous.
         if matches!(self_ty, Ty::InferVar { .. } | Ty::Unknown) {
-            return Ok(UniqueVec::new());
+            return Ok(Some(UniqueVec::new()));
         }
         let trait_ref = goal.trait_ref();
         let Some(visible_impls) = lookup_index.trait_impls_for_trait(trait_ref) else {
-            return Ok(UniqueVec::new());
+            return Ok(Some(UniqueVec::new()));
         };
-        Ok(match TraitSelfHead::from_ty(&self_ty) {
+        match TraitSelfHead::from_ty(&self_ty) {
             Some(self_head) => session.indexed_trait_impl_candidates(
                 item_paths,
                 trait_ref,
                 visible_impls,
                 self_head,
-            )?,
-            None => visible_impls.collect(),
-        })
+            ),
+            None => {
+                let visible_impls = visible_impls.collect::<Vec<_>>();
+                if !session.consume_work(TraitWorkKind::CandidateIndex, visible_impls.len()) {
+                    return Ok(None);
+                }
+                Ok(Some(visible_impls.into_iter().collect()))
+            }
+        }
     }
 
     /// Match one plausible impl against the goal using an isolated trial table.
@@ -127,7 +133,10 @@ impl TraitCandidate {
         I: ItemStoreSource<'query>,
     {
         let mut candidates = Vec::new();
-        for trait_impl in Self::plausible_impls(item_paths, lookup_index, session, goal, table)? {
+        let plausible_impls =
+            Self::plausible_impls(item_paths, lookup_index, session, goal, table)?
+                .expect("unbounded candidate fixture query should not exhaust work");
+        for trait_impl in plausible_impls {
             if let Some(candidate) = Self::probe_impl(item_paths, session, goal, table, trait_impl)?
             {
                 candidates.push(candidate);

--- a/crates/engine/ty/src/trait_selection/chalk/program/build.rs
+++ b/crates/engine/ty/src/trait_selection/chalk/program/build.rs
@@ -55,7 +55,7 @@ impl ChalkProgram {
         lookup_index: &ItemLookupIndex,
         session: &TraitSelectionSession,
         roots: &ChalkProgramRoots,
-    ) -> Result<(), I::Error>
+    ) -> Result<bool, I::Error>
     where
         D: DefMapSource<Error = I::Error>,
         I: ItemStoreSource<'query>,
@@ -63,14 +63,17 @@ impl ChalkProgram {
         let extension_started = Instant::now();
         self.known_items = super::ChalkKnownItems::from_index(lookup_index);
         let discovery_started = Instant::now();
-        let scope = ChalkProgramScope::discover(
+        let Some(scope) = ChalkProgramScope::discover(
             item_paths,
             crate_items,
             lookup_index,
             session,
             roots,
             self,
-        )?;
+        )?
+        else {
+            return Ok(false);
+        };
         let discovery_elapsed = discovery_started.elapsed();
 
         // Associated-type declarations must exist before lowering any trait/impl predicates that
@@ -243,7 +246,7 @@ impl ChalkProgram {
                 "slow Chalk program materialization phases finished"
             );
         }
-        Ok(())
+        Ok(true)
     }
 
     fn collect_trait_associated_tys<'query, D, I>(

--- a/crates/engine/ty/src/trait_selection/chalk/program/mod.rs
+++ b/crates/engine/ty/src/trait_selection/chalk/program/mod.rs
@@ -56,6 +56,13 @@ pub(super) struct ChalkProgramState {
     program: ChalkProgram,
 }
 
+/// Whether the goal-directed database is ready for one solver query.
+pub(super) enum ProgramAvailability {
+    Ready,
+    Unsupported,
+    Exhausted,
+}
+
 /// Semantic definitions that can become entry points into one Chalk program.
 ///
 /// A goal normally contributes one or two traits. Opaque types are roots too because their bounds
@@ -177,7 +184,7 @@ impl ChalkProgramState {
         session: &TraitSelectionSession,
         clauses: &[Clause],
         table: Option<&InferenceTable>,
-    ) -> Result<bool, I::Error>
+    ) -> Result<ProgramAvailability, I::Error>
     where
         D: DefMapSource<Error = I::Error>,
         I: ItemStoreSource<'query>,
@@ -198,7 +205,7 @@ impl ChalkProgramState {
         goal: &TraitGoal,
         associated_ty: TypeAliasRef,
         table: &InferenceTable,
-    ) -> Result<bool, I::Error>
+    ) -> Result<ProgramAvailability, I::Error>
     where
         D: DefMapSource<Error = I::Error>,
         I: ItemStoreSource<'query>,
@@ -216,7 +223,7 @@ impl ChalkProgramState {
         lookup_index: &ItemLookupIndex,
         session: &TraitSelectionSession,
         roots: &ChalkProgramRoots,
-    ) -> Result<bool, I::Error>
+    ) -> Result<ProgramAvailability, I::Error>
     where
         D: DefMapSource<Error = I::Error>,
         I: ItemStoreSource<'query>,
@@ -241,11 +248,13 @@ impl ChalkProgramState {
                     trait_root_ids = ?pending_roots.traits.as_slice(),
                     opaque_type_roots = pending_roots.opaque_tys.len(),
                     function_roots = pending_roots.functions.len(),
-                    succeeded = result.is_ok(),
+                    succeeded = matches!(&result, Ok(true)),
                     "slow Chalk program extension"
                 );
             }
-            result?;
+            if !result? {
+                return Ok(ProgramAvailability::Exhausted);
+            }
             self.roots.merge(&pending_roots);
         }
 
@@ -255,10 +264,17 @@ impl ChalkProgramState {
         // Function callbacks have a stronger invariant: every function type in this query must
         // have real datum. Unsupported signatures are omitted by the builder and stop the query
         // before Chalk can ask its mandatory callback for fabricated data.
-        Ok(roots
-            .functions
-            .iter()
-            .all(|function| self.program.functions.contains_key(function)))
+        Ok(
+            if roots
+                .functions
+                .iter()
+                .all(|function| self.program.functions.contains_key(function))
+            {
+                ProgramAvailability::Ready
+            } else {
+                ProgramAvailability::Unsupported
+            },
+        )
     }
 
     pub(super) fn database(&self) -> &ChalkProgram {

--- a/crates/engine/ty/src/trait_selection/chalk/program/roots.rs
+++ b/crates/engine/ty/src/trait_selection/chalk/program/roots.rs
@@ -13,7 +13,7 @@ use rg_semantic_ir::{CrateItemQuery, ItemLookupIndex, ItemStoreSource};
 
 use super::{ChalkProgram, ChalkProgramRoots, ChalkProgramScope};
 use crate::inference::InferenceTable;
-use crate::trait_selection::TraitSelectionSession;
+use crate::trait_selection::{TraitSelectionSession, session::TraitWorkKind};
 use crate::{Clause, ItemPathQuery, TraitRefLowering};
 
 impl ChalkProgramRoots {
@@ -226,7 +226,7 @@ impl ChalkProgramScope {
         session: &TraitSelectionSession,
         roots: &ChalkProgramRoots,
         program: &ChalkProgram,
-    ) -> Result<Self, I::Error>
+    ) -> Result<Option<Self>, I::Error>
     where
         D: DefMapSource<Error = I::Error>,
         I: ItemStoreSource<'query>,
@@ -253,6 +253,9 @@ impl ChalkProgramScope {
                 if program.materialized_traits.contains(&trait_ref) {
                     continue;
                 }
+                if !session.consume_work(TraitWorkKind::ProgramDefinition, 1) {
+                    return Ok(None);
+                }
 
                 if let Some(header) = session.trait_header_with(item_paths, trait_ref)? {
                     scope
@@ -270,17 +273,21 @@ impl ChalkProgramScope {
                 if trait_ref.origin.as_crate_ref().is_some() {
                     if let Some(impls) = lookup_index.trait_impls_for_trait(trait_ref) {
                         for trait_impl in impls {
-                            scope.discover_impl(
+                            if !scope.discover_impl(
                                 item_paths,
                                 crate_items,
                                 session,
                                 trait_impl.impl_ref,
-                            )?;
+                            )? {
+                                return Ok(None);
+                            }
                         }
                     }
                 } else {
                     for impl_ref in crate_items.impls_for_trait(trait_ref)? {
-                        scope.discover_impl(item_paths, crate_items, session, impl_ref)?;
+                        if !scope.discover_impl(item_paths, crate_items, session, impl_ref)? {
+                            return Ok(None);
+                        }
                     }
                 }
             }
@@ -293,6 +300,9 @@ impl ChalkProgramScope {
                 }
                 if !scope.loaded_opaque_owners.push(opaque.owner) {
                     continue;
+                }
+                if !session.consume_work(TraitWorkKind::ProgramDefinition, 1) {
+                    return Ok(None);
                 }
 
                 for (opaque, bounds) in session
@@ -317,6 +327,9 @@ impl ChalkProgramScope {
                 function_cursor += 1;
                 if program.functions.contains_key(&function) {
                     continue;
+                }
+                if !session.consume_work(TraitWorkKind::ProgramDefinition, 1) {
+                    return Ok(None);
                 }
                 let Some(signature) = session.function_signature_with(item_paths, function)? else {
                     continue;
@@ -346,7 +359,7 @@ impl ChalkProgramScope {
                 "slow Chalk program scope discovery"
             );
         }
-        Ok(scope)
+        Ok(Some(scope))
     }
 
     /// Add one impl and every semantic definition reachable from its header and values.
@@ -356,11 +369,15 @@ impl ChalkProgramScope {
         crate_items: &CrateItemQuery<'query, D, I>,
         session: &TraitSelectionSession,
         impl_ref: rg_ir_model::ImplRef,
-    ) -> Result<(), I::Error>
+    ) -> Result<bool, I::Error>
     where
         D: DefMapSource<Error = I::Error>,
         I: ItemStoreSource<'query>,
     {
+        if !session.consume_work(TraitWorkKind::ProgramDefinition, 1) {
+            return Ok(false);
+        }
+
         // Each semantic impl has one resolved trait, and the trait queue visits every identity
         // once. Keeping this invariant avoids a quadratic ordered-set check for large programs.
         #[cfg(debug_assertions)]
@@ -371,7 +388,7 @@ impl ChalkProgramScope {
         self.impls.push(impl_ref);
 
         let Some(header) = session.impl_header_with(item_paths, item_paths, impl_ref)? else {
-            return Ok(());
+            return Ok(true);
         };
         self.definitions
             .collect_ty(item_paths, &header.self_ty, None)?;
@@ -398,6 +415,6 @@ impl ChalkProgramScope {
             }
         }
         self.impl_headers.insert(impl_ref, header);
-        Ok(())
+        Ok(true)
     }
 }

--- a/crates/engine/ty/src/trait_selection/chalk/solver.rs
+++ b/crates/engine/ty/src/trait_selection/chalk/solver.rs
@@ -33,10 +33,12 @@ use super::super::matcher::TraitSelfHead;
 use super::evidence::{ProjectionAliasLowering, SolverAnswerVars, SolverVariableEnv};
 use super::interner::RgChalkInterner;
 use super::lower::{ChalkLowerer, GenericBinderEnv};
-use super::program::ChalkProgramState;
+use super::program::{ChalkProgramState, ProgramAvailability};
 use super::raise;
 use crate::inference::{InferVarKind, InferenceSubstitution, InferenceTable};
-use crate::trait_selection::{AssocProjectionResult, TraitSelectionSession};
+use crate::trait_selection::{
+    AssocProjectionResult, TraitSelectionSession, session::TraitWorkKind,
+};
 use crate::{Clause, GenericArg, GenericArgs, ItemPathQuery, TraitApplication};
 
 const INTER: RgChalkInterner = RgChalkInterner;
@@ -92,9 +94,13 @@ impl SolverBudget {
         }
     }
 
-    fn should_continue(&self) -> bool {
+    fn should_continue(&self, session: &TraitSelectionSession) -> bool {
         let remaining = self.remaining.get();
         if remaining == 0 {
+            self.exhausted.set(true);
+            return false;
+        }
+        if !session.consume_work(TraitWorkKind::SolverQuantum, 1) {
             self.exhausted.set(true);
             return false;
         }
@@ -283,7 +289,7 @@ impl ChalkTraitSolver {
             .lock()
             .expect("Chalk solver-state lock should not be poisoned");
         let program_started = Instant::now();
-        let supported = state.program.ensure_for_clauses(
+        let availability = state.program.ensure_for_clauses(
             item_paths,
             crate_items,
             lookup_index,
@@ -299,11 +305,18 @@ impl ChalkTraitSolver {
                 "slow Chalk proof program preparation"
             );
         }
-        if !supported {
-            inference_cache.remember_declined_proof(clauses, DeclinedProof::Unsupported);
-            return Ok(ChalkOutcome::Unsupported);
+        match availability {
+            ProgramAvailability::Ready => {}
+            ProgramAvailability::Unsupported => {
+                inference_cache.remember_declined_proof(clauses, DeclinedProof::Unsupported);
+                return Ok(ChalkOutcome::Unsupported);
+            }
+            ProgramAvailability::Exhausted => {
+                inference_cache.remember_declined_proof(clauses, DeclinedProof::Exhausted);
+                return Ok(ChalkOutcome::Exhausted);
+            }
         }
-        let outcome = state.prove_clauses(clauses, table, inference_cache);
+        let outcome = state.prove_clauses(clauses, table, inference_cache, session);
         if program_elapsed >= SLOW_SOLVER_GOAL {
             let solver_outcome = match &outcome {
                 ChalkOutcome::Proven(_) => "proven",
@@ -380,7 +393,7 @@ impl ChalkTraitSolver {
             .lock()
             .expect("Chalk solver-state lock should not be poisoned");
         let program_started = Instant::now();
-        let supported = state.program.ensure_for_goal(
+        let availability = state.program.ensure_for_goal(
             item_paths,
             crate_items,
             lookup_index,
@@ -399,8 +412,10 @@ impl ChalkTraitSolver {
                 "slow Chalk projection program preparation"
             );
         }
-        if !supported {
-            return Ok(ChalkOutcome::Unsupported);
+        match availability {
+            ProgramAvailability::Ready => {}
+            ProgramAvailability::Unsupported => return Ok(ChalkOutcome::Unsupported),
+            ProgramAvailability::Exhausted => return Ok(ChalkOutcome::Exhausted),
         }
         let selected_impl = if let Some((impl_ref, subst)) = selected_impl {
             let generics = item_paths
@@ -416,6 +431,7 @@ impl ChalkTraitSolver {
             selected_impl.as_ref(),
             table,
             inference_cache,
+            session,
         ))
     }
 
@@ -446,9 +462,18 @@ impl ChalkTraitSolver {
         else {
             return Ok(visible_impls.len());
         };
-        Ok(session
-            .indexed_trait_impl_candidates(item_paths, application.def, visible_impls, self_head)?
-            .len())
+        let Some(candidates) = session.indexed_trait_impl_candidates(
+            item_paths,
+            application.def,
+            visible_impls,
+            self_head,
+        )?
+        else {
+            // The caller classifies a count above its admission limit as exhausted. Preserve that
+            // distinction instead of making an unavailable index look like an empty impl set.
+            return Ok(usize::MAX);
+        };
+        Ok(candidates.len())
     }
 }
 
@@ -477,6 +502,7 @@ impl ChalkSolverState {
         clauses: &[Clause],
         table: &InferenceTable,
         inference_cache: &ChalkInferenceCache,
+        session: &TraitSelectionSession,
     ) -> ChalkOutcome<InferenceTable> {
         let binders = GenericBinderEnv::empty();
         let lowerer = ChalkLowerer::new(&binders)
@@ -539,7 +565,7 @@ impl ChalkSolverState {
             self.stable_forests.impl_bounds_solver.solve_limited(
                 self.program.database(),
                 &canonical_goal,
-                &|| budget.should_continue(),
+                &|| budget.should_continue(session),
             )
         } else {
             inference_cache
@@ -548,7 +574,7 @@ impl ChalkSolverState {
                 .expect("Chalk inference-cache lock should not be poisoned")
                 .impl_bounds_solver
                 .solve_limited(self.program.database(), &canonical_goal, &|| {
-                    budget.should_continue()
+                    budget.should_continue(session)
                 })
         };
         let elapsed = started.elapsed();
@@ -627,6 +653,7 @@ impl ChalkSolverState {
         selected_impl: Option<&(ImplRef, GenericArgs)>,
         table: &InferenceTable,
         inference_cache: &ChalkInferenceCache,
+        session: &TraitSelectionSession,
     ) -> ChalkOutcome<AssocProjectionResult> {
         if !self.program.associated_tys().contains_key(&assoc_type_ref) {
             return ChalkOutcome::NoSolution;
@@ -722,7 +749,7 @@ impl ChalkSolverState {
             self.stable_forests.assoc_projection_solver.solve_limited(
                 self.program.database(),
                 &canonical_goal,
-                &|| budget.should_continue(),
+                &|| budget.should_continue(session),
             )
         } else {
             inference_cache
@@ -731,7 +758,7 @@ impl ChalkSolverState {
                 .expect("Chalk inference-cache lock should not be poisoned")
                 .assoc_projection_solver
                 .solve_limited(self.program.database(), &canonical_goal, &|| {
-                    budget.should_continue()
+                    budget.should_continue(session)
                 })
         };
         let elapsed = started.elapsed();

--- a/crates/engine/ty/src/trait_selection/mod.rs
+++ b/crates/engine/ty/src/trait_selection/mod.rs
@@ -31,6 +31,7 @@ use self::native_proof::NativeProofQuery;
 pub use self::projection::AssocProjectionResult;
 use self::projection::CandidateEvidence;
 pub use self::session::TraitSelectionSession;
+use self::session::TraitWorkKind;
 use crate::inference::{InferenceSubstitution, InferenceTable};
 use crate::{
     AssocTypeBinding, Clause, GenericArg, GenericArgs, Substitution, TraitApplication,
@@ -400,18 +401,28 @@ where
             return Ok((selection, true));
         }
 
-        let plausible_impls = TraitCandidate::plausible_impls(
+        let Some(plausible_impls) = TraitCandidate::plausible_impls(
             self.context.item_paths(),
             self.context.lookup_index(),
             self.context.trait_selection(),
             goal,
             table,
-        )?;
+        )?
+        else {
+            return Ok((ExpectedUnique::new(), false));
+        };
 
         let mut definite_selections = ExpectedUnique::new();
         let mut maybe_selections = ExpectedUnique::new();
         let mut fully_evaluated = true;
         for trait_impl in plausible_impls {
+            if !self
+                .context
+                .trait_selection()
+                .consume_work(TraitWorkKind::CandidateProbe, 1)
+            {
+                return Ok((ExpectedUnique::new(), false));
+            }
             let Some(candidate) = TraitCandidate::probe_impl(
                 self.context.item_paths(),
                 self.context.trait_selection(),

--- a/crates/engine/ty/src/trait_selection/mod.rs
+++ b/crates/engine/ty/src/trait_selection/mod.rs
@@ -255,7 +255,7 @@ where
             let clause = match clause {
                 Clause::Implemented(mut application) => {
                     let mut args = Vec::with_capacity(application.args.len());
-                    for arg in &application.args {
+                    for arg in application.args.iter() {
                         let arg = match arg {
                             GenericArg::Type(ty) => {
                                 let (ty, next_table) = self.normalize_ty_with_candidate_evidence(
@@ -275,7 +275,7 @@ where
                 }
                 Clause::AliasEq { mut alias, ty } => {
                     let mut args = Vec::with_capacity(alias.args.len());
-                    for arg in &alias.args {
+                    for arg in alias.args.iter() {
                         let arg = match arg {
                             GenericArg::Type(ty) => {
                                 let (ty, next_table) = self.normalize_ty_with_candidate_evidence(
@@ -400,7 +400,7 @@ where
             return Ok((selection, true));
         }
 
-        let candidates = TraitCandidate::probe_all(
+        let plausible_impls = TraitCandidate::plausible_impls(
             self.context.item_paths(),
             self.context.lookup_index(),
             self.context.trait_selection(),
@@ -411,7 +411,17 @@ where
         let mut definite_selections = ExpectedUnique::new();
         let mut maybe_selections = ExpectedUnique::new();
         let mut fully_evaluated = true;
-        for candidate in candidates {
+        for trait_impl in plausible_impls {
+            let Some(candidate) = TraitCandidate::probe_impl(
+                self.context.item_paths(),
+                self.context.trait_selection(),
+                goal,
+                table,
+                trait_impl,
+            )?
+            else {
+                continue;
+            };
             if active_impls.contains(&candidate.trait_impl.impl_ref) {
                 // Returning an ordinary empty result here would incorrectly prove absence for a
                 // nominal receiver. Mark the probe incomplete so projection normalization enters

--- a/crates/engine/ty/src/trait_selection/native_proof.rs
+++ b/crates/engine/ty/src/trait_selection/native_proof.rs
@@ -182,13 +182,24 @@ where
             application: application.clone(),
             associated_types: Vec::new(),
         };
-        for candidate in TraitCandidate::probe_all(
+        let plausible_impls = TraitCandidate::plausible_impls(
             self.selection.context.item_paths(),
             self.selection.context.lookup_index(),
             self.selection.context.trait_selection(),
             &goal,
             table,
-        )? {
+        )?;
+        for trait_impl in plausible_impls {
+            let Some(candidate) = TraitCandidate::probe_impl(
+                self.selection.context.item_paths(),
+                self.selection.context.trait_selection(),
+                &goal,
+                table,
+                trait_impl,
+            )?
+            else {
+                continue;
+            };
             let Some(header) = self.selection.context.trait_selection().impl_header_with(
                 self.selection.context.item_paths(),
                 self.selection.context.item_paths(),
@@ -251,7 +262,7 @@ where
             application: application.clone(),
             associated_types: Vec::new(),
         };
-        let candidates = TraitCandidate::probe_all(
+        let plausible_impls = TraitCandidate::plausible_impls(
             self.selection.context.item_paths(),
             self.selection.context.lookup_index(),
             self.selection.context.trait_selection(),
@@ -259,10 +270,20 @@ where
             table,
         )?;
         let mut exact = ExpectedUnique::new();
-        let mut all = ExpectedUnique::new();
+        let mut fallbacks = ExpectedUnique::new();
         let mut has_unavailable = false;
 
-        for candidate in candidates {
+        for trait_impl in plausible_impls {
+            let Some(candidate) = TraitCandidate::probe_impl(
+                self.selection.context.item_paths(),
+                self.selection.context.trait_selection(),
+                &goal,
+                table,
+                trait_impl,
+            )?
+            else {
+                continue;
+            };
             let Some(header) = self.selection.context.trait_selection().impl_header_with(
                 self.selection.context.item_paths(),
                 self.selection.context.item_paths(),
@@ -312,9 +333,10 @@ where
                 continue;
             };
             let proof = (candidate.trait_impl.impl_ref, proven_table);
-            all.push(proof.clone());
             if TraitSelfHead::from_ty(&header.self_ty) == Some(goal_head) {
                 exact.push(proof);
+            } else {
+                fallbacks.push(proof);
             }
         }
 
@@ -325,7 +347,7 @@ where
             ExpectedUnique::One((_, table)) => table,
             ExpectedUnique::Ambiguous => return Ok(None),
             ExpectedUnique::Empty if has_unavailable => return Ok(None),
-            ExpectedUnique::Empty => match all {
+            ExpectedUnique::Empty => match fallbacks {
                 ExpectedUnique::One((_, table)) => table,
                 ExpectedUnique::Ambiguous => return Ok(None),
                 ExpectedUnique::Empty => return Ok(Some(TraitProof::NoSolution)),

--- a/crates/engine/ty/src/trait_selection/native_proof.rs
+++ b/crates/engine/ty/src/trait_selection/native_proof.rs
@@ -13,6 +13,7 @@ use rg_std::ExpectedUnique;
 
 use super::{
     TraitGoal, TraitProof, TraitSelectionQuery, candidate::TraitCandidate, matcher::TraitSelfHead,
+    session::TraitWorkKind,
 };
 use crate::inference::InferenceTable;
 use crate::{Clause, GenericArg, TraitApplication, Ty};
@@ -182,14 +183,25 @@ where
             application: application.clone(),
             associated_types: Vec::new(),
         };
-        let plausible_impls = TraitCandidate::plausible_impls(
+        let Some(plausible_impls) = TraitCandidate::plausible_impls(
             self.selection.context.item_paths(),
             self.selection.context.lookup_index(),
             self.selection.context.trait_selection(),
             &goal,
             table,
-        )?;
+        )?
+        else {
+            return Ok(None);
+        };
         for trait_impl in plausible_impls {
+            if !self
+                .selection
+                .context
+                .trait_selection()
+                .consume_work(TraitWorkKind::CandidateProbe, 1)
+            {
+                return Ok(None);
+            }
             let Some(candidate) = TraitCandidate::probe_impl(
                 self.selection.context.item_paths(),
                 self.selection.context.trait_selection(),
@@ -262,18 +274,29 @@ where
             application: application.clone(),
             associated_types: Vec::new(),
         };
-        let plausible_impls = TraitCandidate::plausible_impls(
+        let Some(plausible_impls) = TraitCandidate::plausible_impls(
             self.selection.context.item_paths(),
             self.selection.context.lookup_index(),
             self.selection.context.trait_selection(),
             &goal,
             table,
-        )?;
+        )?
+        else {
+            return Ok(None);
+        };
         let mut exact = ExpectedUnique::new();
         let mut fallbacks = ExpectedUnique::new();
         let mut has_unavailable = false;
 
         for trait_impl in plausible_impls {
+            if !self
+                .selection
+                .context
+                .trait_selection()
+                .consume_work(TraitWorkKind::CandidateProbe, 1)
+            {
+                return Ok(None);
+            }
             let Some(candidate) = TraitCandidate::probe_impl(
                 self.selection.context.item_paths(),
                 self.selection.context.trait_selection(),

--- a/crates/engine/ty/src/trait_selection/projection.rs
+++ b/crates/engine/ty/src/trait_selection/projection.rs
@@ -13,12 +13,17 @@ use rg_semantic_ir::ItemStoreSource;
 use rg_std::ExpectedUnique;
 
 use super::matcher::TraitSelfHead;
+use super::session::{TraitWorkKind, TraitWorkLimit};
 use super::{ChalkOutcome, TraitGoal, TraitSelection, TraitSelectionQuery};
 use crate::inference::InferenceTable;
 use crate::{
     AdtTy, AliasTy, ClosureTy, FnDefTy, GenericArg, GenericArgs, OpaqueTy, ProjectionTy,
     Substitution, TraitApplication, Ty,
 };
+
+// Projection results can keep producing a different, larger projection without repeating an
+// exact semantic cycle. Bound that expansion before it can consume the thread stack.
+pub(super) const NORMALIZATION_DEPTH_LIMIT: usize = 64;
 
 /// Result of normalizing one selected associated type projection.
 ///
@@ -110,6 +115,7 @@ where
             &mut table,
             &mut Vec::new(),
             CandidateEvidence::ROOT,
+            0,
         )?;
         projection.table = table;
         Ok(Some(projection))
@@ -339,7 +345,7 @@ where
     ) -> Result<(Ty, InferenceTable), I::Error> {
         let mut table = table.clone();
         let ty =
-            self.normalize_ty_with_table(ty, &mut table, &mut Vec::new(), candidate_evidence)?;
+            self.normalize_ty_with_table(ty, &mut table, &mut Vec::new(), candidate_evidence, 0)?;
         Ok((ty, table))
     }
 
@@ -349,13 +355,33 @@ where
         table: &mut InferenceTable,
         active: &mut Vec<ProjectionTy>,
         candidate_evidence: CandidateEvidence<'_>,
+        depth: usize,
     ) -> Result<Ty, I::Error> {
+        let session = self.context.trait_selection();
+        if depth >= NORMALIZATION_DEPTH_LIMIT {
+            session.report_limit(
+                TraitWorkLimit::NormalizationDepth,
+                Some(NORMALIZATION_DEPTH_LIMIT),
+            );
+            return Ok(ty.clone());
+        }
+        if !session.consume_work(TraitWorkKind::NormalizationStep, 1) {
+            return Ok(ty.clone());
+        }
+        let child_depth = depth + 1;
+
         Ok(match ty {
             Ty::Tuple(fields) => Ty::tuple(
                 fields
                     .iter()
                     .map(|field| {
-                        self.normalize_ty_with_table(field, table, active, candidate_evidence)
+                        self.normalize_ty_with_table(
+                            field,
+                            table,
+                            active,
+                            candidate_evidence,
+                            child_depth,
+                        )
                     })
                     .collect::<Result<_, _>>()?,
             ),
@@ -365,12 +391,17 @@ where
                     table,
                     active,
                     candidate_evidence,
+                    child_depth,
                 )?),
                 len: *len,
             },
-            Ty::Slice(inner) => {
-                Ty::slice(self.normalize_ty_with_table(inner, table, active, candidate_evidence)?)
-            }
+            Ty::Slice(inner) => Ty::slice(self.normalize_ty_with_table(
+                inner,
+                table,
+                active,
+                candidate_evidence,
+                child_depth,
+            )?),
             Ty::Reference {
                 lifetime,
                 mutability,
@@ -378,28 +409,58 @@ where
             } => Ty::reference_with_lifetime(
                 *lifetime,
                 *mutability,
-                self.normalize_ty_with_table(inner, table, active, candidate_evidence)?,
+                self.normalize_ty_with_table(
+                    inner,
+                    table,
+                    active,
+                    candidate_evidence,
+                    child_depth,
+                )?,
             ),
             Ty::RawPointer { mutability, inner } => Ty::raw_pointer(
                 *mutability,
-                self.normalize_ty_with_table(inner, table, active, candidate_evidence)?,
+                self.normalize_ty_with_table(
+                    inner,
+                    table,
+                    active,
+                    candidate_evidence,
+                    child_depth,
+                )?,
             ),
             Ty::FnPointer { params, ret } => Ty::fn_pointer(
                 params
                     .iter()
                     .map(|param| {
-                        self.normalize_ty_with_table(param, table, active, candidate_evidence)
+                        self.normalize_ty_with_table(
+                            param,
+                            table,
+                            active,
+                            candidate_evidence,
+                            child_depth,
+                        )
                     })
                     .collect::<Result<_, _>>()?,
-                self.normalize_ty_with_table(ret, table, active, candidate_evidence)?,
+                self.normalize_ty_with_table(ret, table, active, candidate_evidence, child_depth)?,
             ),
             Ty::Adt(ty) => Ty::Adt(AdtTy {
                 def: ty.def,
-                args: self.normalize_args(&ty.args, table, active, candidate_evidence)?,
+                args: self.normalize_args(
+                    &ty.args,
+                    table,
+                    active,
+                    candidate_evidence,
+                    child_depth,
+                )?,
             }),
             Ty::FnDef(function) => Ty::FnDef(FnDefTy {
                 def: function.def,
-                args: self.normalize_args(&function.args, table, active, candidate_evidence)?,
+                args: self.normalize_args(
+                    &function.args,
+                    table,
+                    active,
+                    candidate_evidence,
+                    child_depth,
+                )?,
             }),
             Ty::Closure(closure) => Ty::Closure(ClosureTy {
                 id: closure.id,
@@ -407,7 +468,13 @@ where
                     .params
                     .iter()
                     .map(|param| {
-                        self.normalize_ty_with_table(param, table, active, candidate_evidence)
+                        self.normalize_ty_with_table(
+                            param,
+                            table,
+                            active,
+                            candidate_evidence,
+                            child_depth,
+                        )
                     })
                     .collect::<Result<_, _>>()?,
                 ret: Box::new(self.normalize_ty_with_table(
@@ -415,16 +482,29 @@ where
                     table,
                     active,
                     candidate_evidence,
+                    child_depth,
                 )?),
             }),
             Ty::Alias(AliasTy::Opaque(opaque)) => Ty::Alias(AliasTy::Opaque(OpaqueTy {
                 opaque: opaque.opaque,
-                args: self.normalize_args(&opaque.args, table, active, candidate_evidence)?,
+                args: self.normalize_args(
+                    &opaque.args,
+                    table,
+                    active,
+                    candidate_evidence,
+                    child_depth,
+                )?,
             })),
             Ty::Alias(AliasTy::Projection(alias)) => {
                 let alias = ProjectionTy {
                     associated_ty: alias.associated_ty,
-                    args: self.normalize_args(&alias.args, table, active, candidate_evidence)?,
+                    args: self.normalize_args(
+                        &alias.args,
+                        table,
+                        active,
+                        candidate_evidence,
+                        child_depth,
+                    )?,
                 };
                 // Solver retries can reproduce one projection with freshly allocated inference
                 // slots. Their numeric IDs differ, but they still describe the same obligation.
@@ -443,7 +523,13 @@ where
                 let ty = if let Some(normalized) = normalized {
                     let (ty, _applicability, normalized_table) = normalized.into_parts();
                     *table = normalized_table;
-                    self.normalize_ty_with_table(&ty, table, active, candidate_evidence)?
+                    self.normalize_ty_with_table(
+                        &ty,
+                        table,
+                        active,
+                        candidate_evidence,
+                        child_depth,
+                    )?
                 } else {
                     Ty::Alias(AliasTy::Projection(alias))
                 };
@@ -477,12 +563,13 @@ where
         table: &mut InferenceTable,
         active: &mut Vec<ProjectionTy>,
         candidate_evidence: CandidateEvidence<'_>,
+        depth: usize,
     ) -> Result<GenericArgs, I::Error> {
         args.iter()
             .map(|arg| {
                 Ok(match arg {
                     GenericArg::Type(ty) => GenericArg::Type(Box::new(
-                        self.normalize_ty_with_table(ty, table, active, candidate_evidence)?,
+                        self.normalize_ty_with_table(ty, table, active, candidate_evidence, depth)?,
                     )),
                     GenericArg::Lifetime(_) | GenericArg::Const(_) => arg.clone(),
                 })

--- a/crates/engine/ty/src/trait_selection/session.rs
+++ b/crates/engine/ty/src/trait_selection/session.rs
@@ -17,13 +17,16 @@
 use std::{
     collections::HashMap,
     fmt,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
 };
 
 use rg_def_map::DefMapSource;
 use rg_ir_model::{
-    CrateRef, FunctionRef, GenericDefRef, ImplRef, TraitApplicability, TraitDefRef, TraitImplRef,
-    TypeAliasRef,
+    BodyRef, CrateRef, FunctionRef, GenericDefRef, ImplRef, TraitApplicability, TraitDefRef,
+    TraitImplRef, TypeAliasRef,
 };
 use rg_semantic_ir::{CrateItemQuery, ItemLookupIndex, ItemStoreSource};
 use rg_std::{ExpectedUnique, UniqueVec};
@@ -73,6 +76,105 @@ type TraitImplCandidateIndexes = Mutex<HashMap<TraitDefRef, SharedTraitImplCandi
 type ExactCandidateApplicabilities =
     Mutex<HashMap<TraitImplRef, HashMap<TraitGoal, TraitApplicability>>>;
 
+// One body can legitimately ask many cheap questions, while a pathological body must not turn
+// thousands of individually bounded operations into unbounded aggregate work. This allowance is
+// deliberately much larger than one settled Chalk goal and is shared by every clone of the
+// body-owned session.
+const BODY_TRAIT_WORK_LIMIT: usize = 65_536;
+
+/// Deterministic work charged to one body-owned trait-selection session.
+#[derive(Clone, Copy)]
+pub(super) enum TraitWorkKind {
+    CandidateIndex,
+    CandidateProbe,
+    ProgramDefinition,
+    NormalizationStep,
+    SolverQuantum,
+}
+
+impl TraitWorkKind {
+    fn label(self) -> &'static str {
+        match self {
+            Self::CandidateIndex => "body_work.candidate_index",
+            Self::CandidateProbe => "body_work.candidate_probe",
+            Self::ProgramDefinition => "body_work.program_definition",
+            Self::NormalizationStep => "body_work.normalization_step",
+            Self::SolverQuantum => "body_work.solver_quantum",
+        }
+    }
+}
+
+/// The boundary that made a best-effort trait query stop.
+#[derive(Clone, Copy)]
+pub(super) enum TraitWorkLimit {
+    Aggregate(TraitWorkKind),
+    NormalizationDepth,
+}
+
+impl TraitWorkLimit {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Aggregate(kind) => kind.label(),
+            Self::NormalizationDepth => "normalization_depth",
+        }
+    }
+}
+
+/// Work and reporting state shared by every clone of one inference scope.
+struct TraitWorkTracker {
+    body: Option<BodyRef>,
+    limit: Option<usize>,
+    remaining: AtomicUsize,
+    reported: AtomicBool,
+}
+
+impl TraitWorkTracker {
+    fn unbounded() -> Self {
+        Self {
+            body: None,
+            limit: None,
+            remaining: AtomicUsize::new(usize::MAX),
+            reported: AtomicBool::new(false),
+        }
+    }
+
+    fn for_body(body: BodyRef, limit: usize) -> Self {
+        Self {
+            body: Some(body),
+            limit: Some(limit),
+            remaining: AtomicUsize::new(limit),
+            reported: AtomicBool::new(false),
+        }
+    }
+
+    /// Reserve work before starting an operation so concurrent session clones cannot overspend.
+    fn consume(&self, amount: usize) -> bool {
+        if self.limit.is_none() || amount == 0 {
+            return true;
+        }
+
+        let mut remaining = self.remaining.load(Ordering::Relaxed);
+        loop {
+            if remaining < amount {
+                return false;
+            }
+            match self.remaining.compare_exchange_weak(
+                remaining,
+                remaining - amount,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(observed) => remaining = observed,
+            }
+        }
+    }
+
+    fn mark_reported(&self) -> bool {
+        !self.reported.swap(true, Ordering::Relaxed)
+    }
+}
+
 /// Crate-semantic solver state shared by one use-site session and its inference scopes.
 ///
 /// Everything here is safe to keep for the rest of the snapshot after one body finishes. The
@@ -121,6 +223,7 @@ impl TraitSelectionShared {
 pub struct TraitSelectionSession {
     shared: Arc<TraitSelectionShared>,
     inference_cache: Arc<ChalkInferenceCache>,
+    work: Arc<TraitWorkTracker>,
 }
 
 impl fmt::Debug for TraitSelectionSession {
@@ -152,6 +255,7 @@ impl TraitSelectionSession {
         Self {
             shared: Arc::new(TraitSelectionShared::new(use_site, declarations)),
             inference_cache: Arc::new(ChalkInferenceCache::new()),
+            work: Arc::new(TraitWorkTracker::unbounded()),
         }
     }
 
@@ -169,6 +273,7 @@ impl TraitSelectionSession {
         Self {
             shared: self.shared.clone(),
             inference_cache: Arc::new(ChalkInferenceCache::new()),
+            work: Arc::new(TraitWorkTracker::unbounded()),
         }
     }
 
@@ -177,12 +282,55 @@ impl TraitSelectionSession {
     /// Closure identities and live inference variables cannot produce reusable crate-wide Chalk
     /// answers. Clones of the returned session share those answers during this body's fixed point,
     /// and dropping the session releases them before the next body starts.
-    pub fn for_body(&self, body: rg_ir_model::BodyRef) -> Self {
+    pub fn for_body(&self, body: BodyRef) -> Self {
         assert_eq!(
             body.crate_ref, self.shared.use_site,
             "body trait-selection scope must use the session crate"
         );
-        self.fresh_inference_scope()
+        Self {
+            shared: self.shared.clone(),
+            inference_cache: Arc::new(ChalkInferenceCache::new()),
+            work: Arc::new(TraitWorkTracker::for_body(body, BODY_TRAIT_WORK_LIMIT)),
+        }
+    }
+
+    /// Charge deterministic work to this inference scope before starting an expensive step.
+    ///
+    /// Standalone editor queries remain governed by their operation-specific limits. Body-owned
+    /// sessions additionally share one aggregate allowance across fixed-point rounds and clones.
+    pub(super) fn consume_work(&self, kind: TraitWorkKind, amount: usize) -> bool {
+        if self.work.consume(amount) {
+            return true;
+        }
+        self.report_limit(TraitWorkLimit::Aggregate(kind), self.work.limit);
+        false
+    }
+
+    /// Report one fail-soft boundary per inference scope without flooding a pathological body.
+    pub(super) fn report_limit(&self, kind: TraitWorkLimit, limit: Option<usize>) {
+        if !self.work.mark_reported() {
+            return;
+        }
+        crate::profile::metric::WORK_LIMIT_EXHAUSTIONS.inc(kind.label());
+        tracing::warn!(
+            use_site = ?self.shared.use_site,
+            body = ?self.work.body,
+            limit_kind = kind.label(),
+            limit,
+            "trait selection stopped at a work limit; affected results remain unavailable"
+        );
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_work_limit(mut self, limit: usize) -> Self {
+        self.work = Arc::new(TraitWorkTracker::for_body(
+            BodyRef {
+                crate_ref: self.shared.use_site,
+                body: rg_ir_model::BodyId(0),
+            },
+            limit,
+        ));
+        self
     }
 
     /// Prove one conjunction using this session's crate program and inference-scope cache.
@@ -395,7 +543,7 @@ impl TraitSelectionSession {
         trait_ref: TraitDefRef,
         visible_impls: impl IntoIterator<Item = TraitImplRef>,
         self_head: TraitSelfHead,
-    ) -> Result<UniqueVec<TraitImplRef>, I::Error>
+    ) -> Result<Option<UniqueVec<TraitImplRef>>, I::Error>
     where
         D: DefMapSource<Error = I::Error>,
         I: ItemStoreSource<'query>,
@@ -412,12 +560,16 @@ impl TraitSelectionSession {
             .lock()
             .expect("trait impl candidate-index lock should not be poisoned");
         if let Some(index) = index.as_ref() {
-            return Ok(index.candidates(self_head));
+            return Ok(Some(index.candidates(self_head)));
         }
 
         // Lower every visible header for this trait once, then answer all later receiver queries
         // from its semantic `Self` fingerprint. The per-trait lock makes initialization
         // single-flight without serializing indexes for unrelated traits.
+        let visible_impls = visible_impls.into_iter().collect::<Vec<_>>();
+        if !self.consume_work(TraitWorkKind::CandidateIndex, visible_impls.len()) {
+            return Ok(None);
+        }
         let mut built = TraitImplCandidateIndex::default();
         for trait_impl in visible_impls {
             let Some(header) =
@@ -430,7 +582,7 @@ impl TraitSelectionSession {
 
         let candidates = built.candidates(self_head);
         *index = Some(built);
-        Ok(candidates)
+        Ok(Some(candidates))
     }
 
     /// Reattach the caller's table to a cached selection for a stable whole goal.

--- a/crates/engine/ty/src/trait_selection/tests/mod.rs
+++ b/crates/engine/ty/src/trait_selection/tests/mod.rs
@@ -618,13 +618,16 @@ fn blanket_impl_proves_nested_adapter_with_dependent_associated_bound() {
 }
 
 #[test]
-fn probe_rejects_bare_inference_var_blanket_self_match() {
+fn probe_rejects_bare_inference_receiver_for_all_impl_shapes() {
     check_trait_selection_queries(
         r#"
             traits
               trait#0 Marker
+            structs
+              struct#0 User
             impls
               impl#0 impl<T> Marker for T [resolved self: empty]
+              impl#1 impl Marker for User
         "#,
         vec![TraitSelectionCase::probe(
             "reject bare inference receiver",

--- a/crates/engine/ty/src/trait_selection/tests/mod.rs
+++ b/crates/engine/ty/src/trait_selection/tests/mod.rs
@@ -1,11 +1,17 @@
 mod utils;
 
+use std::fmt::Write as _;
+
 use expect_test::expect;
 use rg_ir_model::{TypeAliasId, TypeAliasRef};
+use rg_semantic_ir::CrateItemQuery;
 
 use self::utils::*;
+use super::TraitSelectionSession;
+use super::chalk::{ChalkInferenceCache, ChalkOutcome, ChalkTraitSolver};
+use super::projection::NORMALIZATION_DEPTH_LIMIT;
 use crate::inference::InferenceTable;
-use crate::{GenericArg, ProjectionTy};
+use crate::{AliasTy, Clause, GenericArg, ItemPathQuery, ProjectionTy, Ty};
 
 #[test]
 fn projection_cycle_identity_ignores_fresh_inference_slots() {
@@ -35,6 +41,145 @@ fn projection_cycle_identity_ignores_fresh_inference_slots() {
     assert_ne!(first, repeated);
     assert!(first.equivalent_modulo_inference_ids(&repeated));
     assert!(!first.equivalent_modulo_inference_ids(&unrelated));
+}
+
+#[test]
+fn body_work_exhaustion_keeps_candidate_search_incomplete() {
+    let profile = rg_profile::test_support::ProfileTest::start(
+        crate::profile_descriptors(),
+        "ty.trait_selection.chalk",
+    );
+    let fixture = TraitSelectionFixture::new(
+        r#"
+            traits
+              trait#0 Marker
+            structs
+              struct#0 User
+            impls
+              impl#0 impl Marker for User
+        "#,
+    );
+    let parsed = TraitSelectionQueryParser::new(&fixture).parse_goal("User: Marker");
+    let query = query_with_session(
+        &fixture,
+        TraitSelectionSession::new(fixture.target).with_work_limit(0),
+    );
+
+    let (selection, complete) = query
+        .probe_with_completeness(&parsed.goal, &parsed.table)
+        .expect("bounded candidate query should not fail");
+
+    assert!(selection.is_empty());
+    assert!(
+        !complete,
+        "work exhaustion must not prove candidate absence"
+    );
+    profile.finish().assert_keyed_counter(
+        crate::profile::metric::WORK_LIMIT_EXHAUSTIONS,
+        "body_work.candidate_index",
+        1,
+    );
+}
+
+#[test]
+fn program_work_exhaustion_does_not_publish_a_partial_extension() {
+    let fixture = TraitSelectionFixture::new(
+        r#"
+            traits
+              trait#0 Marker
+            structs
+              struct#0 User
+            impls
+              impl#0 impl Marker for User
+        "#,
+    );
+    let parsed = TraitSelectionQueryParser::new(&fixture).parse_goal("User: Marker");
+    let clauses = [Clause::Implemented(parsed.goal.application)];
+    let item_paths = ItemPathQuery::new(&fixture, &fixture);
+    let crate_items = CrateItemQuery::new(&fixture, &fixture, fixture.target);
+    let solver = ChalkTraitSolver::new();
+
+    let limited = TraitSelectionSession::new(fixture.target).with_work_limit(1);
+    let outcome = solver
+        .prove_clauses(
+            &item_paths,
+            &crate_items,
+            fixture.lookup_index(),
+            &limited,
+            &ChalkInferenceCache::new(),
+            &clauses,
+            &parsed.table,
+        )
+        .expect("bounded Chalk query should not fail");
+    assert!(matches!(outcome, ChalkOutcome::Exhausted));
+
+    // Discovery builds a temporary scope. A later unbounded query must be able to materialize the
+    // same roots from scratch rather than observe a half-published solver database.
+    let outcome = solver
+        .prove_clauses(
+            &item_paths,
+            &crate_items,
+            fixture.lookup_index(),
+            &TraitSelectionSession::new(fixture.target),
+            &ChalkInferenceCache::new(),
+            &clauses,
+            &parsed.table,
+        )
+        .expect("retry after bounded Chalk discovery should not fail");
+    assert!(matches!(outcome, ChalkOutcome::Proven(_)));
+}
+
+#[test]
+fn recursive_projection_normalization_stops_at_its_depth_limit() {
+    let chain_len = NORMALIZATION_DEPTH_LIMIT + 6;
+    let mut source = String::from("traits\n  trait#0 Next\nstructs\n");
+    for index in 0..chain_len {
+        writeln!(source, "  struct#{index} S{index}").expect("string writes should not fail");
+    }
+    writeln!(source, "  struct#{chain_len} User\nimpls").expect("string writes should not fail");
+    for index in 0..chain_len {
+        writeln!(source, "  impl#{index} impl Next for S{index}")
+            .expect("string writes should not fail");
+    }
+    writeln!(source, "type aliases\n  type#0 trait#0::Item")
+        .expect("string writes should not fail");
+    for index in 0..chain_len {
+        if index + 1 == chain_len {
+            writeln!(source, "  type#{} impl#{index}::Item = User", index + 1)
+                .expect("string writes should not fail");
+        } else {
+            writeln!(
+                source,
+                "  type#{} impl#{index}::Item = <S{} as Next>::Item",
+                index + 1,
+                index + 1,
+            )
+            .expect("string writes should not fail");
+        }
+    }
+
+    let fixture = TraitSelectionFixture::new(&source);
+    let profile = rg_profile::test_support::ProfileTest::start(
+        crate::profile_descriptors(),
+        "ty.trait_selection.chalk",
+    );
+    let projection = query(&fixture)
+        .normalize_assoc_type(
+            &TraitSelectionQueryParser::new(&fixture)
+                .parse_assoc_goal("<S0 as Next>::Item")
+                .goal,
+            "Item",
+            &InferenceTable::new(),
+        )
+        .expect("bounded projection query should not fail")
+        .expect("the first projection should have an exact native impl");
+
+    assert!(matches!(projection.ty, Ty::Alias(AliasTy::Projection(_))));
+    profile.finish().assert_keyed_counter(
+        crate::profile::metric::WORK_LIMIT_EXHAUSTIONS,
+        "normalization_depth",
+        1,
+    );
 }
 
 #[test]

--- a/crates/engine/ty/src/trait_selection/tests/utils.rs
+++ b/crates/engine/ty/src/trait_selection/tests/utils.rs
@@ -56,6 +56,10 @@ impl TraitSelectionFixture {
         TraitSelectionFixtureParser::new(source).parse()
     }
 
+    pub(super) fn lookup_index(&self) -> &ItemLookupIndex {
+        &self.lookup_index
+    }
+
     fn type_ref_by_name(&self, name: &str) -> Option<TypeDefRef> {
         self.type_refs_by_name.get(name).copied()
     }
@@ -64,7 +68,11 @@ impl TraitSelectionFixture {
         self.trait_refs_by_name.get(name).copied()
     }
 
-    fn associated_ty_by_name(&self, trait_ref: TraitDefRef, name: &str) -> Option<TypeAliasRef> {
+    pub(super) fn associated_ty_by_name(
+        &self,
+        trait_ref: TraitDefRef,
+        name: &str,
+    ) -> Option<TypeAliasRef> {
         let trait_data = self.store.trait_data(trait_ref.id)?;
         trait_data.items.iter().find_map(|item| {
             let AssocItemId::TypeAlias(id) = item else {
@@ -514,11 +522,18 @@ fn type_ref_path_name(ty: &TypeRef) -> Option<String> {
 pub(super) fn query(
     fixture: &TraitSelectionFixture,
 ) -> TraitSelectionQuery<'_, &TraitSelectionFixture, &TraitSelectionFixture> {
+    query_with_session(fixture, TraitSelectionSession::new(fixture.target))
+}
+
+pub(super) fn query_with_session(
+    fixture: &TraitSelectionFixture,
+    session: TraitSelectionSession,
+) -> TraitSelectionQuery<'_, &TraitSelectionFixture, &TraitSelectionFixture> {
     TraitSelectionQuery::new(TyContext::new(
         fixture,
         fixture,
         &fixture.lookup_index,
-        TraitSelectionSession::new(fixture.target),
+        session,
     ))
 }
 
@@ -1137,17 +1152,17 @@ struct TraitSelectionSnapshot {
     cases: Vec<TraitSelectionCase>,
 }
 
-struct ParsedTraitQuery {
-    goal: TraitGoal,
-    table: InferenceTable,
+pub(super) struct ParsedTraitQuery {
+    pub(super) goal: TraitGoal,
+    pub(super) table: InferenceTable,
     vars: Vec<NamedInferVar>,
     var_names: HashMap<String, String>,
 }
 
-struct ParsedAssocQuery {
-    goal: TraitGoal,
-    assoc_name: String,
-    table: InferenceTable,
+pub(super) struct ParsedAssocQuery {
+    pub(super) goal: TraitGoal,
+    pub(super) assoc_name: String,
+    pub(super) table: InferenceTable,
     vars: Vec<NamedInferVar>,
     var_names: HashMap<String, String>,
 }
@@ -1157,7 +1172,7 @@ struct NamedInferVar {
     ty: Ty,
 }
 
-struct TraitSelectionQueryParser<'a> {
+pub(super) struct TraitSelectionQueryParser<'a> {
     fixture: &'a TraitSelectionFixture,
     table: InferenceTable,
     vars: Vec<NamedInferVar>,
@@ -1165,7 +1180,7 @@ struct TraitSelectionQueryParser<'a> {
 }
 
 impl<'a> TraitSelectionQueryParser<'a> {
-    fn new(fixture: &'a TraitSelectionFixture) -> Self {
+    pub(super) fn new(fixture: &'a TraitSelectionFixture) -> Self {
         Self {
             fixture,
             table: InferenceTable::new(),
@@ -1174,7 +1189,7 @@ impl<'a> TraitSelectionQueryParser<'a> {
         }
     }
 
-    fn parse_goal(mut self, text: &str) -> ParsedTraitQuery {
+    pub(super) fn parse_goal(mut self, text: &str) -> ParsedTraitQuery {
         let (self_ty, trait_path) = split_top_level_keyword(text, ": ")
             .expect("trait query should be written as `Self: Trait<Args>`");
         let (trait_ref, args, associated_types) = self.parse_trait_path(trait_path);
@@ -1189,7 +1204,7 @@ impl<'a> TraitSelectionQueryParser<'a> {
         }
     }
 
-    fn parse_assoc_goal(mut self, text: &str) -> ParsedAssocQuery {
+    pub(super) fn parse_assoc_goal(mut self, text: &str) -> ParsedAssocQuery {
         let text = text.trim();
         assert!(
             text.starts_with('<'),


### PR DESCRIPTION
Before the first release I've decided to check Rust Glancer on a wider set of packages, and it was a good idea -- turns out, on some of them body resolution was either crashing with stack overflow, or it was getting stuck in a loop eating ram slowly.

I've done a few fixes here and there that helped somewhat, but the main bit is that I've introduced limits on how much work is allowed (it's not a proper fix likely, but it at least makes the server usable on a wider variety of projects).

There is also one issue discovered: tokio has a lot of integartion tests, so one of the packages has 174 targets, and it causes an extremely bloated cache with N copies of semantic index that is mostly equivalent. For now I've just removed the limit, but in the future I'll need to optimize this case -- I thought that current approach to targets is suboptimal for a long time now, but never got to actually test and optimize it. Well, at least now I have a good candidate.

It's all somewhat rushed, but last minute fixes never went wrong, right? I guess we'll find out soon.
