### PR TITLE
fix: More candidate filtering and cancellation

### DIFF
--- a/crates/engine/ir-view/src/db.rs
+++ b/crates/engine/ir-view/src/db.rs
@@ -19,7 +19,7 @@ use rg_semantic_ir::{
     CrateItemQuery, ItemLookupQuery, ItemLookupQueryCache, ItemStore, ItemStoreSource,
     TypePathContext, TypePathResolution,
 };
-use rg_std::UniqueVec;
+use rg_std::{CancellationToken, UniqueVec};
 use rg_text::RustEdition;
 use rg_ty::{ItemPathQuery, TraitSelectionSession, TypeLoweringAnchor, TypePathResolver};
 
@@ -82,6 +82,7 @@ impl<'db> IndexedViewDb<'db> {
         current_source: &rg_parse::CurrentSource,
         associations: &rg_parse::DeclarationAssociationIndex,
         selection: CurrentBodySelection,
+        cancellation: CancellationToken,
         synthetic_body_ref: impl FnMut() -> anyhow::Result<rg_ir_model::BodyRef>,
         checkpoint: impl FnMut(CurrentBodyBuildCheckpoint) -> anyhow::Result<()>,
     ) -> anyhow::Result<CurrentBodyBuildOutcome> {
@@ -97,7 +98,10 @@ impl<'db> IndexedViewDb<'db> {
             self.item_lookup_cache.clone(),
             selection,
         )
-        .with_trait_selection(self.trait_selection(crate_ref))
+        .with_trait_selection(
+            self.trait_selection(crate_ref)
+                .with_cancellation(cancellation),
+        )
         .build(synthetic_body_ref, checkpoint)
     }
 

--- a/crates/engine/project/src/project/snapshot.rs
+++ b/crates/engine/project/src/project/snapshot.rs
@@ -160,6 +160,7 @@ impl<'a> ProjectSnapshot<'a> {
         targets: &[(CrateRef, FileId)],
         source: &str,
         offset: u32,
+        cancellation: rg_std::CancellationToken,
         checkpoint: impl FnMut(CurrentBodyBuildCheckpoint) -> anyhow::Result<()>,
     ) -> anyhow::Result<(Analysis<'a>, CurrentBodyBuildSummary)> {
         let source = self.prepare_current_source(targets, source)?;
@@ -167,6 +168,7 @@ impl<'a> ProjectSnapshot<'a> {
             targets,
             source,
             CurrentBodySelection::AtOffset(offset),
+            cancellation,
             checkpoint,
         )
     }
@@ -248,6 +250,7 @@ impl<'a> ProjectSnapshot<'a> {
         targets: &[(CrateRef, FileId)],
         current_source_view: CurrentSourceView,
         selection: CurrentBodySelection,
+        cancellation: rg_std::CancellationToken,
         mut checkpoint: impl FnMut(CurrentBodyBuildCheckpoint) -> anyhow::Result<()>,
     ) -> anyhow::Result<(Analysis<'a>, CurrentBodyBuildSummary)> {
         let current_source = current_source_view.source();
@@ -319,6 +322,7 @@ impl<'a> ProjectSnapshot<'a> {
                 current_source,
                 associations,
                 selection,
+                cancellation.clone(),
                 &mut synthetic_body_ref,
                 &mut checkpoint,
             )?;

--- a/crates/engine/project/src/tests/current_body.rs
+++ b/crates/engine/project/src/tests/current_body.rs
@@ -1,5 +1,6 @@
 use rg_analysis::{CompletionItem, CompletionQuery, CompletionSource, SavedSourceRelationship};
 use rg_body_ir::{CurrentBodyBuildCheckpoint, CurrentBodySelection, CurrentBodyUnavailable};
+use rg_std::CancellationToken;
 use test_fixture::testonly::MarkedText;
 
 use crate::{
@@ -111,7 +112,13 @@ pub fn inspect() {
         let completion_source = CompletionSource::new(current.text(), offset)
             .expect("current source should produce completion syntax");
         let (analysis, summary) = snapshot
-            .analysis_for_current_bodies_at_offset(&targets, current.text(), offset, |_| Ok(()))
+            .analysis_for_current_bodies_at_offset(
+                &targets,
+                current.text(),
+                offset,
+                CancellationToken::new(),
+                |_| Ok(()),
+            )
             .expect("early-start current body should build");
         let labels = targets
             .iter()
@@ -500,7 +507,13 @@ fn current_declaration_headers_use_request_local_semantics() {
     let snapshot = fixture.fixture.project().snapshot();
     let targets = fixture.targets();
     let (analysis, _) = snapshot
-        .analysis_for_current_bodies_at_offset(&targets, current.text(), offset, |_| Ok(()))
+        .analysis_for_current_bodies_at_offset(
+            &targets,
+            current.text(),
+            offset,
+            CancellationToken::new(),
+            |_| Ok(()),
+        )
         .expect("current impl header should build");
     for (crate_ref, file) in targets {
         let hover = analysis
@@ -920,6 +933,7 @@ pub fn inspect() {
             &targets,
             current.text(),
             offset,
+            CancellationToken::new(),
             |checkpoint| {
                 visited.push(checkpoint);
                 if checkpoint == stop_at {
@@ -991,6 +1005,7 @@ pub fn unselected() {
             &targets,
             source,
             CurrentBodySelection::AtOffset(offset),
+            CancellationToken::new(),
             |_| Ok(()),
         )
         .expect("selected exact body should build");
@@ -1079,6 +1094,7 @@ fn unfinished
             &targets,
             source,
             CurrentBodySelection::IntersectingRange(range),
+            CancellationToken::new(),
             |_| Ok(()),
         )
         .expect("current bodies in the requested range should build");
@@ -1140,6 +1156,7 @@ pub fn inspect() {
             &targets,
             source,
             CurrentBodySelection::IntersectingRange(range),
+            CancellationToken::new(),
             |_| Ok(()),
         )
         .expect("ambiguous current roots should fail closed without breaking the request");
@@ -1193,7 +1210,13 @@ impl CurrentBodyFixture {
         let completion_source = CompletionSource::new(current.text(), offset)
             .expect("current body should produce completion syntax");
         let (analysis, summary) = snapshot
-            .analysis_for_current_bodies_at_offset(&targets, current.text(), offset, |_| Ok(()))
+            .analysis_for_current_bodies_at_offset(
+                &targets,
+                current.text(),
+                offset,
+                CancellationToken::new(),
+                |_| Ok(()),
+            )
             .expect("current body should build against the saved fixture");
         let mut items = Vec::new();
 
@@ -1223,9 +1246,13 @@ impl CurrentBodyFixture {
             .expect("current-body marker should fit into u32");
         let before = self.fixture.project().stats();
         let (analysis, summary) = snapshot
-            .analysis_for_current_bodies_at_offset(&self.targets(), current.text(), offset, |_| {
-                Ok(())
-            })
+            .analysis_for_current_bodies_at_offset(
+                &self.targets(),
+                current.text(),
+                offset,
+                CancellationToken::new(),
+                |_| Ok(()),
+            )
             .expect("current-body build summary should be returned");
         drop(analysis);
         assert_eq!(

--- a/crates/engine/ty/src/profile.rs
+++ b/crates/engine/ty/src/profile.rs
@@ -46,6 +46,9 @@ declare_metrics! {
             counter NATIVE_ASSOC_PROJECTIONS = "native.assoc_projections";
             /// Candidate projection probes stopped at an actual recursive impl cycle.
             counter NATIVE_CANDIDATE_CYCLES = "native.candidate_cycles";
+            /// Impl identities rejected before header loading because their crate cannot own an
+            /// implementation for the fully known trait application.
+            counter NATIVE_CANDIDATE_COHERENCE_SKIPS = "native.candidate_coherence_skips";
             /// Candidate projections left for one combined solver goal because the matching impl
             /// had predicates of its own.
             counter NATIVE_CANDIDATE_PREDICATE_DECLINES = "native.candidate_predicate_declines";

--- a/crates/engine/ty/src/trait_selection/candidate.rs
+++ b/crates/engine/ty/src/trait_selection/candidate.rs
@@ -53,7 +53,26 @@ impl TraitCandidate {
         // lookup cannot drift into different candidate universes.
         let self_ty = table.resolve_root_var(goal.self_ty());
         let trait_ref = goal.trait_ref();
-        session.trait_impl_candidates_for_ty(item_lookup, trait_ref, &self_ty)
+        let candidates = session.trait_impl_candidates_for_ty(item_lookup, trait_ref, &self_ty)?;
+        let Some(possible_origins) = goal.possible_impl_origins(table) else {
+            return Some(candidates);
+        };
+
+        // An unresolved impl header still belongs to one known crate. Coherence can reject that
+        // identity before we restore and lower its declaration when the crate owns neither the
+        // trait nor any nominal type participating in this concrete application.
+        let candidate_count = candidates.len();
+        let candidates = candidates
+            .into_iter()
+            .filter(|candidate| {
+                possible_origins.contains(&candidate.impl_ref.origin.origin_crate())
+            })
+            .collect::<UniqueVec<_>>();
+        let skipped = candidate_count - candidates.len();
+        if skipped > 0 {
+            crate::profile::metric::NATIVE_CANDIDATE_COHERENCE_SKIPS.add(skipped as u64);
+        }
+        Some(candidates)
     }
 
     /// Match one plausible impl against the goal using an isolated trial table.

--- a/crates/engine/ty/src/trait_selection/mod.rs
+++ b/crates/engine/ty/src/trait_selection/mod.rs
@@ -20,9 +20,11 @@ mod projection;
 mod session;
 
 use rg_def_map::DefMapSource;
-use rg_ir_model::{GenericDefRef, ImplRef, TraitApplicability, TraitImplRef, TypeAliasRef};
+use rg_ir_model::{
+    CrateRef, GenericDefRef, ImplRef, TraitApplicability, TraitImplRef, TypeAliasRef,
+};
 use rg_semantic_ir::ItemStoreSource;
-use rg_std::ExpectedUnique;
+use rg_std::{ExpectedUnique, UniqueVec};
 
 use self::candidate::TraitCandidate;
 use self::chalk::ChalkOutcome;
@@ -103,6 +105,64 @@ impl TraitGoal {
     /// constraints, such as `<Self as Iterator>::Item = User`.
     pub fn iter_positional_args(&self) -> impl Iterator<Item = &GenericArg> {
         self.application.args.iter().skip(1)
+    }
+
+    /// Return the crates that can possibly own an impl for this fully known application.
+    ///
+    /// Rust coherence requires the impl crate to own either the trait or a local type participating
+    /// in its application. We deliberately recurse through every known type constructor instead of
+    /// reproducing the exact fundamental-type rules here. That over-approximation may retain an
+    /// impossible candidate, but it cannot discard a legal one.
+    ///
+    /// An unresolved type disables the optimization. In particular, a later solution for a type
+    /// parameter or projection can introduce an owning crate that is not visible in the current
+    /// shape, so filtering that goal would turn incomplete inference into a negative proof.
+    fn possible_impl_origins(&self, table: &InferenceTable) -> Option<UniqueVec<CrateRef>> {
+        let mut origins = UniqueVec::new();
+        origins.push(self.trait_ref().origin.origin_crate());
+
+        for arg in &self.application.args {
+            let GenericArg::Type(ty) = arg else {
+                continue;
+            };
+            let ty = table.canonicalize(ty);
+            if !Self::collect_possible_impl_origins(&ty, &mut origins) {
+                return None;
+            }
+        }
+        Some(origins)
+    }
+
+    fn collect_possible_impl_origins(ty: &Ty, origins: &mut UniqueVec<CrateRef>) -> bool {
+        match ty {
+            Ty::Unit | Ty::Never | Ty::Primitive(_) => true,
+            Ty::Tuple(fields) => fields
+                .iter()
+                .all(|field| Self::collect_possible_impl_origins(field, origins)),
+            Ty::Array { inner, .. }
+            | Ty::Slice(inner)
+            | Ty::Reference { inner, .. }
+            | Ty::RawPointer { inner, .. } => Self::collect_possible_impl_origins(inner, origins),
+            Ty::FnPointer { params, ret } => {
+                params
+                    .iter()
+                    .all(|param| Self::collect_possible_impl_origins(param, origins))
+                    && Self::collect_possible_impl_origins(ret, origins)
+            }
+            Ty::Adt(adt) => {
+                origins.push(adt.def.origin.origin_crate());
+                adt.args.iter().all(|arg| match arg {
+                    GenericArg::Type(ty) => Self::collect_possible_impl_origins(ty, origins),
+                    GenericArg::Lifetime(_) | GenericArg::Const(_) => true,
+                })
+            }
+            Ty::Param(_)
+            | Ty::Alias(_)
+            | Ty::Closure(_)
+            | Ty::FnDef(_)
+            | Ty::Unknown
+            | Ty::InferVar { .. } => false,
+        }
     }
 
     pub(crate) fn without_assoc_type_constraints(&self) -> Self {

--- a/crates/engine/ty/src/trait_selection/session.rs
+++ b/crates/engine/ty/src/trait_selection/session.rs
@@ -31,7 +31,7 @@ use rg_ir_model::{
     TraitImplRef, TypeAliasRef,
 };
 use rg_semantic_ir::{CrateItemQuery, ItemLookupQuery, ItemStoreSource};
-use rg_std::{ExpectedUnique, UniqueVec};
+use rg_std::{CancellationToken, ExpectedUnique, UniqueVec};
 
 use super::chalk::{ChalkInferenceCache, ChalkOutcome, ChalkTraitSolver};
 use super::declaration_cache::{OpaqueBounds, TraitSelectionDeclarationCache};
@@ -325,6 +325,7 @@ impl TraitSelectionInferenceScope {
 pub struct TraitSelectionSession {
     shared: Arc<TraitSelectionShared>,
     inference_scope: Arc<TraitSelectionInferenceScope>,
+    cancellation: CancellationToken,
 }
 
 impl fmt::Debug for TraitSelectionSession {
@@ -358,7 +359,18 @@ impl TraitSelectionSession {
             inference_scope: Arc::new(TraitSelectionInferenceScope::new(
                 TraitWorkTracker::unbounded(),
             )),
+            cancellation: CancellationToken::new(),
         }
+    }
+
+    /// Stop expensive semantic expansion when the owning request is no longer observable.
+    ///
+    /// Cancellation is fail-soft inside trait selection: the in-progress query receives an
+    /// exhausted result, then its ordinary request checkpoint turns that into the cancellation
+    /// outcome owned by the caller. Saved builds keep the uncancelled default token.
+    pub fn with_cancellation(mut self, cancellation: CancellationToken) -> Self {
+        self.cancellation = cancellation;
+        self
     }
 
     pub fn use_site(&self) -> CrateRef {
@@ -377,6 +389,7 @@ impl TraitSelectionSession {
             inference_scope: Arc::new(TraitSelectionInferenceScope::new(
                 TraitWorkTracker::unbounded(),
             )),
+            cancellation: self.cancellation.clone(),
         }
     }
 
@@ -395,6 +408,7 @@ impl TraitSelectionSession {
             inference_scope: Arc::new(TraitSelectionInferenceScope::new(
                 TraitWorkTracker::for_body(body, BODY_TRAIT_WORK_LIMIT),
             )),
+            cancellation: self.cancellation.clone(),
         }
     }
 
@@ -403,6 +417,12 @@ impl TraitSelectionSession {
     /// Standalone editor queries remain governed by their operation-specific limits. Body-owned
     /// sessions additionally share one aggregate allowance across fixed-point rounds and clones.
     pub(super) fn consume_work(&self, kind: TraitWorkKind, amount: usize) -> bool {
+        // Program construction and solver search call this at their bounded work quanta. Returning
+        // an exhausted semantic result lets the surrounding current-body pipeline reach its
+        // request checkpoint without completing a now-useless transitive program.
+        if self.cancellation.is_cancelled() {
+            return false;
+        }
         if self.inference_scope.work.consume(amount) {
             return true;
         }

--- a/crates/engine/ty/src/trait_selection/tests/mod.rs
+++ b/crates/engine/ty/src/trait_selection/tests/mod.rs
@@ -3,13 +3,16 @@ mod utils;
 use std::fmt::Write as _;
 
 use expect_test::expect;
-use rg_ir_model::{TypeAliasId, TypeAliasRef};
+use rg_ir_model::{
+    CrateId, CrateRef, DefMapRef, PackageSlot, StructId, TypeAliasId, TypeAliasRef, TypeDefRef,
+};
 use rg_semantic_ir::CrateItemQuery;
+use rg_std::CancellationToken;
 
 use self::utils::*;
-use super::TraitSelectionSession;
 use super::chalk::{ChalkInferenceCache, ChalkOutcome, ChalkTraitSolver};
 use super::projection::NORMALIZATION_DEPTH_LIMIT;
+use super::{TraitCandidate, TraitGoal, TraitSelectionSession};
 use crate::inference::InferenceTable;
 use crate::{
     AdtTy, AliasTy, Clause, GenericArg, ImplMatcher, ItemPathQuery, ProjectionTy, Ty, TyContext,
@@ -144,6 +147,183 @@ fn projection_cycle_identity_ignores_fresh_inference_slots() {
 }
 
 #[test]
+fn possible_impl_origins_include_nested_known_type_owners() {
+    let outer_crate = CrateRef {
+        package: PackageSlot(1),
+        crate_id: CrateId(0),
+    };
+    let nested_sibling_crate = CrateRef {
+        package: PackageSlot(1),
+        crate_id: CrateId(1),
+    };
+    let positional_crate = CrateRef {
+        package: PackageSlot(2),
+        crate_id: CrateId(0),
+    };
+    let nested_ty = Ty::adt(AdtTy::bare(TypeDefRef::new_struct(
+        DefMapRef::Crate(nested_sibling_crate),
+        StructId(0),
+    )));
+    let mut table = InferenceTable::new();
+    let nested_slot = table.new_type_var();
+    assert!(table.unify(&nested_slot, &nested_ty));
+
+    let outer_ty = Ty::adt(AdtTy {
+        def: TypeDefRef::new_struct(DefMapRef::Crate(outer_crate), StructId(0)),
+        args: vec![GenericArg::Type(Box::new(nested_slot))].into(),
+    });
+    let positional_ty = Ty::Tuple(vec![Ty::adt(AdtTy::bare(TypeDefRef::new_struct(
+        DefMapRef::Crate(positional_crate),
+        StructId(0),
+    )))]);
+    let mut goal = TraitGoal::new(
+        outer_ty,
+        trait_ref(0),
+        vec![GenericArg::Type(Box::new(positional_ty))],
+    );
+    // Output constraints do not participate in orphan ownership.
+    goal.associated_types.push(crate::AssocTypeBinding {
+        associated_ty: TypeAliasRef {
+            origin: origin(),
+            id: TypeAliasId(0),
+        },
+        ty: Ty::Unknown,
+    });
+
+    let origins = goal
+        .possible_impl_origins(&table)
+        .expect("solved nested inference should leave a fully known application");
+    let expected_origins = [
+        target(),
+        outer_crate,
+        nested_sibling_crate,
+        positional_crate,
+    ];
+    assert_eq!(origins.len(), expected_origins.len());
+    for expected_origin in expected_origins {
+        assert!(
+            origins.contains(&expected_origin),
+            "expected owner collection to include {expected_origin:?}"
+        );
+    }
+}
+
+#[test]
+fn possible_impl_origins_decline_unresolved_applications() {
+    let outer_ty = |argument| {
+        Ty::adt(AdtTy {
+            def: type_def(0),
+            args: vec![GenericArg::Type(Box::new(argument))].into(),
+        })
+    };
+    let mut table = InferenceTable::new();
+    let unresolved_slot = table.new_type_var();
+    let unresolved_projection = Ty::Alias(AliasTy::Projection(ProjectionTy {
+        associated_ty: TypeAliasRef {
+            origin: origin(),
+            id: TypeAliasId(0),
+        },
+        args: Vec::new().into(),
+    }));
+
+    for (argument, error) in [
+        (Ty::Unknown, "semantic unknown"),
+        (unresolved_slot, "inference variable"),
+        (unresolved_projection, "associated projection"),
+    ] {
+        let goal = TraitGoal::new(outer_ty(argument), trait_ref(0), Vec::new());
+        assert!(
+            goal.possible_impl_origins(&table).is_none(),
+            "{error} should disable coherence filtering"
+        );
+    }
+}
+
+#[test]
+fn coherence_filter_retains_unknown_impl_from_goal_type_owner() {
+    let dependency = CrateRef {
+        package: PackageSlot(1),
+        crate_id: CrateId(0),
+    };
+    let fixture = TraitSelectionFixture::new(
+        r#"
+            traits
+              trait#0 Iterator
+        "#,
+    )
+    .with_unknown_self_impl_dependency(dependency, "Iterator");
+    let goal = TraitGoal::new(
+        Ty::adt(AdtTy::bare(TypeDefRef::new_struct(
+            DefMapRef::Crate(dependency),
+            StructId(0),
+        ))),
+        fixture
+            .trait_ref_by_name("Iterator")
+            .expect("fixture should contain Iterator"),
+        Vec::new(),
+    );
+    let lookup = fixture.lookup_query();
+    let candidates = TraitCandidate::plausible_impls(
+        &lookup,
+        &TraitSelectionSession::new(fixture.target),
+        &goal,
+        &InferenceTable::new(),
+    )
+    .expect("candidate lookup should not exhaust work");
+
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(
+        candidates
+            .as_one()
+            .map(|candidate| candidate.impl_ref.origin),
+        Some(DefMapRef::Crate(dependency))
+    );
+}
+
+#[test]
+fn concrete_projection_skips_unrelated_unknown_impl_origin() {
+    let profile = rg_profile::test_support::ProfileTest::start(
+        crate::profile_descriptors(),
+        "ty.trait_selection.chalk",
+    );
+    let fixture = TraitSelectionFixture::new(
+        r#"
+            traits
+              trait#0 Iterator
+            structs
+              struct#0 Wrapper<T>
+              struct#1 User
+            type aliases
+              type#0 trait#0::Item
+        "#,
+    )
+    .with_unknown_self_impl_dependency(
+        CrateRef {
+            package: PackageSlot(1),
+            crate_id: CrateId(0),
+        },
+        "Iterator",
+    );
+    let parsed = TraitSelectionQueryParser::new(&fixture)
+        .parse_assoc_goal("<Wrapper<User> as Iterator>::Item");
+
+    let result = query(&fixture)
+        .normalize_assoc_type(&parsed.goal, &parsed.assoc_name, &parsed.table)
+        .expect("concrete negative projection should complete natively");
+    assert!(result.is_none());
+
+    let profile = profile.finish();
+    profile.assert_counter(crate::profile::metric::NATIVE_CANDIDATE_COHERENCE_SKIPS, 1);
+    assert_eq!(
+        profile
+            .inner()
+            .counter(crate::profile::metric::PROGRAM_BUILDS.path()),
+        None,
+        "coherence-excluded candidates should not construct a Chalk program",
+    );
+}
+
+#[test]
 fn body_work_exhaustion_keeps_candidate_search_incomplete() {
     let profile = rg_profile::test_support::ProfileTest::start(
         crate::profile_descriptors(),
@@ -227,6 +407,55 @@ fn program_work_exhaustion_does_not_publish_a_partial_extension() {
             &parsed.table,
         )
         .expect("retry after bounded Chalk discovery should not fail");
+    assert!(matches!(outcome, ChalkOutcome::Proven(_)));
+}
+
+#[test]
+fn cancelled_trait_program_stops_without_publishing_a_partial_extension() {
+    let fixture = TraitSelectionFixture::new(
+        r#"
+            traits
+              trait#0 Marker
+            structs
+              struct#0 User
+            impls
+              impl#0 impl Marker for User
+        "#,
+    );
+    let parsed = TraitSelectionQueryParser::new(&fixture).parse_goal("User: Marker");
+    let clauses = [Clause::Implemented(parsed.goal.application)];
+    let item_paths = ItemPathQuery::new(&fixture, &fixture);
+    let crate_items = CrateItemQuery::new(&fixture, &fixture, fixture.target);
+    let solver = ChalkTraitSolver::new();
+    let lookup_query = fixture.lookup_query();
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+
+    let cancelled = TraitSelectionSession::new(fixture.target).with_cancellation(cancellation);
+    let outcome = solver
+        .prove_clauses(
+            &item_paths,
+            &crate_items,
+            &lookup_query,
+            &cancelled,
+            &ChalkInferenceCache::new(),
+            &clauses,
+            &parsed.table,
+        )
+        .expect("cancelled Chalk query should fail soft");
+    assert!(matches!(outcome, ChalkOutcome::Exhausted));
+
+    let outcome = solver
+        .prove_clauses(
+            &item_paths,
+            &crate_items,
+            &lookup_query,
+            &TraitSelectionSession::new(fixture.target),
+            &ChalkInferenceCache::new(),
+            &clauses,
+            &parsed.table,
+        )
+        .expect("retry after cancelled Chalk discovery should not fail");
     assert!(matches!(outcome, ChalkOutcome::Proven(_)));
 }
 

--- a/crates/engine/ty/src/trait_selection/tests/utils.rs
+++ b/crates/engine/ty/src/trait_selection/tests/utils.rs
@@ -24,7 +24,7 @@ use rg_semantic_ir::{
     ItemLookupIndex, ItemLookupIndexSource, ItemLookupQuery, ItemStore, ItemStoreBuilder,
     ItemStoreSource, StructData, TraitData, TypeAliasData, TypeAliasSignature,
 };
-use rg_std::ExpectedUnique;
+use rg_std::{ExpectedUnique, UniqueVec};
 use rg_text::Name;
 
 use super::super::{
@@ -42,10 +42,18 @@ pub(super) struct TraitSelectionFixture {
     pub(super) store: ItemStore,
     pub(super) target: CrateRef,
     lookup_index: ItemLookupIndex,
+    dependencies: Vec<TraitSelectionDependency>,
     type_names: HashMap<TypeDefRef, String>,
     trait_names: HashMap<TraitDefRef, String>,
     type_refs_by_name: HashMap<String, TypeDefRef>,
     trait_refs_by_name: HashMap<String, TraitDefRef>,
+}
+
+struct TraitSelectionDependency {
+    target: CrateRef,
+    def_map: DefMap,
+    store: ItemStore,
+    lookup_index: ItemLookupIndex,
 }
 
 impl TraitSelectionFixture {
@@ -54,6 +62,12 @@ impl TraitSelectionFixture {
     // snapshots and reviews.
     pub(super) fn new(source: &str) -> Self {
         TraitSelectionFixtureParser::new(source).parse()
+    }
+
+    fn dependency(&self, crate_ref: CrateRef) -> Option<&TraitSelectionDependency> {
+        self.dependencies
+            .iter()
+            .find(|dependency| dependency.target == crate_ref)
     }
 
     pub(super) fn lookup_query(&self) -> ItemLookupQuery<'_> {
@@ -86,6 +100,95 @@ impl TraitSelectionFixture {
             })
         })
     }
+
+    /// Add one dependency impl whose macro-generated `Self` type could not be resolved.
+    ///
+    /// The declaration still names a trait from the main fixture. This mirrors dependencies such
+    /// as `metal`, whose impl is legal for a local generated type but enters the conservative
+    /// receiver fallback lane because that type's spelling is unavailable to semantic lowering.
+    pub(super) fn with_unknown_self_impl_dependency(
+        mut self,
+        dependency: CrateRef,
+        trait_name: &str,
+    ) -> Self {
+        let dependency_origin = DefMapRef::Crate(dependency);
+        let trait_ref = self
+            .trait_ref_by_name(trait_name)
+            .unwrap_or_else(|| panic!("fixture should contain trait `{trait_name}`"));
+        let trait_data = self
+            .store
+            .trait_data(trait_ref.id)
+            .expect("fixture trait should have declaration data");
+
+        // Let the dependency's written trait path resolve to the declaration in the main fixture.
+        // The impl's self type deliberately stays source-level unknown.
+        let mut def_map_builder = DefMapBuilder::new(dependency);
+        let root_module = def_map_builder.alloc_module(ModuleData {
+            name: None,
+            name_span: None,
+            docs: None,
+            user_facing_attrs: Default::default(),
+            visibility: Visibility::Public,
+            parent: None,
+            children: Vec::new(),
+            local_defs: Vec::new(),
+            impls: vec![LocalImplId(0)],
+            imports: Vec::new(),
+            unresolved_imports: Vec::new(),
+            scope: Default::default(),
+            origin: ModuleOrigin::Root { file_id: FileId(1) },
+        });
+        let dependency_module = ModuleRef {
+            origin: dependency_origin,
+            module: root_module,
+        };
+        let mut scope = ModuleScopeBuilder::default();
+        scope.insert_binding(
+            &trait_data.name,
+            Namespace::Types,
+            ScopeBinding::new(
+                DefId::Local(trait_data.local_def),
+                Visibility::Public,
+                ScopeBindingProvenance::Direct,
+            ),
+        );
+        def_map_builder
+            .module_mut(root_module)
+            .expect("dependency root module should exist")
+            .scope = scope.freeze();
+
+        let mut store_builder = ItemStoreBuilder::new(dependency_origin, 0);
+        store_builder.impls.alloc(ImplData {
+            local_impl: LocalImplRef {
+                origin: dependency_origin,
+                local_impl: LocalImplId(0),
+            },
+            source: ItemSource {
+                file_id: FileId(1),
+                kind: ItemSourceKind::Generated(GeneratedItemRef {
+                    source: GeneratedSourceId(1),
+                    item: ItemTreeId(0),
+                }),
+            },
+            owner: dependency_module,
+            generics: GenericParams::default(),
+            trait_ref: Some(path_ty(trait_name, Vec::new())),
+            self_ty: TypeRef::unknown_from_text("macro generated self type"),
+            resolved_self_ty: ExpectedUnique::new(),
+            resolved_trait_ref: resolved_one(trait_ref),
+            items: Vec::new(),
+            is_unsafe: false,
+        });
+        let store = store_builder.build();
+        let lookup_index = ItemLookupIndex::build_from_store(&store, &HashMap::new());
+        self.dependencies.push(TraitSelectionDependency {
+            target: dependency,
+            def_map: def_map_builder.build(),
+            store,
+            lookup_index,
+        });
+        self
+    }
 }
 
 impl From<&str> for TraitSelectionFixture {
@@ -98,7 +201,13 @@ impl DefMapSource for TraitSelectionFixture {
     type Error = Infallible;
 
     fn def_map_for_origin(&self, origin_ref: DefMapRef) -> Result<Option<&DefMap>, Self::Error> {
-        Ok((origin_ref == origin()).then_some(&self.def_map))
+        if origin_ref == DefMapRef::Crate(self.target) {
+            return Ok(Some(&self.def_map));
+        }
+        Ok(origin_ref
+            .as_crate_ref()
+            .and_then(|crate_ref| self.dependency(crate_ref))
+            .map(|dependency| &dependency.def_map))
     }
 
     fn crate_is_proc_macro(&self, _crate_ref: CrateRef) -> Result<bool, Self::Error> {
@@ -121,8 +230,26 @@ impl DefMapSource for TraitSelectionFixture {
         Ok(None)
     }
 
-    fn root_module(&self, _target: CrateRef) -> Result<Option<ModuleRef>, Self::Error> {
-        Ok(None)
+    fn item_lookup_dependencies(
+        &self,
+        crate_ref: CrateRef,
+    ) -> Result<UniqueVec<CrateRef>, Self::Error> {
+        if crate_ref != self.target {
+            return Ok(UniqueVec::new());
+        }
+        Ok(self
+            .dependencies
+            .iter()
+            .map(|dependency| dependency.target)
+            .collect())
+    }
+
+    fn root_module(&self, crate_ref: CrateRef) -> Result<Option<ModuleRef>, Self::Error> {
+        let known = crate_ref == self.target || self.dependency(crate_ref).is_some();
+        Ok(known.then_some(ModuleRef {
+            origin: DefMapRef::Crate(crate_ref),
+            module: ModuleId(0),
+        }))
     }
 }
 
@@ -133,11 +260,19 @@ impl<'a> ItemStoreSource<'a> for &'a TraitSelectionFixture {
         &self,
         origin: DefMapRef,
     ) -> Result<Option<&'a ItemStore>, Self::Error> {
-        Ok((origin == DefMapRef::Crate(self.target)).then_some(&self.store))
+        if origin == DefMapRef::Crate(self.target) {
+            return Ok(Some(&self.store));
+        }
+        Ok(origin
+            .as_crate_ref()
+            .and_then(|crate_ref| self.dependency(crate_ref))
+            .map(|dependency| &dependency.store))
     }
 
     fn included_stores(&self) -> Result<Vec<&'a ItemStore>, Self::Error> {
-        Ok(vec![&self.store])
+        Ok(std::iter::once(&self.store)
+            .chain(self.dependencies.iter().map(|dependency| &dependency.store))
+            .collect())
     }
 }
 
@@ -146,7 +281,12 @@ impl<'a> ItemLookupIndexSource<'a> for &'a TraitSelectionFixture {
         &self,
         crate_ref: CrateRef,
     ) -> Result<Option<&'a ItemLookupIndex>, Self::Error> {
-        Ok((crate_ref == self.target).then_some(&self.lookup_index))
+        if crate_ref == self.target {
+            return Ok(Some(&self.lookup_index));
+        }
+        Ok(self
+            .dependency(crate_ref)
+            .map(|dependency| &dependency.lookup_index))
     }
 }
 
@@ -480,6 +620,7 @@ fn fixture_with_traits_impls_aliases_and_structs(
         store: builder.build(),
         target: target(),
         lookup_index: ItemLookupIndex::default(),
+        dependencies: Vec::new(),
         type_names: HashMap::new(),
         trait_names: HashMap::new(),
         type_refs_by_name: HashMap::new(),

--- a/crates/lib/std/src/cancellation.rs
+++ b/crates/lib/std/src/cancellation.rs
@@ -1,0 +1,48 @@
+//! Small cooperative-cancellation signal shared across synchronous engine layers.
+//!
+//! Request futures and semantic work live in different execution domains. Dropping the async
+//! request therefore cannot unwind the synchronous analysis stack directly. A cloned token lets
+//! the request owner mark that work obsolete while hot semantic loops decide where it is safe to
+//! stop.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+/// Cloneable signal for work whose result is no longer needed.
+#[derive(Clone, Debug, Default)]
+pub struct CancellationToken {
+    cancelled: Arc<AtomicBool>,
+}
+
+impl CancellationToken {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mark this token and every clone as cancelled.
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Relaxed);
+    }
+
+    /// Return whether the owner has made this work obsolete.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CancellationToken;
+
+    #[test]
+    fn cancellation_is_shared_by_every_token_clone() {
+        let token = CancellationToken::new();
+        let worker = token.clone();
+
+        token.cancel();
+
+        assert!(worker.is_cancelled());
+    }
+}

--- a/crates/lib/std/src/lib.rs
+++ b/crates/lib/std/src/lib.rs
@@ -9,6 +9,7 @@
 // workspace. It should not be treated as "utils" crate to put stuff you don't know where to put.
 // Putting things here should have good enough justification.
 
+pub mod cancellation;
 pub mod expected_unique;
 pub mod memsize;
 pub mod native_os_string;
@@ -17,6 +18,7 @@ pub mod shrink;
 pub mod unique;
 
 pub use self::{
+    cancellation::CancellationToken,
     expected_unique::ExpectedUnique,
     memsize::{MemoryRecord, MemoryRecordKind, MemoryRecorder, MemoryRecorderMode, MemorySize},
     native_os_string::NativeOsString,

--- a/crates/lsp/engine/src/engine/dispatcher.rs
+++ b/crates/lsp/engine/src/engine/dispatcher.rs
@@ -57,6 +57,7 @@ impl EngineDispatcher {
 
         while let Ok(queued) = receiver.recv() {
             let queue_elapsed = queued.enqueued_at.elapsed();
+            let cancellation = queued.cancellation;
             let command = queued.command;
             // Keep the protocol-to-subsystem mapping explicit. Most arms are deliberately small:
             // they record request identity here and leave query/recovery policy to `QueryRunner`.
@@ -103,6 +104,7 @@ impl EngineDispatcher {
                     self.query_runner().respond_to_query(
                         context,
                         respond_to,
+                        cancellation,
                         |runner, cancellation| runner.goto_definition(input, cancellation),
                     );
                 }
@@ -121,6 +123,7 @@ impl EngineDispatcher {
                     self.query_runner().respond_to_query(
                         context,
                         respond_to,
+                        cancellation,
                         |runner, cancellation| runner.goto_type_definition(input, cancellation),
                     );
                 }
@@ -136,10 +139,12 @@ impl EngineDispatcher {
                         queue_elapsed,
                         &input,
                     );
-                    self.query_runner()
-                        .respond_to_query(context, respond_to, |runner, _| {
-                            runner.goto_implementation(input)
-                        });
+                    self.query_runner().respond_to_query(
+                        context,
+                        respond_to,
+                        cancellation,
+                        |runner, _| runner.goto_implementation(input),
+                    );
                 }
                 EngineCommand::References {
                     input,
@@ -155,10 +160,12 @@ impl EngineDispatcher {
                     );
                     let context =
                         QueryContext::global_operation("references", queue_elapsed, &input);
-                    self.query_runner()
-                        .respond_to_query(context, respond_to, |runner, _| {
-                            runner.references(input, include_declaration)
-                        });
+                    self.query_runner().respond_to_query(
+                        context,
+                        respond_to,
+                        cancellation,
+                        |runner, _| runner.references(input, include_declaration),
+                    );
                 }
                 EngineCommand::PrepareRename { input, respond_to } => {
                     tracing::trace!(
@@ -169,10 +176,12 @@ impl EngineDispatcher {
                     );
                     let context =
                         QueryContext::global_operation("prepare_rename", queue_elapsed, &input);
-                    self.query_runner()
-                        .respond_to_query(context, respond_to, |runner, _| {
-                            runner.prepare_rename(input)
-                        });
+                    self.query_runner().respond_to_query(
+                        context,
+                        respond_to,
+                        cancellation,
+                        |runner, _| runner.prepare_rename(input),
+                    );
                 }
                 EngineCommand::Rename {
                     input,
@@ -187,10 +196,12 @@ impl EngineDispatcher {
                         "engine command started: rename"
                     );
                     let context = QueryContext::global_operation("rename", queue_elapsed, &input);
-                    self.query_runner()
-                        .respond_to_query(context, respond_to, |runner, _| {
-                            runner.rename(input, new_name)
-                        });
+                    self.query_runner().respond_to_query(
+                        context,
+                        respond_to,
+                        cancellation,
+                        |runner, _| runner.rename(input, new_name),
+                    );
                 }
                 EngineCommand::DocumentHighlight { input, respond_to } => {
                     tracing::trace!(
@@ -207,6 +218,7 @@ impl EngineDispatcher {
                     self.query_runner().respond_to_query(
                         context,
                         respond_to,
+                        cancellation,
                         |runner, cancellation| runner.document_highlight(input, cancellation),
                     );
                 }
@@ -222,6 +234,7 @@ impl EngineDispatcher {
                     self.query_runner().respond_to_query(
                         context,
                         respond_to,
+                        cancellation,
                         |runner, cancellation| runner.hover(input, cancellation),
                     );
                 }
@@ -246,6 +259,7 @@ impl EngineDispatcher {
                     self.query_runner().respond_to_query(
                         context,
                         respond_to,
+                        cancellation,
                         |runner, cancellation| {
                             runner.code_action(input, request_context, cancellation)
                         },
@@ -270,6 +284,7 @@ impl EngineDispatcher {
                     self.query_runner().respond_to_query(
                         context,
                         respond_to,
+                        cancellation,
                         |runner, cancellation| {
                             runner.completion(input, client_capabilities, cancellation)
                         },
@@ -285,10 +300,12 @@ impl EngineDispatcher {
                     );
                     let context =
                         QueryContext::target_document("formatting", queue_elapsed, &snapshot);
-                    self.query_runner()
-                        .respond_to_query(context, respond_to, |runner, _| {
-                            runner.formatting(snapshot)
-                        });
+                    self.query_runner().respond_to_query(
+                        context,
+                        respond_to,
+                        cancellation,
+                        |runner, _| runner.formatting(snapshot),
+                    );
                 }
                 EngineCommand::DocumentSymbol {
                     snapshot,
@@ -300,10 +317,12 @@ impl EngineDispatcher {
                     );
                     let context =
                         QueryContext::target_document("document_symbol", queue_elapsed, &snapshot);
-                    self.query_runner()
-                        .respond_to_query(context, respond_to, |runner, _| {
-                            runner.document_symbol(snapshot)
-                        });
+                    self.query_runner().respond_to_query(
+                        context,
+                        respond_to,
+                        cancellation,
+                        |runner, _| runner.document_symbol(snapshot),
+                    );
                 }
                 EngineCommand::InlayHint { input, respond_to } => {
                     tracing::trace!(
@@ -322,16 +341,19 @@ impl EngineDispatcher {
                     self.query_runner().respond_to_query(
                         context,
                         respond_to,
+                        cancellation,
                         |runner, cancellation| runner.inlay_hint(input, cancellation),
                     );
                 }
                 EngineCommand::WorkspaceSymbol { query, respond_to } => {
                     tracing::trace!(query = %query, "engine command started: workspace_symbol");
                     let context = QueryContext::saved_project("workspace_symbol", queue_elapsed);
-                    self.query_runner()
-                        .respond_to_query(context, respond_to, |runner, _| {
-                            runner.workspace_symbol(&query)
-                        });
+                    self.query_runner().respond_to_query(
+                        context,
+                        respond_to,
+                        cancellation,
+                        |runner, _| runner.workspace_symbol(&query),
+                    );
                 }
                 EngineCommand::ReindexWorkspace { respond_to } => {
                     tracing::trace!("engine command started: reindex_workspace");

--- a/crates/lsp/engine/src/engine/mod.rs
+++ b/crates/lsp/engine/src/engine/mod.rs
@@ -21,6 +21,7 @@ use std::{
 
 use anyhow::Context as _;
 use rg_lsp_proto::{EngineError, QueryError, QueryValue, ServiceNotification};
+use rg_std::CancellationToken;
 use tokio::sync::oneshot;
 
 pub(crate) use self::{command::EngineCommand, project::ProjectConfiguration};
@@ -46,6 +47,7 @@ pub(crate) struct EngineHandle {
 pub(crate) struct QueuedEngineCommand {
     pub(crate) command: EngineCommand,
     pub(crate) enqueued_at: Instant,
+    pub(crate) cancellation: CancellationToken,
 }
 
 impl QueuedEngineCommand {
@@ -53,7 +55,25 @@ impl QueuedEngineCommand {
         Self {
             command,
             enqueued_at: Instant::now(),
+            cancellation: CancellationToken::new(),
         }
+    }
+
+    fn with_cancellation(command: EngineCommand, cancellation: CancellationToken) -> Self {
+        Self {
+            command,
+            enqueued_at: Instant::now(),
+            cancellation,
+        }
+    }
+}
+
+/// Marks synchronous engine work obsolete when its async requester disappears.
+struct RequestCancellationGuard(CancellationToken);
+
+impl Drop for RequestCancellationGuard {
+    fn drop(&mut self) {
+        self.0.cancel();
     }
 }
 
@@ -78,9 +98,9 @@ impl EngineHandle {
 
     /// Send one typed command and wait for its response channel.
     ///
-    /// Dropping the waiting RPC future closes the response endpoint. Query lifecycle code notices
-    /// that before starting queued work and can expose the same liveness at feature checkpoints,
-    /// so cancellation does not need a second protocol or another request-state owner.
+    /// Dropping the waiting RPC future closes the response endpoint and marks its cancellation
+    /// token. Query lifecycle code uses the endpoint to skip queued work, while synchronous
+    /// semantic loops use the token to stop bounded work that is already running.
     async fn dispatch<T>(
         &self,
         build: impl FnOnce(oneshot::Sender<T>) -> EngineCommand,
@@ -89,8 +109,13 @@ impl EngineHandle {
         T: Send + 'static,
     {
         let (respond_to, response) = oneshot::channel();
+        let cancellation = CancellationToken::new();
+        let _cancellation_guard = RequestCancellationGuard(cancellation.clone());
         self.sender
-            .send(QueuedEngineCommand::new(build(respond_to)))
+            .send(QueuedEngineCommand::with_cancellation(
+                build(respond_to),
+                cancellation,
+            ))
             .context("send LSP engine command")?;
 
         response.await.context("receive LSP engine response")
@@ -127,5 +152,51 @@ impl EngineHandle {
     pub(crate) fn refresh_inlay_hints(&self) {
         self.notifications
             .send(ServiceNotification::InlayHintRefresh);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::Future as _,
+        sync::mpsc,
+        task::{Context, Poll},
+    };
+
+    use futures::task::noop_waker_ref;
+    use rg_lsp_proto::ServiceNotification;
+
+    use super::{EngineCommand, EngineHandle};
+    use crate::service::{ServiceNotificationPublisher, ServiceNotificationsSink};
+
+    #[derive(Debug)]
+    struct NoopNotifications;
+
+    impl ServiceNotificationPublisher for NoopNotifications {
+        fn send(&self, _notification: ServiceNotification) {}
+    }
+
+    #[test]
+    fn dropping_dispatch_future_cancels_its_queued_command() {
+        let (sender, receiver) = mpsc::channel();
+        let engine = EngineHandle {
+            sender,
+            notifications: ServiceNotificationsSink::from_publisher(NoopNotifications),
+        };
+        let mut dispatch = Box::pin(engine.dispatch(EngineCommand::Shutdown));
+        let mut context = Context::from_waker(noop_waker_ref());
+
+        assert!(matches!(
+            dispatch.as_mut().poll(&mut context),
+            Poll::Pending
+        ));
+        let queued = receiver
+            .try_recv()
+            .expect("polling dispatch should enqueue the engine command");
+        assert!(!queued.cancellation.is_cancelled());
+
+        drop(dispatch);
+
+        assert!(queued.cancellation.is_cancelled());
     }
 }

--- a/crates/lsp/engine/src/engine/query/lifecycle.rs
+++ b/crates/lsp/engine/src/engine/query/lifecycle.rs
@@ -28,6 +28,7 @@ use rg_lsp_proto::{
     EditorDocumentSnapshot, EngineError, GlobalPositionSnapshot, QueryError, QueryScope, QueryValue,
 };
 use rg_project::Project;
+use rg_std::CancellationToken;
 
 use super::QueryRunner;
 use crate::{engine::command::QueryResponder, memory::MemoryReporter};
@@ -60,24 +61,33 @@ impl From<anyhow::Error> for QueryRunError {
 
 /// Lets expensive query phases check whether anyone still wants the result.
 ///
-/// Dropping the RPC future closes the engine response channel. Long-running queries use this value
-/// to check that channel between expensive phases. It carries no document ids and keeps no second
-/// cancellation flag that could disagree with the channel.
+/// Dropping the RPC future cancels the request token and closes the engine response channel.
+/// Ordinary query phases check both here. The token can also enter bounded semantic loops where
+/// polling the response endpoint would cross an engine-layer ownership boundary.
 pub(crate) struct QueryCancellation<'a> {
-    is_cancelled: &'a dyn Fn() -> bool,
+    request: &'a CancellationToken,
+    response_is_closed: &'a dyn Fn() -> bool,
 }
 
 impl<'a> QueryCancellation<'a> {
-    fn new(is_cancelled: &'a dyn Fn() -> bool) -> Self {
-        Self { is_cancelled }
+    fn new(request: &'a CancellationToken, response_is_closed: &'a dyn Fn() -> bool) -> Self {
+        Self {
+            request,
+            response_is_closed,
+        }
     }
 
     /// Stop at a named query boundary if nobody can receive the result anymore.
     pub(crate) fn checkpoint(&self, checkpoint: &'static str) -> anyhow::Result<()> {
-        if (self.is_cancelled)() {
+        if self.request.is_cancelled() || (self.response_is_closed)() {
             return Err(QueryCancelled { checkpoint }.into());
         }
         Ok(())
+    }
+
+    /// Share the request signal with synchronous work that has its own bounded checkpoints.
+    pub(crate) fn token(&self) -> CancellationToken {
+        self.request.clone()
     }
 }
 
@@ -158,6 +168,7 @@ impl QueryRunner<'_> {
         &mut self,
         context: QueryContext,
         respond_to: QueryResponder<T>,
+        cancellation: CancellationToken,
         query: impl FnOnce(&mut Self, &QueryCancellation<'_>) -> Result<T, QueryRunError>,
     ) where
         T: Send + 'static,
@@ -171,7 +182,7 @@ impl QueryRunner<'_> {
         // LSP cancellation drops the RPC handler waiting on this response. The command may still
         // be in the dispatcher queue, but there is no reason to materialize packages or run
         // analysis once nobody can receive the result.
-        if respond_to.is_closed() {
+        if respond_to.is_closed() || cancellation.is_cancelled() {
             tracing::debug!(
                 label,
                 queued_ms = queue_elapsed.as_millis(),
@@ -205,8 +216,11 @@ impl QueryRunner<'_> {
         let memory_control = Arc::clone(&self.memory_control);
         let memory_before = MemoryReporter::snapshot(memory_control.as_ref());
         let result = {
-            let is_cancelled = || respond_to.is_closed();
-            query(self, &QueryCancellation::new(&is_cancelled))
+            let response_is_closed = || respond_to.is_closed();
+            query(
+                self,
+                &QueryCancellation::new(&cancellation, &response_is_closed),
+            )
         };
         let cancelled_checkpoint = result
             .as_ref()
@@ -336,6 +350,7 @@ mod tests {
         DocumentRevision, EditorDocumentSnapshot, GlobalPositionSnapshot, OpenDocumentSession,
         OpenDocumentsRevision, QueryError, QueryScope, QueryValue, ServiceNotification,
     };
+    use rg_std::CancellationToken;
     use tokio::sync::oneshot;
 
     use super::QueryContext;
@@ -365,6 +380,7 @@ mod tests {
         runner.respond_to_query(
             QueryContext::saved_project("workspace_symbol", Duration::ZERO),
             respond_to,
+            CancellationToken::new(),
             |_, _| {
                 query_ran.set(true);
                 Ok(vec![1])
@@ -395,7 +411,9 @@ mod tests {
         let (respond_to, response) = oneshot::channel();
         let context = QueryContext::global_operation("references", Duration::ZERO, &snapshot);
 
-        runner.respond_to_query(context, respond_to, |_, _| Ok(vec![1_usize]));
+        runner.respond_to_query(context, respond_to, CancellationToken::new(), |_, _| {
+            Ok(vec![1_usize])
+        });
 
         let result =
             futures::executor::block_on(response).expect("document query should send a response");
@@ -420,6 +438,7 @@ mod tests {
         runner.respond_to_query(
             QueryContext::saved_project("workspace_symbol", Duration::ZERO),
             respond_to,
+            CancellationToken::new(),
             |_, _| Ok(Vec::<usize>::new()),
         );
 
@@ -442,6 +461,7 @@ mod tests {
         runner.respond_to_query(
             QueryContext::saved_project("completion", Duration::ZERO),
             respond_to,
+            CancellationToken::new(),
             |_, cancellation| {
                 // Model the RPC task disappearing after the engine has already entered the query.
                 drop(response);
@@ -456,6 +476,37 @@ mod tests {
         assert!(
             !work_after_checkpoint_ran.get(),
             "work after a closed-response checkpoint should not run",
+        );
+    }
+
+    #[test]
+    fn query_stops_when_request_token_is_cancelled_during_analysis() {
+        let memory_control: Arc<dyn MemoryControl> = Arc::new(());
+        let mut project = test_project(Arc::clone(&memory_control));
+        let mut runner = QueryRunner::new(&mut project, memory_control);
+        let (respond_to, _response) =
+            oneshot::channel::<Result<QueryValue<Vec<usize>>, QueryError>>();
+        let cancellation = CancellationToken::new();
+        let request_owner = cancellation.clone();
+        let work_after_checkpoint_ran = Cell::new(false);
+
+        runner.respond_to_query(
+            QueryContext::saved_project("inlay_hint", Duration::ZERO),
+            respond_to,
+            cancellation,
+            |_, cancellation| {
+                request_owner.cancel();
+                cancellation
+                    .checkpoint("test semantic work")
+                    .context("stop test query after request cancellation")?;
+                work_after_checkpoint_ran.set(true);
+                Ok(vec![1])
+            },
+        );
+
+        assert!(
+            !work_after_checkpoint_ran.get(),
+            "work after a cancelled request checkpoint should not run",
         );
     }
 

--- a/crates/lsp/engine/src/engine/query/mod.rs
+++ b/crates/lsp/engine/src/engine/query/mod.rs
@@ -318,6 +318,7 @@ impl<'a> QueryRunner<'a> {
                         &body_targets,
                         source_view,
                         body_selection,
+                        cancellation.token(),
                         |checkpoint| {
                             cancellation.checkpoint(Self::current_body_checkpoint(checkpoint))
                         },

--- a/crates/lsp/server/src/methods/text_document/completion/mod.rs
+++ b/crates/lsp/server/src/methods/text_document/completion/mod.rs
@@ -112,7 +112,7 @@ pub(crate) async fn completion(
                             result_count = completions.len(),
                             "completion request answered"
                         );
-                        return Ok(Some(incomplete_response(completions)));
+                        return Ok(Some(complete_response(completions)));
                     }
                     Err(QueryError::EditorChanged) => {
                         tracing::debug!(
@@ -129,10 +129,14 @@ pub(crate) async fn completion(
     }
 }
 
-/// Completion results stay incomplete so the client may ask again as the cursor advances.
-fn incomplete_response(items: Vec<CompletionItem>) -> CompletionResponse {
+/// Return the complete result computed for the final captured document revision.
+///
+/// The retry loop already follows edits that overtake an in-flight request. Claiming that this
+/// same result is incomplete makes clients immediately request the identical position again,
+/// duplicating semantic work and competing with the presentation queries triggered by the edit.
+fn complete_response(items: Vec<CompletionItem>) -> CompletionResponse {
     CompletionResponse::List(CompletionList {
-        is_incomplete: true,
+        is_incomplete: false,
         items,
     })
 }

--- a/crates/lsp/server/src/methods/text_document/completion/tests.rs
+++ b/crates/lsp/server/src/methods/text_document/completion/tests.rs
@@ -65,7 +65,7 @@ async fn did_change_retries_completion_at_rebased_position() {
     let CompletionResponse::List(response) = response else {
         panic!("completion response should be a list");
     };
-    assert!(response.is_incomplete);
+    assert!(!response.is_incomplete);
     let [item] = response.items.as_slice() else {
         panic!("completion response should contain one item");
     };

--- a/editors/code/test/completion-scenario.ts
+++ b/editors/code/test/completion-scenario.ts
@@ -4,7 +4,6 @@ import * as vscode from "vscode";
 import type { CompletionObservation } from "../src/test-support/completion-observer";
 import {
   currentCompletionObservations,
-  delay,
   readySession,
   waitForClientState,
   waitForCompletionObservation,
@@ -47,10 +46,11 @@ export class CompletionScenario {
       await scenario.enableImmediateQuickSuggestions();
       scenario.keyboard = await RendererKeyboard.connect();
 
-      // Reuse the same open document and LSP session. The later runs specifically check that an
-      // earlier incomplete refresh did not leave sticky completion state behind for its successor.
+      // Reuse the same open document and LSP session. Each run checks that VS Code can keep
+      // filtering one complete semantic list locally without starting a provider refresh for
+      // every additional character.
       for (let run = 1; run <= 3; run += 1) {
-        await scenario.completeThroughRapidIncompleteRefresh(run);
+        await scenario.completeThroughRapidClientFiltering(run);
       }
       await scenario.dismissWithoutOpeningASuccessor();
     } finally {
@@ -73,12 +73,12 @@ export class CompletionScenario {
     await vscode.commands.executeCommand("workbench.action.focusActiveEditorGroup");
   }
 
-  private async completeThroughRapidIncompleteRefresh(run: number): Promise<void> {
+  private async completeThroughRapidClientFiltering(run: number): Promise<void> {
     await this.prepareScratch();
     const before = await currentCompletionObservations();
 
-    // Ordinary quick suggestions first produce one semantic incomplete list. Continuing by one
-    // character starts its native incomplete refresh, then the remaining text arrives immediately.
+    // Ordinary quick suggestions produce one complete semantic list. The remaining prefix arrives
+    // through the renderer's native input path and should be filtered from that list client-side.
     await this.type("Comp");
     const initial = this.currentPoint();
     const initialReady = await waitForCompletionObservation(
@@ -87,51 +87,34 @@ export class CompletionScenario {
         observation.phase === "finish" &&
         observation.outcome === "ready" &&
         observation.observedVersion === initial.version &&
-        observation.incomplete === true &&
+        observation.incomplete === false &&
         hasSemanticFixture(observation),
       `run ${run} initial semantic quick suggestion`,
     );
     assert.equal(initialReady.outcome, "ready");
 
     await this.type("l");
-    const refresh = this.currentPoint();
-    await waitForCompletionObservation(
-      before.length,
-      (observation) => observation.phase === "start" && isAt(observation, refresh),
-      `run ${run} incomplete-list refresh start`,
-    );
-
     await this.type("etion");
     await this.type("Fix");
-    const final = this.currentPoint();
+    await this.keyboardOrThrow().waitForSuggestWidgetVisibility(true);
 
-    // A fast provider may finish the one-character refresh before the renderer sends the rest of
-    // the word; a slower provider may be overtaken and cancelled. Both are valid. What matters at
-    // the client boundary is that native typing reaches a semantic result for the final version.
-    await waitForClientState((state) => {
-      const observations = state.session?.completionObservations.slice(before.length) ?? [];
-      return (
-        state.session?.activeCompletionAttempts === 0 &&
-        observations.some(
-          (observation) =>
-            observation.phase === "finish" &&
-            observation.outcome === "ready" &&
-            observation.observedVersion === final.version &&
-            hasSemanticFixture(observation),
-        )
-      );
-    });
+    // Accepting the only matching semantic item gives this completion session a concrete end. By
+    // the time the exact edit and the hidden widget are observed, any refresh belonging to the
+    // session must already have entered the provider middleware.
+    const acceptedText = `${this.originalText}\nimpl CompletionFixture`;
+    const accepted = waitForDocumentText(this.editor.document, acceptedText);
+    await this.keyboardOrThrow().acceptSelectedSuggestion();
+    await accepted;
+    await this.keyboardOrThrow().waitForSuggestWidgetVisibility(false);
+    await waitForClientState((state) => state.session?.activeCompletionAttempts === 0);
 
     const observations = (await currentCompletionObservations()).slice(before.length);
-    assert.ok(
-      observations.some(
-        (observation) =>
-          observation.phase === "finish" &&
-          observation.outcome === "ready" &&
-          observation.observedVersion === final.version &&
-          hasSemanticFixture(observation),
-      ),
-      `run ${run} must return semantic candidates against the final document version: ${JSON.stringify(observations)}`,
+    assert.deepEqual(
+      observations
+        .filter((observation) => observation.phase === "start")
+        .map((observation) => observation.attempt),
+      [initialReady.attempt],
+      `run ${run} must filter the complete semantic result without another provider request: ${JSON.stringify(observations)}`,
     );
   }
 
@@ -146,38 +129,27 @@ export class CompletionScenario {
       (observation) =>
         observation.phase === "finish" &&
         observation.outcome === "ready" &&
-        observation.observedVersion === initial.version,
+        observation.observedVersion === initial.version &&
+        observation.incomplete === false &&
+        hasSemanticFixture(observation),
       "dismissal setup semantic result",
     );
 
     await this.type("l");
     const unchanged = this.currentPoint();
-    const active = await waitForCompletionObservation(
-      before.length,
-      (observation) => observation.phase === "start" && isAt(observation, unchanged),
-      "dismissal provider start",
-    );
     await this.keyboardOrThrow().escape();
+    await this.keyboardOrThrow().waitForSuggestWidgetVisibility(false);
 
     const state = await waitForClientState(
       (candidate) => candidate.session?.activeCompletionAttempts === 0,
     );
     assert.equal(state.session?.activeCompletionAttempts, 0);
-    await delay(100);
     const observations = (await currentCompletionObservations()).slice(before.length);
     assert.ok(
       !observations.some(
-        (observation) =>
-          observation.phase === "start" &&
-          observation.attempt !== active.attempt &&
-          isAt(observation, unchanged),
+        (observation) => observation.phase === "start" && isAt(observation, unchanged),
       ),
-      `Escape must not open another provider request at the unchanged point: ${JSON.stringify(observations)}`,
-    );
-    assert.equal(
-      await this.keyboardOrThrow().suggestWidgetVisible(),
-      false,
-      "Escape must leave suggestions closed",
+      `complete results and Escape must not open a provider request at the unchanged point: ${JSON.stringify(observations)}`,
     );
   }
 

--- a/editors/code/test/renderer-keyboard.ts
+++ b/editors/code/test/renderer-keyboard.ts
@@ -58,15 +58,12 @@ export class RendererKeyboard {
   }
 
   public async escape(): Promise<void> {
-    await this.focusEditorInput();
-    const key = {
-      key: "Escape",
-      code: "Escape",
-      windowsVirtualKeyCode: 27,
-      nativeVirtualKeyCode: 27,
-    };
-    await this.send("Input.dispatchKeyEvent", { type: "keyDown", ...key });
-    await this.send("Input.dispatchKeyEvent", { type: "keyUp", ...key });
+    await this.pressKey("Escape", "Escape", 27);
+  }
+
+  /** Accept the selected suggestion through the renderer's ordinary keyboard path. */
+  public async acceptSelectedSuggestion(): Promise<void> {
+    await this.pressKey("Tab", "Tab", 9);
   }
 
   public async activeElementDescription(): Promise<string> {
@@ -86,6 +83,19 @@ export class RendererKeyboard {
     return response.result?.value === true;
   }
 
+  /** Wait for a concrete renderer state; the deadline only bounds a broken test run. */
+  public async waitForSuggestWidgetVisibility(expected: boolean): Promise<void> {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < 10_000) {
+      if ((await this.suggestWidgetVisible()) === expected) {
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+
+    throw new Error(`suggest widget did not become ${expected ? "visible" : "hidden"}`);
+  }
+
   public dispose(): void {
     this.socket.close();
     for (const pending of this.pending.values()) {
@@ -101,6 +111,18 @@ export class RendererKeyboard {
       this.pending.set(id, { resolve, reject });
       this.socket.send(JSON.stringify({ id, method, params }));
     });
+  }
+
+  private async pressKey(key: string, code: string, keyCode: number): Promise<void> {
+    await this.focusEditorInput();
+    const event = {
+      key,
+      code,
+      windowsVirtualKeyCode: keyCode,
+      nativeVirtualKeyCode: keyCode,
+    };
+    await this.send("Input.dispatchKeyEvent", { type: "keyDown", ...event });
+    await this.send("Input.dispatchKeyEvent", { type: "keyUp", ...event });
   }
 
   private async focusEditorInput(): Promise<void> {


### PR DESCRIPTION
Noticed an overly slow behavior in some project.
The cause was the fallback of deref to all the unknown/maybe targets that was pretty slow to resolve.
This one is fixed by implementing orphan-like filtering logic to only have candidates who can really have the trait impl, reducing the amount of candidates to check.

Also added better support for cancellation, so that serialized queries are cancelled more efficiently.