### PR TITLE
fix: Do not include generated sources to defmap artifacts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ exclude = [
   "test_targets/bench_fixtures/synthetic_def_map_heavy",
   "test_targets/bench_fixtures/synthetic_body_heavy",
   "test_targets/bench_fixtures/rust-analyzer",
+  "reference"
 ]
 resolver = "3"
 

--- a/crates/engine/def-map/src/build/collect.rs
+++ b/crates/engine/def-map/src/build/collect.rs
@@ -126,14 +126,9 @@ impl ExternPreludeBuilder {
     }
 
     /// Freeze the two construction sources into the query-facing extern prelude.
-    pub(super) fn freeze(&self) -> HashMap<Name, ModuleRef> {
-        let mut roots = self.implicit_roots.clone();
-        roots.extend(
-            self.explicit_aliases
-                .iter()
-                .map(|(name, module)| (name.clone(), *module)),
-        );
-        roots
+    pub(super) fn freeze(mut self) -> HashMap<Name, ModuleRef> {
+        self.implicit_roots.extend(self.explicit_aliases);
+        self.implicit_roots
     }
 }
 

--- a/crates/engine/def-map/src/build/finalize.rs
+++ b/crates/engine/def-map/src/build/finalize.rs
@@ -16,10 +16,10 @@ use std::sync::Arc;
 use anyhow::Context as _;
 
 use crate::{
-    CrateData, CrateResolutionEnv, LocalDefData, LocalEnumVariantData, LocalEnumVariantEntry,
-    MacroDefinitionEnv, MacroDefinitionView, MacroExpansionLimitReport, ModuleData,
-    ModuleScopeBuilder, Namespace, PackageDefMaps as DefMapPackage, ScopeBindingProvenance,
-    ScopeEntryRef, ScopeResolutionEnv, ScopeResolver,
+    CrateData, CrateResolutionEnv, GeneratedItemStores, LocalDefData, LocalEnumVariantData,
+    LocalEnumVariantEntry, MacroDefinitionEnv, MacroDefinitionView, MacroExpansionLimitReport,
+    ModuleData, ModuleScopeBuilder, Namespace, PackageDefMaps as DefMapPackage,
+    ScopeBindingProvenance, ScopeEntryRef, ScopeResolutionEnv, ScopeResolver,
 };
 use rg_ir_model::{
     CrateRef, DefId, DefMapRef, LocalDefRef, LocalEnumVariantRef, ModuleId, ModuleRef, Path,
@@ -83,6 +83,10 @@ impl FinalizeCrateStates {
 
     pub(super) fn package(&self, package: PackageSlot) -> Option<&[CrateState]> {
         self.packages.get(package.0)?.as_deref()
+    }
+
+    pub(super) fn take_package(&mut self, package: PackageSlot) -> Option<Vec<CrateState>> {
+        self.packages.get_mut(package.0)?.take()
     }
 
     pub(super) fn iter_packages(&self) -> impl Iterator<Item = Option<&[CrateState]>> + '_ {
@@ -1032,38 +1036,49 @@ fn freeze_crate_scopes(
 }
 
 /// Freezes collected crate states into the package payload stored by `DefMapDb`.
-pub(super) fn freeze_package(package: &Package, package_states: &[CrateState]) -> DefMapPackage {
+pub(super) fn freeze_package(
+    package: &Package,
+    package_states: Vec<CrateState>,
+    generated_items: &mut GeneratedItemStores,
+) -> DefMapPackage {
     let package_name = package.package_name().to_string();
-    let macro_expansion_limits = package_states
-        .iter()
-        .filter_map(|state| {
-            let report = state.macro_expansion_limit.as_ref()?;
-            Some(MacroExpansionLimitReport {
+    let mut crates = Vec::with_capacity(package_states.len());
+    let mut macro_expansion_limits = Vec::new();
+
+    // Split each builder by moving its frozen DefMap into the package and its generated syntax into
+    // the transient phase output. This avoids both cloning the expansion arena and materializing an
+    // intermediate collection that the session would immediately consume.
+    for state in package_states {
+        if let Some(report) = &state.macro_expansion_limit {
+            macro_expansion_limits.push(MacroExpansionLimitReport {
                 package_name: package_name.clone(),
                 crate_name: state.crate_name.clone(),
                 groups: report.groups.clone(),
                 omitted_call_count: report.omitted_call_count,
-            })
-        })
-        .collect();
+            });
+        }
+
+        let crate_ref = state.crate_ref;
+        let (def_map, crate_generated_items) = state.def_map_builder.into_parts();
+        generated_items.insert(crate_ref, crate_generated_items);
+
+        // Persist both Cargo-provided roots and explicit crate-root aliases. Queries read this as a
+        // prelude rather than pretending any of these names are child modules of the crate root.
+        crates.push(CrateData::new(
+            state.cargo_target,
+            state.target_kind,
+            state.crate_name,
+            Some(state.root_module),
+            state.extern_prelude.freeze(),
+            state.prelude,
+            def_map,
+        ));
+    }
+
     DefMapPackage::new(
         package_name,
         package.edition(),
-        package_states.iter().map(freeze_crate_data).collect(),
+        crates,
         macro_expansion_limits,
-    )
-}
-
-fn freeze_crate_data(state: &CrateState) -> CrateData {
-    // Persist both Cargo-provided roots and explicit crate-root aliases. Queries read this as a
-    // prelude rather than pretending any of these names are child modules of the crate root.
-    CrateData::new(
-        state.cargo_target,
-        state.target_kind.clone(),
-        state.crate_name.clone(),
-        Some(state.root_module),
-        state.extern_prelude.freeze(),
-        state.prelude,
-        state.def_map_builder.clone().build(),
     )
 }

--- a/crates/engine/def-map/src/build/macro_source_files.rs
+++ b/crates/engine/def-map/src/build/macro_source_files.rs
@@ -22,15 +22,15 @@
 //! immutable DefMap.
 //!
 //! A “macro source file” is the real file at the far end of one of these edges. This keeps it
-//! distinct from [`crate::GeneratedSourceData`], which is the in-memory syntax produced by the
-//! macro itself.
+//! distinct from [`crate::source::GeneratedSourceData`], which is the in-memory syntax produced by
+//! the macro itself.
 
 use std::{collections::HashMap, sync::Arc};
 
 use rg_item_tree::IncludePathExpression;
 use rg_parse::{FileId, ModuleFileContext};
 
-use crate::{DefMapDb, PackageSlot};
+use crate::{DefMapBuildOutput, PackageSlot};
 
 /// One coalesced project-layer lookup requested while DefMap is collecting expanded syntax.
 ///
@@ -147,5 +147,5 @@ pub enum DefMapBuildProgress {
     /// Construction paused until the project loads or rejects these macro source files.
     NeedsMacroSourceFiles(Vec<MacroSourceFileRequest>),
     /// Every macro source-file request has been resolved and the immutable snapshot is complete.
-    Complete(DefMapDb),
+    Complete(DefMapBuildOutput),
 }

--- a/crates/engine/def-map/src/build/macros/generated_tree.rs
+++ b/crates/engine/def-map/src/build/macros/generated_tree.rs
@@ -7,7 +7,7 @@
 
 use anyhow::{Context as _, Result};
 
-use crate::GeneratedSourceData;
+use crate::source::GeneratedSourceData;
 use rg_arena::Arena;
 use rg_item_tree::{
     CfgExpr, ConstItem, Documentation, EnumItem, ExternBlockItem, ExternCrateItem, FromAst,

--- a/crates/engine/def-map/src/build/mod.rs
+++ b/crates/engine/def-map/src/build/mod.rs
@@ -17,10 +17,12 @@ mod implicit_roots;
 mod imports;
 mod macro_source_files;
 mod macros;
+mod output;
 mod session;
 
 pub(crate) use self::macro_source_files::{MacroSourceFileResolution, MacroSourceFileResolutions};
 pub use self::{
     macro_source_files::{DefMapBuildProgress, MacroSourceFileRequest},
+    output::{DefMapBuildOutput, GeneratedItemStores},
     session::DefMapBuildSession,
 };

--- a/crates/engine/def-map/src/build/output.rs
+++ b/crates/engine/def-map/src/build/output.rs
@@ -1,0 +1,49 @@
+//! Outputs of one selected-package DefMap construction session.
+//!
+//! Frozen DefMap data and generated declaration payloads deliberately have different lifetimes.
+//! The former becomes saved project state. The latter exists only long enough for Semantic IR to
+//! copy signatures and declaration facts, then it is dropped before Body IR or cache writing.
+
+use std::collections::HashMap;
+
+use rg_ir_model::CrateRef;
+use rg_std::MemorySize;
+
+use crate::{DefMapDb, GeneratedItemStore};
+
+/// Generated declaration stores for the crates rebuilt by one DefMap session.
+#[derive(Debug, Clone, Default, MemorySize)]
+pub struct GeneratedItemStores {
+    crates: HashMap<CrateRef, GeneratedItemStore>,
+}
+
+impl GeneratedItemStores {
+    pub fn crate_items(&self, crate_ref: CrateRef) -> Option<&GeneratedItemStore> {
+        self.crates.get(&crate_ref)
+    }
+
+    pub(crate) fn insert(&mut self, crate_ref: CrateRef, items: GeneratedItemStore) {
+        let previous = self.crates.insert(crate_ref, items);
+        debug_assert!(previous.is_none(), "generated crate items inserted twice");
+    }
+}
+
+/// Frozen DefMap replacement plus the transient declarations needed by the next build phase.
+#[derive(Debug, MemorySize)]
+pub struct DefMapBuildOutput {
+    def_map: DefMapDb,
+    generated_items: GeneratedItemStores,
+}
+
+impl DefMapBuildOutput {
+    pub(crate) fn new(def_map: DefMapDb, generated_items: GeneratedItemStores) -> Self {
+        Self {
+            def_map,
+            generated_items,
+        }
+    }
+
+    pub fn into_parts(self) -> (DefMapDb, GeneratedItemStores) {
+        (self.def_map, self.generated_items)
+    }
+}

--- a/crates/engine/def-map/src/build/session.rs
+++ b/crates/engine/def-map/src/build/session.rs
@@ -28,7 +28,10 @@ use super::{
     },
     implicit_roots::build_implicit_roots,
 };
-use crate::{DefMapBuildProgress, DefMapDb, DefMapReadTxn, MacroSourceFileRequest, PackageSlot};
+use crate::{
+    DefMapBuildOutput, DefMapBuildProgress, DefMapDb, DefMapReadTxn, GeneratedItemStores,
+    MacroSourceFileRequest, PackageSlot,
+};
 
 /// Selected-package construction retained across project-owned source capture waves.
 ///
@@ -244,21 +247,26 @@ impl DefMapBuildSession {
         }
 
         let mut next = self.baseline.clone();
+        let mut generated_items = GeneratedItemStores::default();
         for package_slot in self.packages.iter().copied() {
-            let package_states = self.crate_states.package(package_slot).with_context(|| {
-                format!(
-                    "while attempting to fetch completed crate states for package {}",
-                    package_slot.0
-                )
-            })?;
+            let package_states =
+                self.crate_states
+                    .take_package(package_slot)
+                    .with_context(|| {
+                        format!(
+                            "while attempting to fetch completed crate states for package {}",
+                            package_slot.0
+                        )
+                    })?;
             let parse_package = parse.package(package_slot.0).with_context(|| {
                 format!(
                     "while attempting to fetch parsed package {}",
                     package_slot.0
                 )
             })?;
+            let package = freeze_package(parse_package, package_states, &mut generated_items);
             next.mutator()
-                .replace_package(package_slot, freeze_package(parse_package, package_states))
+                .replace_package(package_slot, package)
                 .with_context(|| {
                     format!(
                         "while attempting to replace def-map package {}",
@@ -268,7 +276,10 @@ impl DefMapBuildSession {
         }
         next.mutator().compact_packages(&self.copy_compact_packages);
         self.complete = true;
-        Ok(DefMapBuildProgress::Complete(next))
+        Ok(DefMapBuildProgress::Complete(DefMapBuildOutput::new(
+            next,
+            generated_items,
+        )))
     }
 }
 

--- a/crates/engine/def-map/src/lib.rs
+++ b/crates/engine/def-map/src/lib.rs
@@ -19,7 +19,10 @@ pub use rg_workspace::PackageSlot;
 pub use rg_macro_runtime::MacroExpansionPerformancePreference;
 
 pub use self::{
-    build::{DefMapBuildProgress, DefMapBuildSession, MacroSourceFileRequest},
+    build::{
+        DefMapBuildOutput, DefMapBuildProgress, DefMapBuildSession, GeneratedItemStores,
+        MacroSourceFileRequest,
+    },
     import::{ImportBinding, ImportData, ImportKind, ImportPath},
     local::{
         LocalDefData, LocalDefKind, LocalEnumVariantData, LocalEnumVariantEntry, LocalImplData,
@@ -47,7 +50,7 @@ pub use self::{
         ScopeResolutionRef, Visibility,
     },
     source::{
-        BodyItemSourceRef, GeneratedItemRef, GeneratedSourceData, GeneratedSourceId, ItemSource,
+        BodyItemSourceRef, GeneratedItemRef, GeneratedItemStore, GeneratedSourceId, ItemSource,
         ItemSourceKind,
     },
     store::{

--- a/crates/engine/def-map/src/map.rs
+++ b/crates/engine/def-map/src/map.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     module::ModuleData,
     scope::{Namespace, NamespaceSet, PerNs, Visibility},
-    source::{GeneratedSourceData, GeneratedSourceId},
+    source::{GeneratedItemStore, GeneratedSourceData, GeneratedSourceId},
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, SchemaRead, SchemaWrite, MemorySize, Shrink)]
@@ -31,37 +31,35 @@ struct DefMapData {
     macro_definitions: HashMap<LocalDefId, MacroDefinitionData>,
     /// Sparse ownership for declarations collected through an extern block.
     foreign_blocks: HashMap<LocalDefId, ItemSource>,
-    /// Generated associated items keyed by the macro call they replace.
-    ///
-    /// For `impl User { methods!(); }`, the call source maps to its generated functions, types,
-    /// consts, and any retained nested macro calls.
-    associated_macro_expansions: HashMap<ItemSource, Vec<ItemSource>>,
     local_impls: Arena<LocalImplId, LocalImplData>,
     imports: Arena<ImportId, ImportData>,
-    generated_sources: Arena<GeneratedSourceId, GeneratedSourceData>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct DefMapBuilder {
     def_map: DefMap,
+    generated_items: GeneratedItemStore,
 }
 
 impl DefMapBuilder {
     pub fn new(crate_ref: CrateRef) -> Self {
         Self {
             def_map: DefMap::krate(crate_ref),
+            generated_items: GeneratedItemStore::default(),
         }
     }
 
     pub fn new_body(body_ref: BodyRef) -> Self {
         Self {
             def_map: DefMap::body(body_ref),
+            generated_items: GeneratedItemStore::default(),
         }
     }
 
     pub fn partial(&self) -> PartialDefMap<'_> {
         PartialDefMap {
             def_map: &self.def_map,
+            generated_items: &self.generated_items,
         }
     }
 
@@ -135,26 +133,24 @@ impl DefMapBuilder {
     }
 
     /// Records the generated items that replace one trait/impl macro invocation.
-    pub fn insert_associated_macro_expansion(
+    pub(crate) fn insert_associated_macro_expansion(
         &mut self,
         call: ItemSource,
         generated_items: Vec<ItemSource>,
     ) {
-        self.def_map
-            .data
-            .associated_macro_expansions
-            .insert(call, generated_items);
+        self.generated_items
+            .insert_associated_macro_expansion(call, generated_items);
     }
 
     pub fn alloc_import(&mut self, import: ImportData) -> ImportId {
         self.def_map.data.imports.alloc(import)
     }
 
-    pub fn alloc_generated_source(
+    pub(crate) fn alloc_generated_source(
         &mut self,
         generated_source: GeneratedSourceData,
     ) -> GeneratedSourceId {
-        self.def_map.data.generated_sources.alloc(generated_source)
+        self.generated_items.alloc_source(generated_source)
     }
 
     /// Resolves source-level visibility into the module identity used by scope lookup.
@@ -291,7 +287,16 @@ impl DefMapBuilder {
     }
 
     pub fn build(self) -> DefMap {
+        debug_assert!(
+            self.generated_items.is_empty(),
+            "generated crate declarations must be handed to Semantic IR",
+        );
         self.def_map
+    }
+
+    /// Separates frozen resolution data from the generated declarations consumed by Semantic IR.
+    pub(crate) fn into_parts(self) -> (DefMap, GeneratedItemStore) {
+        (self.def_map, self.generated_items)
     }
 }
 
@@ -302,6 +307,7 @@ impl DefMapBuilder {
 #[derive(Debug, Clone, Copy)]
 pub struct PartialDefMap<'a> {
     def_map: &'a DefMap,
+    generated_items: &'a GeneratedItemStore,
 }
 
 impl<'a> PartialDefMap<'a> {
@@ -348,12 +354,12 @@ impl<'a> PartialDefMap<'a> {
         self.def_map.imports_with_ids()
     }
 
-    /// Returns a retained generated source allocated so far during macro collection.
-    pub fn generated_source(
+    /// Returns a generated source allocated so far during macro collection.
+    pub(crate) fn generated_source(
         &self,
         generated_source: GeneratedSourceId,
     ) -> Option<&'a GeneratedSourceData> {
-        self.def_map.generated_source(generated_source)
+        self.generated_items.source(generated_source)
     }
 }
 
@@ -475,14 +481,6 @@ impl DefMap {
         self.data.foreign_blocks.get(&local_def).copied()
     }
 
-    /// Returns generated items that replace one associated-item macro call.
-    pub fn associated_macro_expansion(&self, call: ItemSource) -> Option<&[ItemSource]> {
-        self.data
-            .associated_macro_expansions
-            .get(&call)
-            .map(Vec::as_slice)
-    }
-
     /// Returns impl block data by id.
     pub fn local_impl(&self, local_impl: LocalImplId) -> Option<&LocalImplData> {
         self.data.local_impls.get(local_impl)
@@ -507,19 +505,6 @@ impl DefMap {
 
     pub fn import(&self, import: ImportId) -> Option<&ImportData> {
         self.data.imports.get(import)
-    }
-
-    /// Returns one retained generated source by id.
-    pub fn generated_source(
-        &self,
-        generated_source: GeneratedSourceId,
-    ) -> Option<&GeneratedSourceData> {
-        self.data.generated_sources.get(generated_source)
-    }
-
-    /// Returns all retained generated sources in stable generated-source-id order.
-    pub fn generated_sources(&self) -> &[GeneratedSourceData] {
-        self.data.generated_sources.as_slice()
     }
 
     pub fn imports_with_ids(&self) -> impl Iterator<Item = (ImportId, &ImportData)> {

--- a/crates/engine/def-map/src/source.rs
+++ b/crates/engine/def-map/src/source.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use rg_arena::Arena;
 use rg_item_tree::{ItemNode, ItemTreeId, ItemTreeRef};
 use rg_parse::{FileId, Span};
@@ -6,7 +8,10 @@ use wincode::{SchemaRead, SchemaWrite};
 
 use rg_ir_model::BodyRef;
 
-/// Stable identifier of one retained macro expansion payload.
+/// Stable identifier of one macro expansion payload produced during crate construction.
+///
+/// The id remains part of compact source provenance after the payload is discarded, just as an
+/// [`ItemTreeRef`] remains useful after the transient ItemTree phase has finished.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SchemaRead, SchemaWrite, MemorySize, Shrink)]
 #[memsize(leaf)]
 #[shrink(leaf)]
@@ -22,7 +27,10 @@ impl rg_arena::ArenaId for GeneratedSourceId {
     }
 }
 
-/// Crate-local reference to one generated item payload.
+/// Crate-local source identity for one generated item.
+///
+/// During Semantic IR lowering this addresses [`GeneratedItemStore`]. Later phases retain it only
+/// as provenance and use the semantic declaration data copied during lowering.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SchemaRead, SchemaWrite, MemorySize, Shrink)]
 #[shrink(leaf)]
 pub struct GeneratedItemRef {
@@ -118,18 +126,71 @@ impl From<ItemTreeRef> for ItemSource {
     }
 }
 
-/// Item-tree-shaped payload retained for one declarative macro expansion.
-#[derive(Debug, Clone, PartialEq, Eq, SchemaRead, SchemaWrite, MemorySize, Shrink)]
-pub struct GeneratedSourceData {
-    pub origin_file_id: FileId,
-    pub origin_span: Span,
-    pub origin_source: ItemTreeRef,
-    pub top_level: Vec<ItemTreeId>,
-    pub items: Arena<ItemTreeId, ItemNode>,
+/// Item-tree-shaped payload produced for one declarative macro expansion.
+///
+/// This data is intentionally construction-only. DefMap uses it while collecting scopes and
+/// Semantic IR copies the declaration facts it needs before the surrounding store is dropped.
+#[derive(Debug, Clone, PartialEq, Eq, MemorySize, Shrink)]
+pub(crate) struct GeneratedSourceData {
+    pub(crate) origin_file_id: FileId,
+    pub(crate) origin_span: Span,
+    pub(crate) origin_source: ItemTreeRef,
+    pub(crate) top_level: Vec<ItemTreeId>,
+    pub(crate) items: Arena<ItemTreeId, ItemNode>,
 }
 
 impl GeneratedSourceData {
-    pub fn item(&self, item_id: ItemTreeId) -> Option<&ItemNode> {
+    pub(crate) fn item(&self, item_id: ItemTreeId) -> Option<&ItemNode> {
         self.items.get(item_id)
+    }
+}
+
+/// Crate-local generated declarations retained only between DefMap and Semantic IR construction.
+///
+/// Macro expansion needs item-tree-shaped declarations while it discovers modules, definitions,
+/// imports, and associated items. Those declarations are substantially larger than the resulting
+/// semantic facts, so this store travels beside the frozen DefMap instead of becoming part of it.
+#[derive(Debug, Clone, Default, MemorySize, Shrink)]
+pub struct GeneratedItemStore {
+    sources: Arena<GeneratedSourceId, GeneratedSourceData>,
+    /// Generated associated items keyed by the macro call they replace.
+    ///
+    /// For `impl User { methods!(); }`, the call source maps to its generated functions, types,
+    /// consts, and any retained nested macro calls.
+    associated_macro_expansions: HashMap<ItemSource, Vec<ItemSource>>,
+}
+
+impl GeneratedItemStore {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.sources.is_empty() && self.associated_macro_expansions.is_empty()
+    }
+
+    pub(crate) fn alloc_source(&mut self, source: GeneratedSourceData) -> GeneratedSourceId {
+        self.sources.alloc(source)
+    }
+
+    pub(crate) fn source(&self, source: GeneratedSourceId) -> Option<&GeneratedSourceData> {
+        self.sources.get(source)
+    }
+
+    pub(crate) fn insert_associated_macro_expansion(
+        &mut self,
+        call: ItemSource,
+        generated_items: Vec<ItemSource>,
+    ) {
+        self.associated_macro_expansions
+            .insert(call, generated_items);
+    }
+
+    pub fn item(&self, item: GeneratedItemRef) -> Option<&ItemNode> {
+        self.sources
+            .get(item.source)
+            .and_then(|source| source.item(item.item))
+    }
+
+    pub fn associated_macro_expansion(&self, call: ItemSource) -> Option<&[ItemSource]> {
+        self.associated_macro_expansions
+            .get(&call)
+            .map(Vec::as_slice)
     }
 }

--- a/crates/engine/def-map/src/testonly.rs
+++ b/crates/engine/def-map/src/testonly.rs
@@ -6,12 +6,16 @@ use rg_text::PackageNameInterners;
 use rg_workspace::{SysrootSources, TargetKind, WorkspaceLoweringConfig, WorkspaceMetadata};
 use test_fixture::{CrateFixture, fixture_crate};
 
-use crate::{DefMapBuildProgress, DefMapDb, MacroExpansionPerformancePreference, PackageSlot};
+use crate::{
+    DefMapBuildOutput, DefMapBuildProgress, DefMapDb, GeneratedItemStores,
+    MacroExpansionPerformancePreference, PackageSlot,
+};
 
 /// End-to-end fixture for tests that need name resolution data.
 pub struct DefMapFixture {
     item_tree: ItemTreeFixture,
     def_map: DefMapDb,
+    generated_items: GeneratedItemStores,
     workspace: WorkspaceMetadata,
 }
 
@@ -56,16 +60,18 @@ impl DefMapFixture {
     pub fn build_from_crate(fixture: CrateFixture, workspace: WorkspaceMetadata) -> Self {
         let item_tree = ItemTreeFixture::build_from_crate(fixture, &workspace);
         let mut names = PackageNameInterners::new(item_tree.parse_db().package_count());
-        let def_map = build_source_closed_def_map(
+        let output = build_source_closed_def_map(
             &workspace,
             item_tree.parse_db(),
             item_tree.item_tree_db(),
             &mut names,
         );
+        let (def_map, generated_items) = output.into_parts();
 
         Self {
             item_tree,
             def_map,
+            generated_items,
             workspace,
         }
     }
@@ -80,6 +86,10 @@ impl DefMapFixture {
 
     pub fn def_map_db(&self) -> &DefMapDb {
         &self.def_map
+    }
+
+    pub fn take_generated_items(&mut self) -> GeneratedItemStores {
+        std::mem::take(&mut self.generated_items)
     }
 
     pub fn workspace(&self) -> &WorkspaceMetadata {
@@ -154,7 +164,7 @@ pub(crate) fn build_source_closed_def_map(
     parse: &ParseDb,
     item_tree: &ItemTreeDb,
     names: &mut PackageNameInterners,
-) -> DefMapDb {
+) -> DefMapBuildOutput {
     let package_count = parse.package_count();
     let baseline = DefMapDb::all_offloaded(package_count);
     let baseline_read = baseline.read_txn(crate::DefMapLoader::resident_only(
@@ -178,7 +188,7 @@ pub(crate) fn build_source_closed_def_map(
         .advance(&baseline_read, parse, item_tree, names)
         .expect("fixture DefMap session should advance")
     {
-        DefMapBuildProgress::Complete(def_map) => def_map,
+        DefMapBuildProgress::Complete(output) => output,
         DefMapBuildProgress::NeedsMacroSourceFiles(requests) => panic!(
             "fixture requested {} macro source file(s); use an rg_project fixture for source-discovery behavior",
             requests.len(),

--- a/crates/engine/def-map/src/tests/rebuild.rs
+++ b/crates/engine/def-map/src/tests/rebuild.rs
@@ -203,9 +203,10 @@ impl RebuildFixture {
             WorkspaceMetadata::for_tests(fixture.metadata(), WorkspaceLoweringConfig::default())
                 .expect("fixture workspace metadata should build");
         let (parse, item_tree, mut names) = Self::build_item_tree(&workspace);
-        let mut old = crate::testonly::build_source_closed_def_map(
+        let output = crate::testonly::build_source_closed_def_map(
             &workspace, &parse, &item_tree, &mut names,
         );
+        let (mut old, _) = output.into_parts();
         let clean_package = package_slot(&parse, clean_package);
         let clean_payload = Arc::new(
             old.resident_package(clean_package)
@@ -251,7 +252,7 @@ impl RebuildFixture {
             .advance(&old_read, &parse, &item_tree, &mut names)
             .expect("fixture DefMap package rebuild session should advance")
         {
-            DefMapBuildProgress::Complete(def_map) => def_map,
+            DefMapBuildProgress::Complete(output) => output.into_parts().0,
             DefMapBuildProgress::NeedsMacroSourceFiles(requests) => panic!(
                 "source-closed rebuild fixture requested {} macro source file(s)",
                 requests.len(),

--- a/crates/engine/project/benches/analysis_pipeline.rs
+++ b/crates/engine/project/benches/analysis_pipeline.rs
@@ -77,11 +77,16 @@ fn semantic_ir_db(bencher: Bencher<'_, '_>, target: BenchTarget) {
             (
                 fixture.item_tree_after_def_map.clone(),
                 fixture.def_map.clone(),
+                fixture.generated_items.clone(),
             )
         })
-        .bench_local_values(|(item_tree, def_map)| {
-            let semantic_ir = rg_project::bench_support::build_semantic_ir(&item_tree, &def_map)
-                .expect("semantic IR should build");
+        .bench_local_values(|(item_tree, def_map, generated_items)| {
+            let semantic_ir = rg_project::bench_support::build_semantic_ir(
+                &item_tree,
+                &def_map,
+                &generated_items,
+            )
+            .expect("semantic IR should build");
             black_box_drop(semantic_ir);
         });
 }

--- a/crates/engine/project/benches/shared/mod.rs
+++ b/crates/engine/project/benches/shared/mod.rs
@@ -7,7 +7,7 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
-use rg_def_map::DefMapDb;
+use rg_def_map::{DefMapDb, GeneratedItemStores};
 use rg_item_tree::ItemTreeDb;
 use rg_parse::ParseDb;
 use rg_semantic_ir::SemanticIrDb;
@@ -189,6 +189,7 @@ pub(crate) struct BenchFixture {
     pub(crate) item_tree_after_def_map: ItemTreeDb,
     pub(crate) names_after_semantic_ir: PackageNameInterners,
     pub(crate) def_map: DefMapDb,
+    pub(crate) generated_items: GeneratedItemStores,
     pub(crate) semantic_ir: SemanticIrDb,
     pub(crate) source_files: usize,
     pub(crate) source_bytes: u64,
@@ -253,18 +254,22 @@ impl BenchFixture {
         // measured DefMap iterations, while downstream benchmarks receive the completed state.
         let mut parse_after_def_map = parse_before_def_map.clone();
         let mut item_tree_after_def_map = item_tree_before_def_map.clone();
-        let def_map = rg_project::bench_support::build_def_map(
+        let def_map_output = rg_project::bench_support::build_def_map(
             &workspace,
             &mut parse_after_def_map,
             &mut item_tree_after_def_map,
             &mut names,
         )
         .unwrap_or_else(|error| panic!("{target} def map should build: {error}"));
+        let (def_map, generated_items) = def_map_output.into_parts();
         let def_map_imports = def_map.stats(&workspace).import_count;
 
-        let semantic_ir =
-            rg_project::bench_support::build_semantic_ir(&item_tree_after_def_map, &def_map)
-                .unwrap_or_else(|error| panic!("{target} semantic IR should build: {error}"));
+        let semantic_ir = rg_project::bench_support::build_semantic_ir(
+            &item_tree_after_def_map,
+            &def_map,
+            &generated_items,
+        )
+        .unwrap_or_else(|error| panic!("{target} semantic IR should build: {error}"));
         let semantic_stats = semantic_ir.stats();
         let semantic_items = semantic_stats.struct_count
             + semantic_stats.union_count
@@ -296,6 +301,7 @@ impl BenchFixture {
             item_tree_after_def_map,
             names_after_semantic_ir,
             def_map,
+            generated_items,
             semantic_ir,
             source_files,
             source_bytes,

--- a/crates/engine/project/src/cache/codec/mod.rs
+++ b/crates/engine/project/src/cache/codec/mod.rs
@@ -57,7 +57,7 @@ pub(crate) const PACKAGE_CACHE_CONTAINER_PREFIX_BYTES: usize = 8 + 4 * size_of::
 // Protect one independently decoded allocation from corrupted lengths while leaving ample room for
 // realistic crate/file payloads. Aggregate phase sections may exceed this because they are nested
 // lazy containers; their manifests and individual shards remain bounded.
-const PACKAGE_CACHE_DECODE_LIMIT_BYTES: usize = 256 * 1024 * 1024;
+const PACKAGE_CACHE_DECODE_LIMIT_BYTES: usize = 384 * 1024 * 1024;
 
 type PackageCacheWincodeConfig =
     wincode::config::Configuration<true, PACKAGE_CACHE_DECODE_LIMIT_BYTES>;

--- a/crates/engine/project/src/project/bench_support.rs
+++ b/crates/engine/project/src/project/bench_support.rs
@@ -6,7 +6,7 @@
 
 use anyhow::Context as _;
 use rg_body_ir::{BodyIrBuildPolicy, BodyIrDb, PackageBodiesCoverage};
-use rg_def_map::{DefMapDb, PackageSlot};
+use rg_def_map::{DefMapBuildOutput, DefMapDb, GeneratedItemStores, PackageSlot};
 use rg_item_tree::ItemTreeDb;
 use rg_package_store::{PackageEntry, PackageStore, PackageSubset};
 use rg_parse::ParseDb;
@@ -34,7 +34,7 @@ pub fn build_def_map(
     parse: &mut ParseDb,
     item_tree: &mut ItemTreeDb,
     names: &mut PackageNameInterners,
-) -> anyhow::Result<DefMapDb> {
+) -> anyhow::Result<DefMapBuildOutput> {
     let source_packages =
         PhasePackageSet::from_packages((0..parse.package_count()).map(PackageSlot).collect());
     let baseline = DefMapDb::all_offloaded(parse.package_count());
@@ -65,6 +65,7 @@ pub fn build_def_map(
 pub fn build_semantic_ir(
     item_tree: &ItemTreeDb,
     def_map: &DefMapDb,
+    generated_items: &GeneratedItemStores,
 ) -> anyhow::Result<SemanticIrDb> {
     let package_count = def_map.package_count();
     let packages = (0..package_count).map(PackageSlot).collect::<Vec<_>>();
@@ -75,6 +76,7 @@ pub fn build_semantic_ir(
         .build_packages(
             item_tree,
             def_map,
+            generated_items,
             &packages,
             rg_def_map::DefMapLoader::resident_only("all-source benchmark DefMap"),
             rg_semantic_ir::SemanticIrLoader::resident_only("all-source benchmark Semantic IR"),

--- a/crates/engine/project/src/project/build/batch_indexing/mod.rs
+++ b/crates/engine/project/src/project/build/batch_indexing/mod.rs
@@ -194,7 +194,7 @@ pub(super) fn build(
 
         let baseline_def_map_txn =
             def_map.read_txn_for_subset(loaders.def_map.clone(), &rebuild_subset);
-        let next_def_map = macro_source_files::build_packages(
+        let next_def_map_output = macro_source_files::build_packages(
             &def_map,
             &baseline_def_map_txn,
             workspace,
@@ -208,6 +208,7 @@ pub(super) fn build(
         )
         .context("while attempting to build package batch def maps")?;
         drop(baseline_def_map_txn);
+        let (next_def_map, generated_items) = next_def_map_output.into_parts();
         def_map = next_def_map;
 
         macro_expansion_limit_summary.extend(MacroExpansionLimitBuildSummary::capture(
@@ -252,6 +253,7 @@ pub(super) fn build(
             def_map,
             semantic_ir,
             body_ir,
+            generated_items,
         )
         .checkpoint(sampler, metric::DEF_MAP_MEMORY, &def_map);
 
@@ -259,6 +261,7 @@ pub(super) fn build(
             .build_packages(
                 &item_tree,
                 &def_map,
+                &generated_items,
                 batch.as_slice(),
                 loaders.def_map.clone(),
                 loaders.semantic_ir.clone(),
@@ -274,9 +277,11 @@ pub(super) fn build(
             def_map,
             semantic_ir,
             body_ir,
+            generated_items,
         )
         .checkpoint(sampler, metric::SEMANTIC_IR_MEMORY, &semantic_ir);
 
+        drop(generated_items);
         drop(item_tree);
         checkpoint_memory!(
             names,

--- a/crates/engine/project/src/project/build/checkpoint_memory.rs
+++ b/crates/engine/project/src/project/build/checkpoint_memory.rs
@@ -1,5 +1,5 @@
 use rg_body_ir::BodyIrDb;
-use rg_def_map::DefMapDb;
+use rg_def_map::{DefMapDb, GeneratedItemStores};
 use rg_item_tree::ItemTreeDb;
 use rg_parse::ParseDb;
 use rg_profile::{MemorySnapshotMetric, ProfileMemoryRecord, ProfileMemorySnapshot};
@@ -26,6 +26,7 @@ pub(super) struct CheckpointMemory<'a> {
     item_tree: Option<&'a ItemTreeDb>,
     source_fingerprints: Option<&'a Vec<Option<Fingerprint>>>,
     def_map: Option<&'a DefMapDb>,
+    generated_items: Option<&'a GeneratedItemStores>,
     semantic_ir: Option<&'a SemanticIrDb>,
     body_ir: Option<&'a BodyIrDb>,
 }
@@ -52,6 +53,7 @@ impl<'a> CheckpointMemory<'a> {
             item_tree: self.item_tree.or(other.item_tree),
             source_fingerprints: self.source_fingerprints.or(other.source_fingerprints),
             def_map: self.def_map.or(other.def_map),
+            generated_items: self.generated_items.or(other.generated_items),
             semantic_ir: self.semantic_ir.or(other.semantic_ir),
             body_ir: self.body_ir.or(other.body_ir),
         }
@@ -136,6 +138,8 @@ impl<'a> CheckpointMemory<'a> {
                 .and_then(|value| sampler.measure_retained(value)),
             self.def_map
                 .and_then(|value| sampler.measure_retained(value)),
+            self.generated_items
+                .and_then(|value| sampler.measure_retained(value)),
             self.semantic_ir
                 .and_then(|value| sampler.measure_retained(value)),
             self.body_ir
@@ -150,6 +154,7 @@ impl<'a> CheckpointMemory<'a> {
         Self::record_memory_value(recorder, "item_tree", self.item_tree);
         Self::record_memory_value(recorder, "source_fingerprints", self.source_fingerprints);
         Self::record_memory_value(recorder, "def_map", self.def_map);
+        Self::record_memory_value(recorder, "generated_items", self.generated_items);
         Self::record_memory_value(recorder, "semantic_ir", self.semantic_ir);
         Self::record_memory_value(recorder, "body_ir", self.body_ir);
     }
@@ -183,5 +188,6 @@ impl_checkpoint_memory_from!(PackageBuildPlan, build_plan);
 impl_checkpoint_memory_from!(ItemTreeDb, item_tree);
 impl_checkpoint_memory_from!(Vec<Option<Fingerprint>>, source_fingerprints);
 impl_checkpoint_memory_from!(DefMapDb, def_map);
+impl_checkpoint_memory_from!(GeneratedItemStores, generated_items);
 impl_checkpoint_memory_from!(SemanticIrDb, semantic_ir);
 impl_checkpoint_memory_from!(BodyIrDb, body_ir);

--- a/crates/engine/project/src/project/build/phases.rs
+++ b/crates/engine/project/src/project/build/phases.rs
@@ -171,7 +171,7 @@ pub(super) fn build(
     // mutable while the coordinator answers complete batches and resumes the same DefMap
     // construction state. The coordinator preserves the semantic difference: modules receive a
     // child context, while includes keep the call-site module context.
-    let def_map = macro_source_files::build_packages(
+    let def_map_output = macro_source_files::build_packages(
         &baseline_def_map,
         &baseline_def_map_txn,
         workspace,
@@ -184,6 +184,7 @@ pub(super) fn build(
         memory_hooks,
     )
     .context("while attempting to build def map db")?;
+    let (def_map, generated_items) = def_map_output.into_parts();
     drop(baseline_def_map_txn);
 
     // The fixed point has finalized every source-built package file table, including files reached
@@ -226,6 +227,7 @@ pub(super) fn build(
         item_tree,
         source_fingerprints,
         def_map,
+        generated_items,
     );
     memory.checkpoint(sampler, metric::DEF_MAP_MEMORY, &def_map);
 
@@ -238,6 +240,7 @@ pub(super) fn build(
         .build_packages(
             &item_tree,
             &def_map,
+            &generated_items,
             build_plan.source_packages.as_slice(),
             loaders.def_map.clone(),
             loaders.semantic_ir.clone(),
@@ -251,16 +254,18 @@ pub(super) fn build(
         item_tree,
         source_fingerprints,
         def_map,
+        generated_items,
         semantic_ir,
     );
     memory.checkpoint(sampler, metric::SEMANTIC_IR_MEMORY, &semantic_ir);
 
     // ----------------------------
-    // 8. Drop transient item trees
+    // 8. Drop transient declaration stores
     // ----------------------------
-    // ItemTree is a lowering input, not retained project state. Cache-backed builds only populate
-    // packages that missed the artifact cache, but even that sparse tree should disappear before
-    // body lowering so retained-memory checkpoints stay focused on durable phase state.
+    // ItemTree and macro-generated item stores are lowering inputs, not retained project state.
+    // Cache-backed builds only populate packages that missed the artifact cache, but even those
+    // sparse stores should disappear before body lowering and cache writing.
+    drop(generated_items);
     drop(item_tree);
     let memory = checkpoint_memory!(
         names,

--- a/crates/engine/project/src/project/macro_source_files.rs
+++ b/crates/engine/project/src/project/macro_source_files.rs
@@ -27,7 +27,7 @@ use std::{
 
 use anyhow::Context as _;
 use rg_def_map::{
-    DefMapBuildProgress, DefMapBuildSession, DefMapDb, DefMapReadTxn,
+    DefMapBuildOutput, DefMapBuildProgress, DefMapBuildSession, DefMapDb, DefMapReadTxn,
     MacroExpansionPerformancePreference, MacroSourceFileRequest, PackageSlot,
 };
 use rg_item_tree::ItemTreeDb;
@@ -65,7 +65,7 @@ pub(super) fn build_packages(
     names: &mut PackageNameInterners,
     performance_preference: MacroExpansionPerformancePreference,
     memory_hooks: &dyn ProjectMemoryHooks,
-) -> anyhow::Result<DefMapDb> {
+) -> anyhow::Result<DefMapBuildOutput> {
     // Different requests can resolve to the same package-local file, even in different waves. The
     // session coalesces request identity; this separate map coalesces captured path identity.
     let mut captured_files_by_path = HashMap::<(PackageSlot, PathBuf), FileId>::new();
@@ -99,7 +99,7 @@ pub(super) fn build_packages(
 
         let requests = match progress {
             DefMapBuildProgress::NeedsMacroSourceFiles(requests) => requests,
-            DefMapBuildProgress::Complete(db) => return Ok(db),
+            DefMapBuildProgress::Complete(output) => return Ok(output),
         };
         metric::MACRO_SOURCE_FILE_DISCOVERY_WAVES.inc();
         metric::MACRO_SOURCE_FILE_REQUESTS.add(requests.len().try_into().unwrap_or(u64::MAX));

--- a/crates/engine/project/src/project/update/package.rs
+++ b/crates/engine/project/src/project/update/package.rs
@@ -93,7 +93,7 @@ fn try_rebuild_packages(state: &mut ProjectState, packages: &[PackageSlot]) -> a
     let copy_compact_packages = state
         .split_indexing_mode
         .copy_compact_packages(&state.package_residency, packages.as_slice());
-    let def_map = macro_source_files::build_packages(
+    let def_map_output = macro_source_files::build_packages(
         &state.def_map,
         &old_def_map_txn,
         &state.workspace,
@@ -106,6 +106,7 @@ fn try_rebuild_packages(state: &mut ProjectState, packages: &[PackageSlot]) -> a
         memory_hooks.as_ref(),
     )
     .context("while attempting to rebuild affected def-map packages")?;
+    let (def_map, generated_items) = def_map_output.into_parts();
     drop(old_def_map_txn);
     // The selected package file tables now contain only sources reachable from this rebuild,
     // including late macro source files and excluding generated paths that disappeared.
@@ -117,12 +118,14 @@ fn try_rebuild_packages(state: &mut ProjectState, packages: &[PackageSlot]) -> a
         .build_packages(
             &item_tree,
             &def_map,
+            &generated_items,
             packages.as_slice(),
             loaders.def_map.clone(),
             loaders.semantic_ir.clone(),
             &rebuild_subset,
         )
         .context("while attempting to rebuild affected semantic IR packages")?;
+    drop(generated_items);
 
     let body_builder = state
         .body_ir

--- a/crates/engine/semantic-ir/src/build/lower.rs
+++ b/crates/engine/semantic-ir/src/build/lower.rs
@@ -7,7 +7,10 @@
 use anyhow::Context as _;
 
 use crate::ItemStore;
-use rg_def_map::{DefMapDb, DefMapReadTxn, ItemSource, ItemSourceKind, PackageSlot};
+use rg_def_map::{
+    DefMapDb, DefMapReadTxn, GeneratedItemStore, GeneratedItemStores, ItemSource, ItemSourceKind,
+    PackageSlot,
+};
 use rg_ir_model::{CrateId, CrateRef};
 use rg_item_tree::{ItemNode, ItemTreeDb, Package as ItemTreePackage};
 
@@ -16,6 +19,7 @@ use crate::{ItemStoreLowerer, ItemStoreSourceReader, PackageIr};
 pub(super) fn build_package(
     item_tree: &ItemTreeDb,
     def_map: &DefMapDb,
+    generated_items: &GeneratedItemStores,
     package: PackageSlot,
 ) -> anyhow::Result<PackageIr> {
     let def_map_package = def_map
@@ -32,12 +36,20 @@ pub(super) fn build_package(
             package,
             crate_id: CrateId(crate_idx),
         };
+        let crate_generated_items = generated_items.crate_items(crate_ref).with_context(|| {
+            format!("while attempting to fetch generated declarations for crate {crate_idx}")
+        })?;
         crates.push(
-            CrateLowering::new(item_tree_package, crate_ref, &def_map_txn)
-                .lower()
-                .with_context(|| {
-                    format!("while attempting to lower semantic IR for crate {crate_idx}")
-                })?,
+            CrateLowering::new(
+                item_tree_package,
+                crate_generated_items,
+                crate_ref,
+                &def_map_txn,
+            )
+            .lower()
+            .with_context(|| {
+                format!("while attempting to lower semantic IR for crate {crate_idx}")
+            })?,
         );
     }
 
@@ -46,6 +58,7 @@ pub(super) fn build_package(
 
 struct CrateLowering<'a, 'db> {
     item_tree: &'a ItemTreePackage,
+    generated_items: &'a GeneratedItemStore,
     crate_ref: CrateRef,
     def_map_txn: &'a DefMapReadTxn<'db>,
 }
@@ -53,11 +66,13 @@ struct CrateLowering<'a, 'db> {
 impl<'a, 'db> CrateLowering<'a, 'db> {
     fn new(
         item_tree: &'a ItemTreePackage,
+        generated_items: &'a GeneratedItemStore,
         crate_ref: CrateRef,
         def_map_txn: &'a DefMapReadTxn<'db>,
     ) -> Self {
         Self {
             item_tree,
+            generated_items,
             crate_ref,
             def_map_txn,
         }
@@ -91,25 +106,20 @@ impl<'a, 'db> ItemStoreSourceReader<'a> for CrateLowering<'a, 'db> {
                     )
                 })?
             }
-            ItemSourceKind::Generated(item_ref) => self
-                .def_map_txn
-                .def_map(self.crate_ref)
-                .with_context(|| {
-                    format!(
-                        "while attempting to fetch generated item {:?} from generated source {:?}",
-                        item_ref.item, item_ref.source
-                    )
-                })?
-                .and_then(|def_map| def_map.generated_source(item_ref.source))
-                .and_then(|source| source.item(item_ref.item))
-                .with_context(|| {
+            ItemSourceKind::Generated(item_ref) => {
+                self.generated_items.item(item_ref).with_context(|| {
                     format!(
                         "while attempting to find generated item {:?} from generated source {:?}",
                         item_ref.item, item_ref.source
                     )
-                })?,
+                })?
+            }
             ItemSourceKind::Body(_) => anyhow::bail!("Body is not supported"),
         };
         Ok(item)
+    }
+
+    fn associated_macro_expansion(&self, source: ItemSource) -> Option<&[ItemSource]> {
+        self.generated_items.associated_macro_expansion(source)
     }
 }

--- a/crates/engine/semantic-ir/src/build/mod.rs
+++ b/crates/engine/semantic-ir/src/build/mod.rs
@@ -5,7 +5,7 @@ mod lower;
 
 use anyhow::Context as _;
 
-use rg_def_map::{DefMapLoader, PackageSlot};
+use rg_def_map::{DefMapLoader, GeneratedItemStores, PackageSlot};
 use rg_package_store::PackageSubset;
 
 use crate::{SemanticIrDb, SemanticIrLoader};
@@ -20,6 +20,7 @@ impl SemanticIrDb {
         &'db self,
         item_tree: &'db rg_item_tree::ItemTreeDb,
         def_map: &'db rg_def_map::DefMapDb,
+        generated_items: &'db GeneratedItemStores,
         packages: &'db [PackageSlot],
         def_map_loader: DefMapLoader<'db>,
         semantic_ir_loader: SemanticIrLoader<'db>,
@@ -31,7 +32,7 @@ impl SemanticIrDb {
         {
             let mut mutator = next.mutator();
             for package in &packages {
-                let rebuilt = lower::build_package(item_tree, def_map, *package)?;
+                let rebuilt = lower::build_package(item_tree, def_map, generated_items, *package)?;
                 mutator
                     .replace_package(*package, rebuilt)
                     .with_context(|| {

--- a/crates/engine/semantic-ir/src/item/lowering.rs
+++ b/crates/engine/semantic-ir/src/item/lowering.rs
@@ -22,6 +22,10 @@ use rg_text::Name;
 /// Reads item-tree-shaped payloads from the storage layer named by an `ItemSource`.
 pub trait ItemStoreSourceReader<'item> {
     fn item(&self, source: ItemSource) -> anyhow::Result<&'item ItemNode>;
+
+    fn associated_macro_expansion(&self, _source: ItemSource) -> Option<&[ItemSource]> {
+        None
+    }
 }
 
 /// Lowers a collected DefMap into item-shaped semantic storage.
@@ -288,9 +292,9 @@ where
                 return;
             }
             // Clone the small sparse replacement list before recursing so mutable semantic
-            // lowering does not retain a borrow into the DefMap that owns the expansion graph.
+            // lowering does not retain a borrow into the transient expansion store.
             let generated_items = self
-                .def_map
+                .reader
                 .associated_macro_expansion(source)
                 .unwrap_or_default()
                 .to_vec();

--- a/crates/engine/semantic-ir/src/testonly.rs
+++ b/crates/engine/semantic-ir/src/testonly.rs
@@ -26,24 +26,29 @@ impl SemanticIrFixture {
         Self::build_from_def_map(DefMapFixture::build_with_fake_sysroot(fixture))
     }
 
-    pub fn build_from_def_map(def_map: DefMapFixture) -> Self {
+    pub fn build_from_def_map(mut def_map: DefMapFixture) -> Self {
         let package_count = def_map.parse_db().package_count();
         let packages = (0..package_count).map(PackageSlot).collect::<Vec<_>>();
         let subset = PackageSubset::all(package_count);
         let baseline = SemanticIrDb::from_package_store(PackageStore::all_offloaded(package_count));
+        let generated_items = def_map.take_generated_items();
 
         // Fixtures build every package from source, but still enter Semantic IR through the same
-        // baseline-replacement path used by project construction.
+        // baseline-replacement path used by project construction. The generated declaration store
+        // is dropped immediately afterward so every downstream fixture query exercises the same
+        // retained-state boundary as a real project.
         let semantic_ir = baseline
             .build_packages(
                 def_map.item_tree_db(),
                 def_map.def_map_db(),
+                &generated_items,
                 &packages,
                 rg_def_map::DefMapLoader::resident_only("fixture DefMap"),
                 crate::SemanticIrLoader::resident_only("fixture Semantic IR"),
                 &subset,
             )
             .expect("fixture semantic ir db should build");
+        drop(generated_items);
 
         Self {
             def_map,


### PR DESCRIPTION
When testing a project which had a lot of macro-generated code, I've stumbled upon a bug where defmap got too big to deserialize. Turns out, we were storing generated sources in defmap artifacts even though they're basically not used -- we only need them for semantic indexing and that's it.

This PR fixes that, and also increases the shard size limit from 256mb to 384mb (even without generated sources the defmap shard was 225mb already, so it's dangerously close).

