### PR TITLE
fix: disable jemalloc on OpenBSD

### DIFF
--- a/crates/rust-glancer/Cargo.toml
+++ b/crates/rust-glancer/Cargo.toml
@@ -38,7 +38,7 @@ tower-lsp-server.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(not(any(target_env = "msvc", target_os = "openbsd")))'.dependencies]
 tikv-jemallocator = { workspace = true, optional = true }
 tikv-jemalloc-sys = { workspace = true, optional = true }
 

--- a/crates/rust-glancer/src/memory.rs
+++ b/crates/rust-glancer/src/memory.rs
@@ -11,7 +11,10 @@ use rg_project::{ProjectMemoryHooks, ProjectMemoryPurgePoint};
 
 const JEMALLOC_PURGE_AFTER_BUILD_ENV: &str = "RUST_GLANCER_PURGE_MEMORY_AFTER_BUILD";
 
-#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
+#[cfg(all(
+    feature = "jemalloc",
+    not(any(target_env = "msvc", target_os = "openbsd"))
+))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
@@ -59,7 +62,10 @@ impl ProjectMemoryHooks for ProjectProcessMemoryHooks {
 
 impl ProcessMemoryControl {
     pub(crate) fn allocator_name() -> &'static str {
-        if cfg!(all(feature = "jemalloc", not(target_env = "msvc"))) {
+        if cfg!(all(
+            feature = "jemalloc",
+            not(any(target_env = "msvc", target_os = "openbsd"))
+        )) {
             "jemalloc"
         } else {
             "system"
@@ -67,12 +73,18 @@ impl ProcessMemoryControl {
     }
 
     pub(crate) fn allocator_stats() -> Option<AllocatorStats> {
-        #[cfg(all(feature = "jemalloc-stats", not(target_env = "msvc")))]
+        #[cfg(all(
+            feature = "jemalloc-stats",
+            not(any(target_env = "msvc", target_os = "openbsd"))
+        ))]
         {
             jemalloc_stats::capture()
         }
 
-        #[cfg(not(all(feature = "jemalloc-stats", not(target_env = "msvc"))))]
+        #[cfg(not(all(
+            feature = "jemalloc-stats",
+            not(any(target_env = "msvc", target_os = "openbsd"))
+        )))]
         {
             None
         }
@@ -90,13 +102,19 @@ impl ProcessMemoryControl {
             return false;
         }
 
-        #[cfg(all(feature = "jemalloc-stats", not(target_env = "msvc")))]
+        #[cfg(all(
+            feature = "jemalloc-stats",
+            not(any(target_env = "msvc", target_os = "openbsd"))
+        ))]
         {
             jemalloc_stats::purge();
             true
         }
 
-        #[cfg(not(all(feature = "jemalloc-stats", not(target_env = "msvc"))))]
+        #[cfg(not(all(
+            feature = "jemalloc-stats",
+            not(any(target_env = "msvc", target_os = "openbsd"))
+        )))]
         {
             false
         }


### PR DESCRIPTION
jemalloc allocator (used via `tikv_jemallocator` crate) is not supported on OpenBSD => disable it via conditional compilation.

**Build OK on OpenBSD** current/amd64 with Rust version 1.98.0 with `no-default-features` (`jemalloc-stats` feature not compiled).

```sh
$ rustc -vV
rustc 1.98.0 (88d9e12ae 2026-08-18) (built from a source tarball)
binary: rustc
commit-hash: 88d9e12ae178fab0fb5cc050a94da85685d449ea
commit-date: 2026-08-18
host: x86_64-unknown-openbsd
release: 1.98.0
LLVM version: 22.1.8

$ cargo build -v --release --no-default-features

$ target/release/rust-glancer -h
An incomplete-by-design Rust LSP implementation

Usage: rust-glancer <COMMAND>

Commands:
  analyze      Analyze the crate or workspace package located at `path`
  compare-lsp  Compare rust-glancer LSP query behavior against another LSP server
  lsp          Start the language server over stdio
  help         Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```