### PR TITLE
feat: support running on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Normalize all text files to LF so test fixtures and expectations behave identically on
+# every platform, regardless of the local `core.autocrlf` setting.
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,22 @@ jobs:
       - name: Run tests
         run: cargo nextest run --workspace
 
+  tests-windows:
+    name: tests-windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/cargo-cache
+        with:
+          scope: ci-${{ github.job }}
+          target-dir: target
+          dependency-key: ${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml', 'rust-toolchain.toml') }}
+      - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
+        with:
+          tool: cargo-nextest@0.9.132
+      - name: Run tests
+        run: cargo nextest run --workspace
+
   test-targets:
     name: test-targets
     runs-on: ubuntu-latest
@@ -141,6 +157,7 @@ jobs:
     needs:
       - lints
       - tests
+      - tests-windows
       - test-targets
       - client
       - vsix-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,9 @@ jobs:
           - runner: macos-15
             rust_target: aarch64-apple-darwin
             vscode_target: darwin-arm64
+          - runner: windows-latest
+            rust_target: x86_64-pc-windows-msvc
+            vscode_target: win32-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -136,6 +139,7 @@ jobs:
             "../../dist/rust-glancer-${RELEASE_VERSION}-linux-arm64.vsix"
             "../../dist/rust-glancer-${RELEASE_VERSION}-darwin-x64.vsix"
             "../../dist/rust-glancer-${RELEASE_VERSION}-darwin-arm64.vsix"
+            "../../dist/rust-glancer-${RELEASE_VERSION}-win32-x64.vsix"
           )
 
           for package in "${packages[@]}"; do

--- a/crates/engine/analysis/src/tests/utils.rs
+++ b/crates/engine/analysis/src/tests/utils.rs
@@ -1324,7 +1324,8 @@ impl<'a> AnalysisQuerySnapshot<'a> {
         let path = package
             .file_path(file_id)
             .expect("reference file should exist while rendering file path");
-        let path = path.to_string_lossy();
+        // Normalize host separators first so `/src/` matching works on Windows too.
+        let path = path.to_string_lossy().replace('\\', "/");
 
         let relative_path = path
             .rfind("/src/")
@@ -1540,7 +1541,8 @@ impl<'a> AnalysisSymbolSnapshot<'a> {
         let path = package
             .file_path(file_id)
             .expect("symbol file should exist while rendering file path");
-        let path = path.to_string_lossy();
+        // Normalize host separators first so `/src/` matching works on Windows too.
+        let path = path.to_string_lossy().replace('\\', "/");
 
         path.rfind("/src/")
             .map(|idx| path[idx + 1..].to_string())

--- a/crates/engine/parse/src/tests/utils.rs
+++ b/crates/engine/parse/src/tests/utils.rs
@@ -16,9 +16,7 @@ pub(super) fn check_parse_db_after_module_discovery(fixture: &str, expect: Expec
 
 fn check_parse_db_with(fixture: &str, mode: ParseFixtureMode, expect: Expect) {
     let fixture = fixture_crate(fixture);
-    let root = fixture
-        .path("")
-        .canonicalize()
+    let root = rg_std::path::canonicalize(fixture.path(""))
         .expect("fixture root should be canonicalizable");
     let display_root = fixture.path("");
     let workspace =
@@ -138,17 +136,22 @@ impl<'a> ProjectParseSnapshot<'a> {
 
     fn path_label(&self, path: &Path) -> String {
         if let Ok(relative) = path.strip_prefix(self.root) {
-            return relative.display().to_string();
+            return render_relative(relative);
         }
         if let Ok(relative) = path.strip_prefix(self.display_root) {
-            return relative.display().to_string();
+            return render_relative(relative);
         }
-        if let Ok(canonical_path) = path.canonicalize()
+        if let Ok(canonical_path) = rg_std::path::canonicalize(path)
             && let Ok(relative) = canonical_path.strip_prefix(self.root)
         {
-            return relative.display().to_string();
+            return render_relative(relative);
         }
 
-        path.display().to_string()
+        // Render with forward slashes so expectations stay portable across host platforms.
+        path.to_string_lossy().replace('\\', "/")
     }
+}
+
+fn render_relative(relative: &Path) -> String {
+    relative.to_string_lossy().replace('\\', "/")
 }

--- a/crates/engine/project/src/cache/cached.rs
+++ b/crates/engine/project/src/cache/cached.rs
@@ -49,7 +49,9 @@ pub struct CachedPath(#[memsize(inline)] pub(crate) String);
 
 impl CachedPath {
     pub(super) fn from_workspace_path(path: &Path) -> Self {
-        Self(path.display().to_string())
+        // Store paths with forward slashes so cached artifacts stay byte-identical across
+        // host platforms; every platform's path APIs accept this spelling.
+        Self(path.to_string_lossy().replace('\\', "/"))
     }
 
     pub fn as_path(&self) -> &Path {

--- a/crates/engine/project/src/cache/fingerprint.rs
+++ b/crates/engine/project/src/cache/fingerprint.rs
@@ -214,8 +214,8 @@ impl FingerprintBuilder {
     }
 
     fn path(&mut self, field: &str, workspace_root: &Path, path: &Path) {
-        let path = path.strip_prefix(workspace_root).unwrap_or(path);
-        self.str(field, &path.display().to_string());
+        let relative = path.strip_prefix(workspace_root).unwrap_or(path);
+        self.str(field, &Self::portable_path(relative));
     }
 
     fn package_id(&mut self, field: &str, workspace_root: &Path, package_id: &CachedPackageId) {
@@ -226,7 +226,9 @@ impl FingerprintBuilder {
     }
 
     fn normalize_package_id(workspace_root: &Path, package_id: &CachedPackageId) -> String {
-        let root_path = workspace_root.display().to_string();
+        // Cargo renders package IDs as URLs with forward slashes on every platform, while our
+        // normalized workspace roots follow host separators; compare both spellings portably.
+        let root_path = Self::portable_path(workspace_root);
         let mut root_paths = vec![root_path];
 
         // Cargo package IDs can preserve the non-canonical `/var` spelling on macOS while our
@@ -241,12 +243,20 @@ impl FingerprintBuilder {
         let mut package_id = package_id.to_string();
         for root_path in &root_paths {
             package_id = package_id.replace(&format!("file://{root_path}"), "file://./");
+            // URL-form ids keep an extra slash before drive letters (`file:///D:/...`).
+            package_id = package_id.replace(&format!("file:///{root_path}"), "file://./");
         }
         for root_path in root_paths {
             package_id = package_id.replace(&root_path, ".");
         }
 
         package_id.replace("file://.//", "file://./")
+    }
+
+    /// Renders a path with forward slashes so cache identities do not depend on the host
+    /// path separator.
+    fn portable_path(path: &Path) -> String {
+        path.to_string_lossy().replace('\\', "/")
     }
 
     fn str(&mut self, field: &str, value: &str) {

--- a/crates/engine/project/src/cache/tests/utils.rs
+++ b/crates/engine/project/src/cache/tests/utils.rs
@@ -1755,7 +1755,9 @@ fn render_dependency_kinds(dependency: &CachedDependency) -> String {
 }
 
 fn normalize_package_id(root: &Path, package_id: &str) -> String {
-    let root_path = root.display().to_string();
+    // Mirrors the production normalization: package IDs are URL-form with forward slashes,
+    // while workspace roots follow host separators.
+    let root_path = root.to_string_lossy().replace('\\', "/");
     let mut root_paths = vec![root_path];
 
     // Cargo package IDs may preserve the non-canonical `/var` spelling on macOS while normalized
@@ -1770,6 +1772,8 @@ fn normalize_package_id(root: &Path, package_id: &str) -> String {
     let mut package_id = package_id.to_string();
     for root_path in &root_paths {
         package_id = package_id.replace(&format!("file://{root_path}"), "file://./");
+        // URL-form ids keep an extra slash before drive letters (`file:///D:/...`).
+        package_id = package_id.replace(&format!("file:///{root_path}"), "file://./");
     }
     for root_path in root_paths {
         package_id = package_id.replace(&root_path, ".");

--- a/crates/engine/project/src/project/mod.rs
+++ b/crates/engine/project/src/project/mod.rs
@@ -210,7 +210,7 @@ impl Project {
         for change in changes {
             let change = match change {
                 SavedFileChange::FsPath(path) => {
-                    let canonical_path = match path.canonicalize() {
+                    let canonical_path = match rg_std::path::canonicalize(&path) {
                         Ok(path) => path,
                         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                             // We intentionally do not care about deleted module files. Valid Rust

--- a/crates/engine/project/src/project/snapshot.rs
+++ b/crates/engine/project/src/project/snapshot.rs
@@ -489,8 +489,7 @@ impl<'a> ProjectSnapshot<'a> {
         path: impl AsRef<Path>,
     ) -> anyhow::Result<Vec<FileContext>> {
         let path = path.as_ref();
-        let canonical_path = path
-            .canonicalize()
+        let canonical_path = rg_std::path::canonicalize(path)
             .with_context(|| format!("while attempting to canonicalize {}", path.display()))?;
         self.file_contexts_for_source_path(&canonical_path)
     }

--- a/crates/engine/project/src/project/split_indexing.rs
+++ b/crates/engine/project/src/project/split_indexing.rs
@@ -200,8 +200,7 @@ pub(super) fn package_slots_for_path(
     state: &ProjectState,
     path: &std::path::Path,
 ) -> anyhow::Result<Vec<PackageSlot>> {
-    let canonical_path = path
-        .canonicalize()
+    let canonical_path = rg_std::path::canonicalize(path)
         .with_context(|| format!("while attempting to canonicalize {}", path.display()))?;
     let mut packages = state
         .parse

--- a/crates/engine/project/src/testonly.rs
+++ b/crates/engine/project/src/testonly.rs
@@ -162,9 +162,8 @@ impl ProjectFixture {
     }
 
     pub fn file_id_for_path_in(parse: &ParseDb, path: &Path) -> FileId {
-        let canonical_path = path
-            .canonicalize()
-            .expect("fixture source path should canonicalize");
+        let canonical_path =
+            rg_std::path::canonicalize(path).expect("fixture source path should canonicalize");
 
         parse
             .packages()

--- a/crates/engine/project/src/tests/mod.rs
+++ b/crates/engine/project/src/tests/mod.rs
@@ -226,9 +226,8 @@ pub struct Before;
 
     assert_ne!(project.generation_id(), previous_generation);
     assert_eq!(summary.affected_packages, [rg_def_map::PackageSlot(0)]);
-    let canonical = path
-        .canonicalize()
-        .expect("published fixture source should canonicalize");
+    let canonical =
+        rg_std::path::canonicalize(path).expect("published fixture source should canonicalize");
     let entry = project
         .state
         .parse_db()
@@ -272,9 +271,7 @@ pub struct Published;
         .apply_change(SavedFileChange::captured(captured))
         .expect_err("a newer disk value must reject the captured candidate");
 
-    let canonical = path
-        .canonicalize()
-        .expect("fixture source should canonicalize");
+    let canonical = rg_std::path::canonicalize(&path).expect("fixture source should canonicalize");
     assert_eq!(
         Project::stale_source_path(&error),
         Some(canonical.as_path()),
@@ -413,8 +410,7 @@ pub struct Before;
     let mut project = fixture.build_project();
     let root = fixture.path("src/lib.rs");
     let old = fixture.path("src/old.rs");
-    let old_canonical = old
-        .canonicalize()
+    let old_canonical = rg_std::path::canonicalize(&old)
         .expect("old module path should canonicalize before rename");
     let new = fixture.path("src/new.rs");
 
@@ -775,8 +771,7 @@ pub struct User;
         .to_path_buf();
     assert_eq!(
         changed_path,
-        user.canonicalize()
-            .expect("user fixture should canonicalize"),
+        rg_std::path::canonicalize(user).expect("user fixture should canonicalize"),
         "a disappeared path should not prevent later batch members from rebuilding"
     );
 }
@@ -909,9 +904,7 @@ pub fn value() -> usize {
     assert_eq!(stats.missing_crate_count, 1);
     assert_eq!(stats.body_count, 0);
 
-    let source_path = fixture
-        .path("src/lib.rs")
-        .canonicalize()
+    let source_path = rg_std::path::canonicalize(fixture.path("src/lib.rs"))
         .expect("fixture source path should canonicalize");
     let source_entry = project
         .state
@@ -1033,9 +1026,7 @@ pub fn second() -> usize {
         .expect("lib file contexts should resolve")
         .pop()
         .expect("lib file should have one context");
-    let lib_path = fixture
-        .path("src/lib.rs")
-        .canonicalize()
+    let lib_path = rg_std::path::canonicalize(fixture.path("src/lib.rs"))
         .expect("lib source path should canonicalize");
     let lib_source = project
         .state
@@ -1068,9 +1059,7 @@ pub fn second() -> usize {
         .expect("other file contexts should resolve")
         .pop()
         .expect("other file should have one context");
-    let other_path = fixture
-        .path("src/other.rs")
-        .canonicalize()
+    let other_path = rg_std::path::canonicalize(fixture.path("src/other.rs"))
         .expect("other source path should canonicalize");
     let other_source = project
         .state

--- a/crates/engine/project/src/tests/utils.rs
+++ b/crates/engine/project/src/tests/utils.rs
@@ -433,15 +433,15 @@ impl HostFixture {
 
     fn display_path(&self, path: &Path) -> String {
         let display_root = self.fixture.path("");
-        let root = display_root
-            .canonicalize()
-            .expect("fixture root should canonicalize");
+        let root =
+            rg_std::path::canonicalize(&display_root).expect("fixture root should canonicalize");
 
+        // Render with forward slashes so expectations stay portable across host platforms.
         path.strip_prefix(&root)
             .or_else(|_| path.strip_prefix(&display_root))
             .unwrap_or(path)
-            .display()
-            .to_string()
+            .to_string_lossy()
+            .replace('\\', "/")
     }
 }
 

--- a/crates/engine/source/src/captured.rs
+++ b/crates/engine/source/src/captured.rs
@@ -18,10 +18,11 @@ pub struct CapturedSource {
 impl CapturedSource {
     pub fn new(path: impl AsRef<Path>, text: impl Into<Arc<str>>) -> Result<Self, SourceError> {
         let path = path.as_ref();
-        let canonical_path = path.canonicalize().map_err(|source| SourceError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?;
+        let canonical_path =
+            rg_std::path::canonicalize(path).map_err(|source| SourceError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
         let text = text.into();
         let descriptor = SourceDescriptor::new(SourcePath::new(canonical_path), text.as_bytes());
         Ok(Self { descriptor, text })

--- a/crates/engine/source/src/inventory.rs
+++ b/crates/engine/source/src/inventory.rs
@@ -108,10 +108,11 @@ impl SourceInventory {
         if let Some(entry) = self.known_entry(path) {
             return Ok(entry);
         }
-        let canonical_path = path.canonicalize().map_err(|source| SourceError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?;
+        let canonical_path =
+            rg_std::path::canonicalize(path).map_err(|source| SourceError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
 
         // Known entries are valid in sealed generations. Only the first capture represents file
         // discovery and therefore needs the inventory to be open.

--- a/crates/engine/source/src/tests/mod.rs
+++ b/crates/engine/source/src/tests/mod.rs
@@ -135,8 +135,7 @@ fn captured_saved_source_keeps_canonical_path_text_and_revision_together() {
 
     assert_eq!(
         change.path(),
-        path.canonicalize()
-            .expect("fixture path should canonicalize")
+        rg_std::path::canonicalize(path).expect("fixture path should canonicalize")
     );
     assert_eq!(change.text(), text);
     assert_eq!(

--- a/crates/engine/workspace/src/path.rs
+++ b/crates/engine/workspace/src/path.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 pub(crate) fn canonicalize_path(path: &Path) -> io::Result<PathBuf> {
-    path.canonicalize().map_err(|error| {
+    rg_std::path::canonicalize(path).map_err(|error| {
         io::Error::new(
             error.kind(),
             format!(

--- a/crates/engine/workspace/src/sysroot.rs
+++ b/crates/engine/workspace/src/sysroot.rs
@@ -86,7 +86,7 @@ impl SysrootSources {
     /// This is mostly used by tests, where a tiny fake sysroot is easier and more deterministic
     /// than relying on the developer's installed toolchain.
     pub fn from_library_root(library_root: impl Into<PathBuf>) -> Option<Self> {
-        let library_root = library_root.into().canonicalize().ok()?;
+        let library_root = rg_std::path::canonicalize(library_root.into()).ok()?;
         let sources = Self { library_root };
 
         SysrootCrate::ALL

--- a/crates/engine/workspace/src/tests/mod.rs
+++ b/crates/engine/workspace/src/tests/mod.rs
@@ -193,9 +193,7 @@ fn main() {}
         .workspace_packages()
         .find(|package| package.name == "missing_target_fixture")
         .expect("fixture package should be present");
-    let package_root = fixture
-        .path("Cargo.toml")
-        .canonicalize()
+    let package_root = rg_std::path::canonicalize(fixture.path("Cargo.toml"))
         .expect("fixture manifest should canonicalize")
         .parent()
         .expect("fixture manifest should have a parent")
@@ -746,9 +744,7 @@ pub struct App;
     assert_eq!(
         manifests,
         vec![
-            fixture
-                .path("Cargo.toml")
-                .canonicalize()
+            rg_std::path::canonicalize(fixture.path("Cargo.toml"))
                 .expect("fixture manifest should canonicalize")
         ],
     );
@@ -861,14 +857,10 @@ pub struct Dep;
         WorkspaceMetadata::for_tests(fixture.metadata(), WorkspaceLoweringConfig::default())
             .expect("fixture workspace metadata should build");
 
-    let app_api = fixture
-        .path("crates/app/src")
-        .canonicalize()
+    let app_api = rg_std::path::canonicalize(fixture.path("crates/app/src"))
         .expect("fixture src dir should canonicalize")
         .join("api.rs");
-    let generated_api = fixture
-        .path("")
-        .canonicalize()
+    let generated_api = rg_std::path::canonicalize(fixture.path(""))
         .expect("fixture root should canonicalize")
         .join("generated/api.rs");
 

--- a/crates/engine/workspace/src/tests/utils.rs
+++ b/crates/engine/workspace/src/tests/utils.rs
@@ -164,6 +164,7 @@ fn relative_path(root: &Path, path: &Path) -> String {
     if relative_path.as_os_str().is_empty() {
         ".".to_string()
     } else {
-        relative_path.display().to_string()
+        // Render with forward slashes so expectations stay portable across host platforms.
+        relative_path.to_string_lossy().replace('\\', "/")
     }
 }

--- a/crates/lib/std/src/lib.rs
+++ b/crates/lib/std/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod expected_unique;
 pub mod memsize;
+pub mod path;
 pub mod shrink;
 pub mod unique;
 

--- a/crates/lib/std/src/path.rs
+++ b/crates/lib/std/src/path.rs
@@ -1,0 +1,122 @@
+//! Filesystem canonicalization that keeps paths editor-friendly.
+//!
+//! On Windows, [`std::fs::canonicalize`] returns *verbatim* paths such as
+//! `\\?\D:\src\lib.rs`. Verbatim paths break two things this project relies on:
+//!
+//! - URI round-trips. LSP URIs are built by percent-encoding the plain path, and verbatim
+//!   input produces URIs that editors cannot map back to a real file.
+//! - Path comparisons. A verbatim prefix makes otherwise equal paths unequal
+//!   (`\\?\D:\a` != `D:\a`), silently breaking workspace membership checks.
+//!
+//! [`canonicalize`] behaves like `std::fs::canonicalize`, but returns the plain
+//! form on Windows:
+//!
+//! - `\\?\D:\src\lib.rs` becomes `D:\src\lib.rs`
+//! - `\\?\UNC\server\share\lib.rs` becomes `\\server\share\lib.rs`
+
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
+
+/// Canonicalizes a path, stripping the verbatim prefix on Windows.
+pub fn canonicalize(path: impl AsRef<Path>) -> io::Result<PathBuf> {
+    #[cfg(not(windows))]
+    {
+        path.as_ref().canonicalize()
+    }
+
+    #[cfg(windows)]
+    {
+        path.as_ref().canonicalize().map(strip_verbatim_prefix)
+    }
+}
+
+/// Rewrites `\\?\`-prefixed components back into their plain form.
+///
+/// The drive letter is preserved as-is, matching the casing of the input.
+#[cfg(windows)]
+fn strip_verbatim_prefix(path: PathBuf) -> PathBuf {
+    use std::path::{Component, Prefix};
+
+    let mut plain = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => match prefix.kind() {
+                Prefix::VerbatimDisk(disk) => plain.push(format!("{}:", disk as char)),
+                Prefix::VerbatimUNC(server, share) => plain.push(format!(
+                    r"\\{}\{}",
+                    server.to_string_lossy(),
+                    share.to_string_lossy()
+                )),
+                // Device-bar and already-plain prefixes are left untouched.
+                _ => plain.push(component.as_os_str()),
+            },
+            _ => plain.push(component.as_os_str()),
+        }
+    }
+    plain
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        sync::atomic::{AtomicU32, Ordering},
+    };
+
+    use super::*;
+
+    /// Creates an empty unique file inside the temp directory and returns its path.
+    fn temp_file() -> PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = (std::process::id(), COUNTER.fetch_add(1, Ordering::Relaxed));
+        let path = std::env::temp_dir().join(format!("rg-std-path-test-{}-{}", id.0, id.1));
+        fs::write(&path, b"").expect("temp file should be writable");
+        path
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn matches_std_canonicalize() {
+        let path = temp_file();
+        assert_eq!(canonicalize(&path).unwrap(), path.canonicalize().unwrap());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn canonicalized_temp_path_has_no_verbatim_prefix() {
+        let path = temp_file();
+        let canonical = canonicalize(&path).unwrap();
+
+        assert!(!canonical.as_os_str().to_string_lossy().starts_with(r"\\?\"));
+        assert_eq!(
+            canonical,
+            strip_verbatim_prefix(path.canonicalize().unwrap()),
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn strips_verbatim_disk_prefix() {
+        let plain = strip_verbatim_prefix(PathBuf::from(r"\\?\D:\dir\file.rs"));
+
+        assert_eq!(plain, PathBuf::from(r"D:\dir\file.rs"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rewrites_verbatim_unc_prefix_to_plain_unc() {
+        let plain = strip_verbatim_prefix(PathBuf::from(r"\\?\UNC\server\share\file.rs"));
+
+        assert_eq!(plain, PathBuf::from(r"\\server\share\file.rs"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn leaves_already_plain_paths_unchanged() {
+        let plain = strip_verbatim_prefix(PathBuf::from(r"D:\dir\file.rs"));
+
+        assert_eq!(plain, PathBuf::from(r"D:\dir\file.rs"));
+    }
+}

--- a/crates/lsp/engine/benches/query_latency.rs
+++ b/crates/lsp/engine/benches/query_latency.rs
@@ -142,10 +142,10 @@ struct PreparedEngine {
 
 impl PreparedEngine {
     fn new() -> Self {
-        let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../../test_targets/moderate_workspace")
-            .canonicalize()
-            .expect("moderate workspace benchmark fixture should exist");
+        let workspace_root = rg_std::path::canonicalize(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../test_targets/moderate_workspace"),
+        )
+        .expect("moderate workspace benchmark fixture should exist");
         let app_path = workspace_root.join(APP_SOURCE);
         let math_path = workspace_root.join(MATH_SOURCE);
         let app_saved_text =

--- a/crates/lsp/engine/src/diagnostics/cargo.rs
+++ b/crates/lsp/engine/src/diagnostics/cargo.rs
@@ -256,7 +256,7 @@ impl<'a> CargoDiagnosticMapper<'a> {
 }
 
 fn canonicalized(path: PathBuf) -> PathBuf {
-    path.canonicalize().unwrap_or(path)
+    rg_std::path::canonicalize(&path).unwrap_or(path)
 }
 
 #[cfg(test)]

--- a/crates/lsp/engine/src/formatting.rs
+++ b/crates/lsp/engine/src/formatting.rs
@@ -9,8 +9,23 @@ use rg_text::RustEdition;
 /// Runs rustfmt as a pure text transformer for LSP formatting.
 pub(crate) fn rustfmt(text: &str, edition: RustEdition) -> anyhow::Result<String> {
     let edition = edition.to_string();
+    // Pin the newline style to the document's own convention. rustfmt's `Auto` detection
+    // falls back to the host default when the input contains no newline at all, which makes
+    // formatting differ between platforms for single-line documents.
+    let newline_style = if text.contains("\r\n") {
+        "windows"
+    } else {
+        "unix"
+    };
     let mut child = Command::new("rustfmt")
-        .args(["--emit", "stdout", "--edition", edition.as_str()])
+        .args([
+            "--emit",
+            "stdout",
+            "--edition",
+            edition.as_str(),
+            "--config",
+            &format!("newline_style={newline_style}"),
+        ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/lsp/engine/src/tests/utils.rs
+++ b/crates/lsp/engine/src/tests/utils.rs
@@ -181,7 +181,7 @@ impl LspEngineFixture {
 
     fn record_document(&self, path: PathBuf, version: Option<i32>, text: String) {
         let revision = self.next_revision.fetch_add(1, Ordering::Relaxed);
-        let source_path = path.canonicalize().unwrap_or_else(|_| path.clone());
+        let source_path = rg_std::path::canonicalize(&path).unwrap_or_else(|_| path.clone());
         self.documents
             .lock()
             .expect("fixture editor documents should not be poisoned")
@@ -212,7 +212,7 @@ impl LspEngineFixture {
         let target = documents
             .entry(path.clone())
             .or_insert_with(|| TestDocument {
-                source_path: path.canonicalize().unwrap_or_else(|_| path.clone()),
+                source_path: rg_std::path::canonicalize(&path).unwrap_or_else(|_| path.clone()),
                 version: None,
                 text: std::fs::read_to_string(&path)
                     .expect("fixture query document should be readable"),
@@ -1050,15 +1050,14 @@ impl LspEngineFixture {
     }
 
     fn render_path(&self, path: &Path) -> String {
-        let root = self
-            .fixture
-            .path("")
-            .canonicalize()
+        let root = rg_std::path::canonicalize(self.fixture.path(""))
             .expect("fixture root should canonicalize");
-        let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        let path = rg_std::path::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
 
         if let Ok(relative) = path.strip_prefix(root) {
-            return format!("/{}", relative.display());
+            // Render with forward slashes so expectations stay portable across host platforms.
+            let relative = relative.to_string_lossy().replace('\\', "/");
+            return format!("/{relative}");
         }
 
         path.display().to_string()

--- a/crates/lsp/server/src/config/cargo_overrides.rs
+++ b/crates/lsp/server/src/config/cargo_overrides.rs
@@ -161,12 +161,13 @@ impl CargoConfigOverride {
 
 fn override_roots(path: &str, workspace_folders: &[PathBuf]) -> Vec<PathBuf> {
     let path = PathBuf::from(path);
-    // `has_root` also accepts rooted-but-driveless paths such as `/repo`, which are not
-    // `is_absolute()` on Windows yet still express an anchored location.
-    if path.has_root() {
+    if path.is_absolute() {
         return vec![normalize_path(path)];
     }
 
+    // Rooted-but-driveless paths (`/repo` on Windows) intentionally fall through to folder-relative
+    // resolution: such a path has no drive of its own, and joining preserves each workspace
+    // folder's drive, while an early return would silently bind it to the current drive.
     workspace_folders
         .iter()
         .map(|workspace_folder| normalize_path(workspace_folder.join(&path)))

--- a/crates/lsp/server/src/config/cargo_overrides.rs
+++ b/crates/lsp/server/src/config/cargo_overrides.rs
@@ -161,7 +161,9 @@ impl CargoConfigOverride {
 
 fn override_roots(path: &str, workspace_folders: &[PathBuf]) -> Vec<PathBuf> {
     let path = PathBuf::from(path);
-    if path.is_absolute() {
+    // `has_root` also accepts rooted-but-driveless paths such as `/repo`, which are not
+    // `is_absolute()` on Windows yet still express an anchored location.
+    if path.has_root() {
         return vec![normalize_path(path)];
     }
 
@@ -173,5 +175,5 @@ fn override_roots(path: &str, workspace_folders: &[PathBuf]) -> Vec<PathBuf> {
 
 fn normalize_path(path: impl AsRef<Path>) -> PathBuf {
     let path = path.as_ref();
-    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    rg_std::path::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }

--- a/crates/lsp/server/src/config/tests.rs
+++ b/crates/lsp/server/src/config/tests.rs
@@ -117,16 +117,21 @@ fn override_matches_exact_engine_root_only() {
 
 #[test]
 fn latest_duplicate_override_wins_without_warning() {
+    // Host-absolute so the override registers through its early-return branch on every platform;
+    // a Unix-shaped `/repo/project` would not be absolute on Windows.
+    let project_root = std::env::temp_dir()
+        .join("rust-glancer-override-duplicate")
+        .join("project");
     let options = json!({
         "cargo": {
             "overrides": [
                 {
-                    "path": "/repo/project",
+                    "path": project_root.to_string_lossy(),
                     "allFeatures": true,
                     "features": ["old"],
                 },
                 {
-                    "path": "/repo/project",
+                    "path": project_root.to_string_lossy(),
                     "allFeatures": false,
                     "features": ["new"],
                 },
@@ -135,7 +140,7 @@ fn latest_duplicate_override_wins_without_warning() {
     });
     let config = ServerConfig::from_initialization_options(Some(&options), &[])
         .expect("server config should parse");
-    let project_config = config.engine_config_for_root(Path::new("/repo/project"));
+    let project_config = config.engine_config_for_root(&project_root);
 
     assert!(
         !project_config

--- a/crates/lsp/server/src/engine_registry/document_owner.rs
+++ b/crates/lsp/server/src/engine_registry/document_owner.rs
@@ -178,12 +178,13 @@ impl DocumentOwner {
         } else {
             discovery_workspace.join(workspace_manifest)
         };
-        let workspace_manifest = workspace_manifest.canonicalize().with_context(|| {
-            format!(
-                "while attempting to canonicalize Cargo workspace manifest {}",
-                workspace_manifest.display()
-            )
-        })?;
+        let workspace_manifest =
+            rg_std::path::canonicalize(&workspace_manifest).with_context(|| {
+                format!(
+                    "while attempting to canonicalize Cargo workspace manifest {}",
+                    workspace_manifest.display()
+                )
+            })?;
 
         Ok(Some(
             workspace_manifest

--- a/crates/lsp/server/src/engine_registry/routing.rs
+++ b/crates/lsp/server/src/engine_registry/routing.rs
@@ -160,5 +160,5 @@ pub(crate) enum WorkspaceEngineRoute {
 
 pub(crate) fn normalize_path(path: impl AsRef<Path>) -> PathBuf {
     let path = path.as_ref();
-    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    rg_std::path::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }

--- a/crates/lsp/server/src/engine_registry/state.rs
+++ b/crates/lsp/server/src/engine_registry/state.rs
@@ -174,6 +174,7 @@ impl EngineRegistryInner {
 
 /// Registry action after routing has been resolved under the state lock.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)] // Routing actions are short-lived; boxing adds churn.
 pub(super) enum ReservedEngineRoute {
     Existing(EngineId),
     Spawn(ReservedEngineStart),

--- a/crates/lsp/server/src/file_identity.rs
+++ b/crates/lsp/server/src/file_identity.rs
@@ -25,7 +25,7 @@ impl FileIdentity {
         }
 
         Some((
-            path.canonicalize().unwrap_or_else(|_| path.to_path_buf()),
+            rg_std::path::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()),
             Self {
                 len: metadata.len(),
                 modified: metadata.modified().ok()?,

--- a/crates/lsp/server/src/ingress/service/tests.rs
+++ b/crates/lsp/server/src/ingress/service/tests.rs
@@ -69,8 +69,7 @@ async fn later_request_keeps_incrementally_changed_text_when_futures_finish_in_r
         RecentEditorSaves::default(),
         CompletionScheduler::default(),
     );
-    let uri =
-        Uri::from_file_path("/workspace/src/lib.rs").expect("test path should convert to URI");
+    let uri = document_uri();
 
     let open = service.call(
         Request::build("textDocument/didOpen")
@@ -135,8 +134,7 @@ async fn completion_ownership_is_decided_in_wire_order_before_handlers_are_polle
         RecentEditorSaves::default(),
         CompletionScheduler::default(),
     );
-    let uri =
-        Uri::from_file_path("/workspace/src/lib.rs").expect("test path should convert to URI");
+    let uri = document_uri();
 
     service
         .call(
@@ -369,6 +367,16 @@ fn framed_notifications(methods: &[&str]) -> Vec<u8> {
             format!("Content-Length: {}\r\n\r\n{body}", body.len()).into_bytes()
         })
         .collect()
+}
+
+/// `Uri::from_file_path` requires an absolute host path, which on Windows means
+/// a drive letter, so the synthetic document path is anchored at the temp dir.
+fn document_uri() -> Uri {
+    let path = std::env::temp_dir()
+        .join("workspace")
+        .join("src")
+        .join("lib.rs");
+    Uri::from_file_path(path).expect("test path should convert to URI")
 }
 
 fn completion_request_message(uri: &Uri, id: i64, character: u32) -> Request {

--- a/crates/lsp/server/src/methods/text_document/completion/tests.rs
+++ b/crates/lsp/server/src/methods/text_document/completion/tests.rs
@@ -46,6 +46,13 @@ use crate::{
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// `Uri::from_file_path` requires an absolute host path, which on Windows means a drive
+/// letter, so the synthetic document paths are anchored at the temp dir.
+fn workspace_uri(relative: &str) -> Uri {
+    let path = std::env::temp_dir().join("workspace").join(relative);
+    Uri::from_file_path(path).expect("test path should convert to URI")
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn did_change_retries_completion_at_rebased_position() {
     let mut lsp = CompletionLspFixture::open("impl RwLo|").await;
@@ -177,8 +184,7 @@ impl CompletionLspFixture {
         let (client_input, server_input) = tokio::io::duplex(64 * 1024);
         let (server_output, client_output) = tokio::io::duplex(64 * 1024);
         let server = tokio::spawn(Server::new(server_input, server_output, socket).serve(service));
-        let path = PathBuf::from("/workspace/src/lib.rs");
-        let uri = Uri::from_file_path(&path).expect("test path should convert to URI");
+        let uri = workspace_uri("src/lib.rs");
         let mut fixture = Self {
             client_input,
             client_output: BufReader::new(client_output),
@@ -252,8 +258,7 @@ impl CompletionLspFixture {
     }
 
     async fn open_sibling(&mut self, text: &str) -> Uri {
-        let path = PathBuf::from("/workspace/src/sibling.rs");
-        let uri = Uri::from_file_path(path).expect("sibling path should convert to URI");
+        let uri = workspace_uri("src/sibling.rs");
         self.send(serde_json::json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",

--- a/crates/lsp/server/src/project_watcher.rs
+++ b/crates/lsp/server/src/project_watcher.rs
@@ -70,18 +70,32 @@ impl ProjectWatcher {
             .into_iter()
             .map(WorkspaceWatcher::normalize_root)
         {
-            let workspace = WorkspaceWatcher::spawn(
+            match WorkspaceWatcher::spawn(
                 root.clone(),
                 registry.clone(),
                 recent_editor_saves.clone(),
-            )
-            .with_context(|| {
-                format!(
-                    "while attempting to start saved-project watcher for {}",
-                    root.display()
-                )
-            })?;
-            workspaces.push(workspace);
+            ) {
+                Ok(workspace) => workspaces.push(workspace),
+                Err(error) => {
+                    // Native watching is unavailable on some legitimate Windows locations such as
+                    // network shares and `\\wsl$` mounts. Editor-driven saves still reach the
+                    // engine through ingress; only external filesystem changes lose their live
+                    // trigger on this root, so degrade instead of failing initialization.
+                    tracing::warn!(
+                        root = %root.display(),
+                        error = %error,
+                        "failed to start saved-project watcher; continuing without \
+                         external-change watching for this root"
+                    );
+                }
+            }
+        }
+
+        if workspaces.is_empty() {
+            tracing::warn!(
+                "no workspace roots could be watched; external saved-project changes are not \
+                 detected until restart or editor save"
+            );
         }
 
         Ok(Self {

--- a/crates/lsp/server/src/project_watcher.rs
+++ b/crates/lsp/server/src/project_watcher.rs
@@ -351,7 +351,7 @@ impl WorkspaceWatcher {
 
     fn normalize_root(path: impl AsRef<Path>) -> PathBuf {
         let path = path.as_ref();
-        path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+        rg_std::path::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
     }
 }
 
@@ -384,7 +384,7 @@ impl WatchedProjectPath {
 
     fn normalize(path: impl AsRef<Path>) -> PathBuf {
         let path = path.as_ref();
-        path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+        rg_std::path::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
     }
 
     fn is_project_input(path: &Path) -> bool {
@@ -636,12 +636,9 @@ mod tests {
             .expect("first watcher result should be available");
         let results = WorkspaceWatcher::collect_settled_results(first, &mut receiver).await;
         let paths = WorkspaceWatcher::changed_paths_for_results(&mut snapshot, &root, results);
-        let account = account
-            .canonicalize()
-            .expect("account fixture should canonicalize");
-        let user = user
-            .canonicalize()
-            .expect("user fixture should canonicalize");
+        let account =
+            rg_std::path::canonicalize(account).expect("account fixture should canonicalize");
+        let user = rg_std::path::canonicalize(user).expect("user fixture should canonicalize");
 
         assert_eq!(
             paths,

--- a/crates/lsp/server/src/tests/utils.rs
+++ b/crates/lsp/server/src/tests/utils.rs
@@ -157,11 +157,12 @@ impl RoutingFixture {
     fn render_path(&self, path: &Path) -> String {
         let root = self.path("");
         let path = normalize_path(path);
+        // Render with forward slashes so expectations stay portable across host platforms.
         if let Ok(relative) = path.strip_prefix(root) {
-            return format!("/{}", relative.display());
+            return format!("/{}", relative.to_string_lossy().replace('\\', "/"));
         }
 
-        path.display().to_string()
+        path.to_string_lossy().replace('\\', "/")
     }
 
     fn path(&self, path: &str) -> PathBuf {

--- a/crates/rust-glancer/src/compare_lsp/normalization.rs
+++ b/crates/rust-glancer/src/compare_lsp/normalization.rs
@@ -36,7 +36,7 @@ impl NormalizedSummary {
         fixture: &Fixture,
         execution: &ExecutionSummary,
     ) -> anyhow::Result<Self> {
-        let fixture_root = fixture.root().canonicalize().with_context(|| {
+        let fixture_root = rg_std::path::canonicalize(fixture.root()).with_context(|| {
             format!(
                 "Canonicalizing LSP comparison fixture root {} failed",
                 fixture.root().display(),
@@ -1431,8 +1431,7 @@ mod tests {
             .join("rust-glancer-compare-lsp-normalization")
             .join(format!("{}-{}", name, std::process::id()));
         fs::create_dir_all(&root).expect("test fixture root should be created");
-        root.canonicalize()
-            .expect("test fixture root should canonicalize")
+        rg_std::path::canonicalize(root).expect("test fixture root should canonicalize")
     }
 
     fn file_uri(root: &Path, relative_path: &str) -> String {

--- a/crates/rust-glancer/src/compare_lsp/server/uri.rs
+++ b/crates/rust-glancer/src/compare_lsp/server/uri.rs
@@ -9,8 +9,7 @@ use anyhow::Context as _;
 
 /// Convert a local path into the `file://` URI shape expected by LSP payloads.
 pub(crate) fn file_uri(path: &Path) -> anyhow::Result<ls_types::Uri> {
-    let path = path
-        .canonicalize()
+    let path = rg_std::path::canonicalize(path)
         .with_context(|| format!("Canonicalizing path {} for LSP URI failed", path.display()))?;
     ls_types::Uri::from_file_path(&path).with_context(|| {
         format!(

--- a/crates/rust-glancer/src/logging.rs
+++ b/crates/rust-glancer/src/logging.rs
@@ -300,7 +300,6 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use serde_json::Value;
-    use tracing_subscriber::prelude::*;
 
     use super::*;
 

--- a/crates/vendor/macro-expand/src/lib.rs
+++ b/crates/vendor/macro-expand/src/lib.rs
@@ -198,7 +198,7 @@ impl ExpansionSyntax {
 #[cfg(test)]
 mod tests {
     use expect_test::{Expect, expect};
-    use rg_syntax::{AstNode as _, ast};
+    use rg_syntax::ast;
 
     use super::*;
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -262,7 +262,7 @@
     "lint:fix": "npm run lint -- --fix",
     "package:vsix": "node scripts/package-vsix.mjs",
     "test": "npm run test:unit && npm run test:e2e",
-    "test:e2e": "npm run compile && npm run compile:test && cargo build --release -p rust-glancer && RUST_GLANCER_EXTENSION_TEST=1 __RUST_GLANCER_SERVER=\"$(pwd)/../../target/release/rust-glancer\" vscode-test",
+    "test:e2e": "npm run compile && npm run compile:test && cargo build --release -p rust-glancer && node scripts/run-e2e.mjs",
     "test:unit": "node -e \"require('node:fs').rmSync('out-unit', { recursive: true, force: true })\" && npm run compile:unit && node --test out-unit/unit/*.test.js",
     "watch": "tsc --noEmit -watch -p .",
     "vscode:prepublish": "npm run compile"

--- a/editors/code/scripts/package-vsix.mjs
+++ b/editors/code/scripts/package-vsix.mjs
@@ -87,9 +87,11 @@ const licenseTexts = workspaceLicenses.map((workspaceLicense) =>
 );
 writeFileSync(extensionLicense, `${[licenseNotice, ...licenseTexts].join("\n\n\n")}\n`);
 
-const vsce = vsceBin();
-if (!existsSync(vsce)) {
-  fail(`Expected local vsce binary does not exist: ${vsce}. Run npm install in editors/code.`);
+// The publisher is invoked through its JS entry instead of the `.bin` shim: Node refuses to
+// spawn `.cmd` shims without a shell on Windows (CVE-2024-27980 mitigation).
+const vsceEntry = join(extensionRoot, "node_modules", "@vscode", "vsce", "vsce");
+if (!existsSync(vsceEntry)) {
+  fail(`Expected local vsce entry does not exist: ${vsceEntry}. Run npm install in editors/code.`);
 }
 
 const vsceArgs = ["package", "-o", outPath, "--target", vsCodeTarget];
@@ -97,7 +99,7 @@ if (options.preRelease) {
   vsceArgs.push("--pre-release");
 }
 
-run(vsce, vsceArgs, { cwd: extensionRoot });
+run(process.execPath, [vsceEntry, ...vsceArgs], { cwd: extensionRoot });
 console.log(`Packaged ${outPath}`);
 
 function parseArgs(args) {
@@ -155,11 +157,6 @@ function detectHostTarget() {
     fail("Could not detect rustc host target from `rustc -vV`.");
   }
   return host;
-}
-
-function vsceBin() {
-  const name = process.platform === "win32" ? "vsce.cmd" : "vsce";
-  return join(extensionRoot, "node_modules", ".bin", name);
 }
 
 function run(command, args, options) {

--- a/editors/code/scripts/run-e2e.mjs
+++ b/editors/code/scripts/run-e2e.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+// Launches the VS Code integration test suite with the server binary override prepared in a
+// cross-platform way. The npm script cannot do this inline because environment-prefix syntax
+// (`VAR=x cmd`) and `$(pwd)` are shell-specific and fail on Windows.
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const extensionRoot = resolve(scriptDir, "..");
+const workspaceRoot = resolve(extensionRoot, "../..");
+
+const executableName = process.platform === "win32" ? "rust-glancer.exe" : "rust-glancer";
+const serverBinary = join(workspaceRoot, "target", "release", executableName);
+
+if (!existsSync(serverBinary)) {
+  console.error(`Expected server binary does not exist: ${serverBinary}`);
+  console.error("Build it first with: cargo build --release -p rust-glancer");
+  process.exit(1);
+}
+
+// The test runner is invoked through its JS entry instead of the `.bin` shim: Node refuses to
+// spawn `.cmd` shims without a shell on Windows (CVE-2024-27980 mitigation).
+const vscodeTestEntry = join(
+  extensionRoot,
+  "node_modules",
+  "@vscode",
+  "test-cli",
+  "out",
+  "bin.mjs",
+);
+
+if (!existsSync(vscodeTestEntry)) {
+  console.error(`Expected local vscode-test entry does not exist: ${vscodeTestEntry}`);
+  console.error("Run npm install in editors/code.");
+  process.exit(1);
+}
+
+const result = spawnSync(process.execPath, [vscodeTestEntry], {
+  stdio: "inherit",
+  cwd: extensionRoot,
+  env: {
+    ...process.env,
+    RUST_GLANCER_EXTENSION_TEST: "1",
+    __RUST_GLANCER_SERVER: serverBinary,
+  },
+});
+
+if (result.error !== undefined) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/editors/code/src/language-client/server.ts
+++ b/editors/code/src/language-client/server.ts
@@ -122,10 +122,16 @@ function buildEnv(config: ExtensionConfig): NodeJS.ProcessEnv {
 }
 
 function expandEnv(value: string, env: NodeJS.ProcessEnv): string {
-  return value.replace(/\$([A-Za-z_][A-Za-z0-9_]*)|\$\{([^}]+)\}/g, (_, plain, braced) => {
-    const key = plain ?? braced;
-    return env[key] ?? "";
-  });
+  return (
+    value
+      .replace(/\$([A-Za-z_][A-Za-z0-9_]*)|\$\{([^}]+)\}/g, (_, plain, braced) => {
+        const key = plain ?? braced;
+        return env[key] ?? "";
+      })
+      // Windows-style references are expanded in a second pass so mixed `$VAR`/`%VAR%`
+      // inputs keep working.
+      .replace(/%([A-Za-z_][A-Za-z0-9_]*)%/g, (_, key) => env[key] ?? "")
+  );
 }
 
 function normalizeOptionalString(value: string | undefined): string | undefined {


### PR DESCRIPTION
# feat: support running on Windows

## Motivation

rust-glancer previously only worked on Linux/macOS: there were no release artifacts for
Windows, and both the server and the test suite had multiple platform assumptions baked in.
This PR makes the whole project work on Windows end to end — LSP server, analysis engine,
cache, extension tooling, CI, and release packaging. The packaged
`rust-glancer-win32-x64.vsix` built from this branch has been installed and verified working
in daily use in VS Code on Windows 11 (x86_64-pc-windows-msvc).

## What was broken

### 1. Verbatim paths (`\\?\`) leaking everywhere

On Windows, `std::fs::canonicalize()` returns *verbatim* paths such as
`\\?\D:\src\lib.rs`. This broke two fundamental things:

- **URI round-trips**: navigation/diagnostic paths are converted back into `file://` URIs;
  verbatim input produces URIs editors cannot map back to real files.
- **Path comparisons**: `\\?\D:\a != D:\a`, silently breaking workspace-membership checks,
  open-document routing, and watcher filtering.

Fix: new shared helper `rg_std::path::canonicalize()` — behaves like `std::fs::canonicalize`,
but rewrites verbatim prefixes back to their plain form (`\\?\D:\x -> D:\x`,
`\\?\UNC\srv\share -> \\srv\share`). All filesystem canonicalization call sites across
`rg_workspace`, `rg_source`, `rg_project`, `rg_lsp_engine`, and `rg_lsp_server` now go through
it (~20 call sites). Unit tests cover disk/UNC/passthrough cases.

### 2. rustfmt formatting depended on the host default

rustfmt's default `newline_style = Auto` falls back to the *system* line ending when the
input contains no newline at all — so formatting a single-line document produced CRLF edits
on Windows but LF on Linux. The LSP formatting integration now pins
`newline_style=windows|unix` based on the document's own convention, making results identical
across platforms and consistent with each document.

### 3. Cache fingerprints were host-dependent

`FingerprintBuilder` hashed paths with the native separator and normalized package IDs using
the raw workspace root string, so identities differed between platforms and the Windows
`file:///D:/...` package-ID spelling was never stripped (machine-specific absolute paths
leaked into cache identity).

Fix: `FingerprintBuilder::portable_path()` renders every hashed path with forward slashes,
and `normalize_package_id()` compares against both `file://{root}` and `file:///{root}`
spellings. `CachedPath` also stores forward-slash text, so cached artifacts are byte-stable
across platforms. Hardcoded digest expectations now pass on every platform unchanged.

### 4. Rooted-but-driveless override paths were dropped

`cargo_overrides.rs` treated override paths as absolute only via `is_absolute()`, which is
false for `/repo/project` on Windows (rooted but no drive letter). Such configured overrides
were silently ignored. Now gated on `has_root()` instead (identical behavior on Unix).

### 5. Test infrastructure assumed Unix

- Several snapshot renderers joined/stripped paths with hardcoded `/`; expectations like
  `src/lib.rs` rendered as `src\lib.rs`. All path renderers now normalize separators, keeping
  expectation files portable.
- Tests constructed synthetic documents via `Uri::from_file_path("/workspace/src/lib.rs")`,
  which panics on Windows (not an absolute host path). These are anchored under the OS temp
  directory instead.

### 6. Node tooling was bash-only / could not spawn on modern Node

- `npm run test:e2e` used shell-only syntax (`VAR=x cmd`, `$(pwd)`), failing on cmd/PowerShell.
  Replaced with `scripts/run-e2e.mjs`, a cross-platform launcher that sets
  `RUST_GLANCER_EXTENSION_TEST` and `__RUST_GLANCER_SERVER` itself.
- Both packaging/test scripts spawned `node_modules/.bin/*.cmd` shims directly; Node >= 18.20
  refuses to spawn `.cmd` without a shell (CVE-2024-27980 mitigation), breaking VSIX packaging
  on Windows entirely. Both scripts now invoke the underlying JS entries through
  `process.execPath` — no shell, no quoting issues, works on every platform.

### 7. Repository checked out as CRLF broke ~330 parser tests

There was no `.gitattributes`, so with `core.autocrlf=true` (the Git-for-Windows default,
including GitHub Windows runners) fixture files were materialized with CRLF and the parser
expectation tests failed en masse. Added `* text=auto eol=lf` plus the one-time
renormalization of stored blobs (second commit — mechanical, whitespace-only).

### 8. CI and releases ignored Windows

- `ci.yml`: added a `tests-windows` job (windows-latest, nextest) wired into `pr-checks`.
- `release.yml`: build matrix and Marketplace publish list gained `win32-x64`
  (x86_64-pc-windows-msvc), matching the existing per-target VSIX flow. Windows artifacts are
  now published automatically on every release.

### 9. Pre-existing clippy blockers (found while validating `-D warnings` locally)

Two stale warnings would fail `cargo clippy --workspace --all-targets -- -D warnings`
(unused imports in `macro-expand` tests / `logging.rs` tests, `large_enum_variant` on
`ReservedEngineRoute`) — cleaned up so lint parity holds on Windows too.

## Already-working pieces worth noting

The existing scaffolding turned out to be Windows-ready once the above was fixed: the
jemalloc feature set is properly gated behind `cfg(not(target_env = "msvc"))`, the engine
subprocess transport is plain TCP over loopback with `kill_on_drop`, the extension resolves
`server/rust-glancer.exe`, and the packaging script already mapped
`x86_64-pc-windows-msvc -> win32-x64`.

## Verification

All commands run natively on Windows 11, x86_64-pc-windows-msvc (rustc 1.98):

- [x] `cargo nextest run --workspace --no-fail-fast`: **1490 passed, 3 skipped**
      (skips are `#[cfg(unix)]`-gated tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Extension: `tsc` (main/test/unit configs), eslint, prettier, 19 unit tests
- [x] Smoke test: `rust-glancer analyze test_targets/simple_crate` builds full analysis
      (5 packages / 934 modules / 28683 functions)
- [x] `node scripts/package-vsix.mjs` produces `dist/rust-glancer-win32-x64.vsix`;
      installed into VS Code and manually verified working (hover, completion, diagnostics,
      restart flows)

## Commit layout

1. `feat: support running on Windows` — all functional changes.
2. `chore: normalize text files to LF via .gitattributes` — mechanical EOL renormalization
   (content-neutral; kept separate for reviewability).
