### PR TITLE
feat: VS Code extension menu

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -48,6 +48,14 @@
     ],
     "commands": [
       {
+        "command": "rust-glancer.showServerActions",
+        "title": "Rust Glancer: Show Server Actions"
+      },
+      {
+        "command": "rust-glancer.startServer",
+        "title": "Rust Glancer: Start Server"
+      },
+      {
         "command": "rust-glancer.restartServer",
         "title": "Rust Glancer: Restart Server"
       },
@@ -58,6 +66,10 @@
       {
         "command": "rust-glancer.reindexWorkspace",
         "title": "Rust Glancer: Reindex Workspace"
+      },
+      {
+        "command": "rust-glancer.openLogs",
+        "title": "Rust Glancer: Open Logs"
       }
     ],
     "configuration": {

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -5,9 +5,12 @@
  * links, tests, and LSP execute-command calls from drifting apart.
  */
 export const EXTENSION_COMMANDS = {
+  showServerActions: "rust-glancer.showServerActions",
+  startServer: "rust-glancer.startServer",
   restartServer: "rust-glancer.restartServer",
   stopServer: "rust-glancer.stopServer",
   reindexWorkspace: "rust-glancer.reindexWorkspace",
+  openLogs: "rust-glancer.openLogs",
   goToTypeFromHover: "rust-glancer.gotoTypeFromHover",
   goToImplementationFromHover: "rust-glancer.gotoImplementationFromHover",
   testGetState: "rust-glancer.test.getState",

--- a/editors/code/src/extension-controller.ts
+++ b/editors/code/src/extension-controller.ts
@@ -6,6 +6,7 @@
  */
 import * as vscode from "vscode";
 
+import { EXTENSION_COMMANDS } from "./commands";
 import { LanguageClientSlot } from "./language-client/language-client-slot";
 import type { LanguageClientSessionSnapshot } from "./language-client/language-client-session";
 import { isRustFile } from "./utils/lsp-utils";
@@ -19,6 +20,7 @@ export interface ExtensionControllerSnapshot {
 export class ExtensionController implements vscode.Disposable {
   private readonly clientSlot: LanguageClientSlot;
   private readonly workspaceListeners: vscode.Disposable;
+  private serverEnabled = true;
 
   /** Wires VS Code workspace/editor events to the window-level LSP client lifecycle. */
   public constructor(
@@ -52,6 +54,7 @@ export class ExtensionController implements vscode.Disposable {
 
   /** Starts the window-level LSP session when the window has a filesystem workspace folder. */
   public async start(): Promise<void> {
+    this.serverEnabled = true;
     const workspaceFolder = this.selectedWorkspaceFolder();
     if (workspaceFolder === undefined) {
       this.extensionLog.info("no workspace folder found; rust-glancer server was not started");
@@ -59,12 +62,21 @@ export class ExtensionController implements vscode.Disposable {
       return;
     }
 
-    const client = await this.clientSlot.getSession(workspaceFolder);
+    // A session can remain in the slot after its process exits. Replace that stopped session so
+    // the explicit start action always creates a live client instead of only refreshing its UI.
+    const current = this.clientSlot.current();
+    const client =
+      current === undefined
+        ? await this.clientSlot.getSession(workspaceFolder)
+        : current.isRunning()
+          ? current
+          : await this.clientSlot.replace(workspaceFolder);
     client?.refreshStatus();
   }
 
   /** Restarts the window-level LSP session, or starts it if it is not currently running. */
   public async restart(): Promise<void> {
+    this.serverEnabled = true;
     const workspaceFolder = this.selectedWorkspaceFolder();
     if (workspaceFolder === undefined) {
       void vscode.window.showWarningMessage("Rust Glancer needs an open workspace folder.");
@@ -75,15 +87,19 @@ export class ExtensionController implements vscode.Disposable {
     client?.refreshStatus();
   }
 
-  /** Stops the window-level LSP session. Engine-specific stopping will live in the server later. */
+  /** Stops the window-level LSP session until the user explicitly starts it again. */
   public async stopServer(): Promise<void> {
     const client = this.clientSlot.current();
-    if (client === undefined || !client.isRunning()) {
-      void vscode.window.showWarningMessage("Rust Glancer has no running server to stop.");
-      return;
-    }
+    const statusState = this.status.snapshot().state;
+    const serverWasActive = client?.isRunning() === true || statusState === "starting";
+    this.serverEnabled = false;
 
     await this.clientSlot.stop();
+    this.status.stopped("stopped by user");
+
+    if (!serverWasActive) {
+      void vscode.window.showWarningMessage("Rust Glancer has no running server to stop.");
+    }
   }
 
   /** Runs workspace reindexing against the active engine selected by the LSP server. */
@@ -94,6 +110,55 @@ export class ExtensionController implements vscode.Disposable {
     }
 
     await this.clientSlot.current()?.reindexWorkspace();
+  }
+
+  /** Lets the status item expose common server operations without giving one action precedence. */
+  public async showServerActions(): Promise<void> {
+    const running = this.clientSlot.current()?.isRunning() === true;
+    const lifecycleActions: ServerActionQuickPickItem[] = running
+      ? [
+          {
+            label: "$(refresh) Reindex Workspace",
+            description: "Refresh analysis from the workspace on disk",
+            command: EXTENSION_COMMANDS.reindexWorkspace,
+          },
+          {
+            label: "$(debug-restart) Restart Server",
+            description: "Restart the language server and reinitialize the workspace",
+            command: EXTENSION_COMMANDS.restartServer,
+          },
+          {
+            label: "$(stop-circle) Stop Server",
+            description: "Keep the language server stopped until it is started manually",
+            command: EXTENSION_COMMANDS.stopServer,
+          },
+        ]
+      : [
+          {
+            label: "$(play-circle) Start Server",
+            description: "Start the language server for this window",
+            command: EXTENSION_COMMANDS.startServer,
+          },
+        ];
+    const selected = await vscode.window.showQuickPick<ServerActionQuickPickItem>(
+      [
+        ...lifecycleActions,
+        {
+          label: "$(output) Open Logs",
+          description: "Show language-server output",
+          command: EXTENSION_COMMANDS.openLogs,
+        },
+      ],
+      {
+        title: "Rust Glancer Server Actions",
+        placeHolder: running ? "Choose a server action" : "The server is not running",
+        matchOnDescription: true,
+      },
+    );
+
+    if (selected !== undefined) {
+      await vscode.commands.executeCommand(selected.command);
+    }
   }
 
   /** Stops the managed language-client session and leaves the status view globally stopped. */
@@ -136,6 +201,10 @@ export class ExtensionController implements vscode.Disposable {
       this.refreshActiveStatus();
       return false;
     }
+    if (!this.serverEnabled) {
+      this.status.stopped("stopped by user");
+      return false;
+    }
 
     const client = await this.clientSlot.getSession(workspaceFolder);
     client?.refreshStatus();
@@ -153,6 +222,10 @@ export class ExtensionController implements vscode.Disposable {
     const workspaceFolder = this.selectedWorkspaceFolder();
     if (workspaceFolder === undefined) {
       await this.stop();
+      return;
+    }
+    if (!this.serverEnabled) {
+      this.status.stopped("stopped by user");
       return;
     }
 
@@ -190,6 +263,10 @@ export class ExtensionController implements vscode.Disposable {
       return;
     }
 
-    this.status.stopped("no active Rust workspace");
+    this.status.stopped(this.serverEnabled ? "no active Rust workspace" : "stopped by user");
   }
+}
+
+interface ServerActionQuickPickItem extends vscode.QuickPickItem {
+  readonly command: string;
 }

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -54,6 +54,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     status,
     controller,
     registerHoverActionCommands(extensionLog),
+    vscode.commands.registerCommand(EXTENSION_COMMANDS.showServerActions, async () => {
+      await controller?.showServerActions();
+    }),
+    vscode.commands.registerCommand(EXTENSION_COMMANDS.startServer, async () => {
+      await controller?.start();
+    }),
     vscode.commands.registerCommand(EXTENSION_COMMANDS.restartServer, async () => {
       await controller?.restart();
     }),
@@ -62,6 +68,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.commands.registerCommand(EXTENSION_COMMANDS.reindexWorkspace, async () => {
       await controller?.reindexWorkspace();
+    }),
+    vscode.commands.registerCommand(EXTENSION_COMMANDS.openLogs, () => {
+      serverOutput.output.show();
     }),
   );
 

--- a/editors/code/src/language-client/language-client-session.ts
+++ b/editors/code/src/language-client/language-client-session.ts
@@ -63,7 +63,7 @@ export class LanguageClientSession implements vscode.Disposable {
   }
 
   public isRunning(): boolean {
-    return this.client !== undefined;
+    return this.client !== undefined && this.clientStatus.isRunning();
   }
 
   public async start(): Promise<boolean> {

--- a/editors/code/src/status/status-view.ts
+++ b/editors/code/src/status/status-view.ts
@@ -30,7 +30,7 @@ export class StatusView implements vscode.Disposable {
   public constructor() {
     this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
     this.item.name = "Rust Glancer";
-    this.item.command = EXTENSION_COMMANDS.restartServer;
+    this.item.command = EXTENSION_COMMANDS.showServerActions;
   }
 
   public starting(details: StatusDetails): void {
@@ -176,7 +176,7 @@ export class StatusView implements vscode.Disposable {
       appendTextField(tooltip, "Source", this.details.serverSource);
     }
 
-    tooltip.appendMarkdown("Click to restart the server.");
+    tooltip.appendMarkdown("Click for server actions.");
     return tooltip;
   }
 }

--- a/editors/code/test/extension.test.ts
+++ b/editors/code/test/extension.test.ts
@@ -38,9 +38,12 @@ suite("Rust Glancer extension", () => {
     );
 
     const commands = await vscode.commands.getCommands(true);
+    assert.ok(commands.includes(EXTENSION_COMMANDS.showServerActions));
+    assert.ok(commands.includes(EXTENSION_COMMANDS.startServer));
     assert.ok(commands.includes(EXTENSION_COMMANDS.restartServer));
     assert.ok(commands.includes(EXTENSION_COMMANDS.stopServer));
     assert.ok(commands.includes(EXTENSION_COMMANDS.reindexWorkspace));
+    assert.ok(commands.includes(EXTENSION_COMMANDS.openLogs));
 
     await vscode.commands.executeCommand(EXTENSION_COMMANDS.reindexWorkspace);
     const reindexed = await waitForClientState((state) => readySession(state) !== undefined);
@@ -77,6 +80,13 @@ suite("Rust Glancer extension", () => {
 
     await vscode.window.showTextDocument(simpleDocument);
     await vscode.window.showTextDocument(moderateDocument);
+    const stillStopped = await vscode.commands.executeCommand<ExtensionControllerState>(
+      EXTENSION_COMMANDS.testGetState,
+    );
+    assert.equal(stillStopped?.session, undefined);
+    assert.equal(stillStopped?.status.state, "stopped");
+
+    await vscode.commands.executeCommand(EXTENSION_COMMANDS.startServer);
     const restartedModerate = await waitForClientState(
       (state) => readySession(state) !== undefined && state.session !== undefined,
     );
@@ -108,6 +118,13 @@ interface ProjectUris {
   readonly testTargets: vscode.Uri;
   readonly simple: vscode.Uri;
   readonly moderate: vscode.Uri;
+}
+
+interface ExtensionControllerState {
+  readonly status: {
+    readonly state: string;
+  };
+  readonly session: unknown;
 }
 
 function rustGlancerExtension(): vscode.Extension<unknown> {

--- a/editors/code/unit/commands.test.ts
+++ b/editors/code/unit/commands.test.ts
@@ -8,4 +8,12 @@ describe("command identifiers", () => {
     assert.equal(EXTENSION_COMMANDS.reindexWorkspace, "rust-glancer.reindexWorkspace");
     assert.equal(SERVER_COMMANDS.reindexWorkspace, "rust-glancer.internal.reindexWorkspace");
   });
+
+  it("exposes the status menu lifecycle commands", () => {
+    assert.equal(EXTENSION_COMMANDS.showServerActions, "rust-glancer.showServerActions");
+    assert.equal(EXTENSION_COMMANDS.startServer, "rust-glancer.startServer");
+    assert.equal(EXTENSION_COMMANDS.restartServer, "rust-glancer.restartServer");
+    assert.equal(EXTENSION_COMMANDS.stopServer, "rust-glancer.stopServer");
+    assert.equal(EXTENSION_COMMANDS.openLogs, "rust-glancer.openLogs");
+  });
 });


### PR DESCRIPTION
Right now, clicking on server status in vs code bar resets the server, which is kind of counterintuitive. This PR makes it so that clicking opens menu with possible actions -- stop/start server, open logs, reindex workspace.