### PR TITLE
fix: Reduce memory fragmentation after initial indexing

### DIFF
--- a/crates/engine/project/src/project/build/mod.rs
+++ b/crates/engine/project/src/project/build/mod.rs
@@ -160,6 +160,9 @@ impl ProjectBuilder {
         ResidencyApplication::fresh(&mut state)
             .apply_profiled(&mut memory_sampler)
             .context("while attempting to apply package cache residency")?;
+        // Once offloading separates the small saved state from transient indexing data, move that
+        // retained state out of the allocator pages fragmented during the build.
+        state.compact_if_fully_offloaded();
         self.memory_hooks
             .purge(ProjectMemoryPurgePoint::AfterProjectBuild);
 

--- a/crates/engine/project/src/project/mod.rs
+++ b/crates/engine/project/src/project/mod.rs
@@ -97,6 +97,15 @@ impl Project {
         self.state.stats()
     }
 
+    /// Compact a project whose analysis phase payloads are all cache-backed.
+    ///
+    /// Returns `false` without cloning when any phase payload is still resident. Hosts should call
+    /// this only at an idle lifecycle boundary, then run their allocator cleanup hook after the
+    /// replaced state has been dropped.
+    pub fn compact_if_fully_offloaded(&mut self) -> bool {
+        self.state.compact_if_fully_offloaded()
+    }
+
     /// Iterates bounded macro-expansion-limit diagnostics from resident packages.
     pub fn macro_expansion_limit_reports(
         &self,

--- a/crates/engine/project/src/project/offloading.rs
+++ b/crates/engine/project/src/project/offloading.rs
@@ -259,8 +259,8 @@ impl<'a> ResidencyApplication<'a> {
     fn finish_offloading(&mut self, offloaded_packages: &PhasePackageSet) {
         if !offloaded_packages.is_empty() {
             // Offloading drops many strong `Name` handles from phase payloads. Prune the interner
-            // immediately so dead weak entries and their Arc control blocks do not pin allocator
-            // pages until a later rebuild happens to compact the project.
+            // immediately so dead weak entries and their Arc control blocks are not carried into
+            // the idle-boundary project compaction.
             Shrink::shrink_to_fit(&mut self.project.names);
 
             // File ids and paths remain resident as the source inventory. Line indexes are larger

--- a/crates/engine/project/src/project/split_indexing.rs
+++ b/crates/engine/project/src/project/split_indexing.rs
@@ -294,7 +294,16 @@ fn finish_with_sampler(
     sampler: &mut BuildMemorySampler,
 ) -> anyhow::Result<()> {
     let packages = finish_resident_with_sampler(state, sampler)?;
-    apply_finished_residency_with_sampler(state, &packages, sampler)
+    apply_finished_residency_with_sampler(state, &packages, sampler)?;
+
+    if state.compact_if_fully_offloaded() {
+        state
+            .memory_hooks
+            .purge(ProjectMemoryPurgePoint::AfterDeferredIndexingFinish);
+        record_project_checkpoint(state, sampler, "after deferred indexing compaction");
+    }
+
+    Ok(())
 }
 
 /// Make a query-shaped analysis surface available in the saved project before analysis runs.

--- a/crates/engine/project/src/project/state.rs
+++ b/crates/engine/project/src/project/state.rs
@@ -113,6 +113,28 @@ impl ProjectState {
         &mut self.parse
     }
 
+    /// Reallocate the small cache-backed state after indexing allocations have died.
+    ///
+    /// Fresh indexing interleaves long-lived project metadata with much larger transient phase
+    /// data. Purging releases wholly unused pages, but pages that contain even one retained value
+    /// stay active. Cloning only after every phase payload is offloaded gives the allocator a
+    /// densely allocated replacement, then dropping the old state makes its fragmented pages
+    /// purgeable.
+    pub(crate) fn compact_if_fully_offloaded(&mut self) -> bool {
+        let fully_offloaded = (0..self.parse.package_count()).all(|package_idx| {
+            let package = PackageSlot(package_idx);
+            self.def_map.resident_package(package).is_none()
+                && self.semantic_ir.resident_package(package).is_none()
+                && self.body_ir.package_is_offloaded(package)
+        });
+        if !fully_offloaded {
+            return false;
+        }
+
+        *self = self.clone();
+        true
+    }
+
     /// Starts a read transaction over resident and lazy-loadable offloaded packages.
     pub(crate) fn read_txn(&self) -> anyhow::Result<ProjectReadTxn<'_>> {
         ProjectReadTxn::new(self)

--- a/crates/engine/project/src/tests/mod.rs
+++ b/crates/engine/project/src/tests/mod.rs
@@ -1695,6 +1695,7 @@ pub fn answer() -> i32 {
             "after package payload offload",
             "after package offload cleanup",
             "after deferred indexing cleanup",
+            "after deferred indexing compaction",
         ],
         "deferred indexing should profile both lowering and the follow-up residency pass",
     );

--- a/crates/lsp/engine/src/engine/project/mod.rs
+++ b/crates/lsp/engine/src/engine/project/mod.rs
@@ -394,6 +394,17 @@ impl ProjectCoordinator {
             self.deferred_indexing_finish
                 .finish_returned(&mut self.project, generation, result);
 
+        // A successful finish is the first point where every package has completed its configured
+        // residency transition. If that offloaded every analysis payload, reallocate the small
+        // saved state now so the purge can release pages fragmented by the indexing build. The
+        // compaction method stays a no-op for policies that keep any payload resident.
+        if matches!(
+            &outcome,
+            Some(rg_lsp_proto::DeferredIndexingOutcome::Succeeded)
+        ) {
+            self.project.compact_if_fully_offloaded();
+        }
+
         // Reconciliation consumes the detached result on every path: merged, stale, failed, or
         // unknown. Purge only after that ownership boundary so the background project's Body IR
         // can actually leave allocator arenas instead of waiting for the next query cleanup.

--- a/crates/lsp/engine/src/engine/project/state.rs
+++ b/crates/lsp/engine/src/engine/project/state.rs
@@ -135,4 +135,11 @@ impl ProjectState {
             saved.release_query_memory();
         }
     }
+
+    /// Reallocate a fully cache-backed saved project after transient indexing state has died.
+    pub(super) fn compact_if_fully_offloaded(&mut self) -> bool {
+        self.saved
+            .as_mut()
+            .is_some_and(Project::compact_if_fully_offloaded)
+    }
 }


### PR DESCRIPTION
I have this annoying thing that full indexing fragments the memory quite a bit (the more peak rss is, the more fragmentation is there), so after full indexing rss even after puring is higher than after restart and using already existing index (e.g. something like 200mb vs 50mb on bevy).

I'm still fighting this issue, but this one small thing helps somewhat (but not fully).